### PR TITLE
Expose a web service method to fetch user activity.

### DIFF
--- a/ehri-frames/src/test/java/eu/ehri/project/views/EventViewsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/views/EventViewsTest.java
@@ -124,6 +124,22 @@ public class EventViewsTest extends AbstractFixtureTest {
     }
 
     @Test
+    public void testListByUser() throws Exception {
+        List<SystemEvent> events = Lists
+                .newArrayList(eventViews
+                        .listByUser(query, user1, user2));
+        assertEquals(0, events.size());
+
+        createItemWithIdentifier("foo", user1);
+        createItemWithIdentifier("bar", user1);
+
+        List<SystemEvent> events2 = Lists
+                .newArrayList(eventViews
+                        .listByUser(query, user1, user2));
+        assertEquals(2, events2.size());
+    }
+
+    @Test
     public void testListAsUserWatching() throws Exception {
         DocumentaryUnit doc1 = createItemWithIdentifier("foo", user1);
         Thread.sleep(10);


### PR DESCRIPTION
Currently, fetching user activity on the front-end is done in a fairly stupid way, filtering the global event list for events associated with the single user in question. This is extremely slow if the user has little or no activity because we end up traversing the whole list.

This change introduces a WS method for traversing an individual user's event stream, with filtering options as per the system wide method.

It additionally provides a few micro-optimisations that should make stream filtering slightly more efficient, such as using `Set` and `EnumSet` container types for filter options.
