### PR TITLE
Import callback refactoring and Javadoc improvements.

### DIFF
--- a/ehri-cmdline/src/test/java/eu/ehri/project/commands/RdfExportTest.java
+++ b/ehri-cmdline/src/test/java/eu/ehri/project/commands/RdfExportTest.java
@@ -2,6 +2,7 @@ package eu.ehri.project.commands;
 
 import eu.ehri.project.test.AbstractFixtureTest;
 import org.apache.commons.cli.CommandLine;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -13,6 +14,7 @@ import static org.junit.Assert.assertTrue;
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public class RdfExportTest extends AbstractFixtureTest {
+    @Ignore("Ignored until SailGraph supports array properties (which we need). It doesn't as of Blueprints 2.5.0")
     @Test
     public void testExportTurtle() throws Exception {
         File temp = File.createTempFile("temp-file-name", ".turtle");

--- a/ehri-extension/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/ImportResource.java
@@ -192,7 +192,7 @@ public class ImportResource extends AbstractRestResource {
 
             // Run the import!
             ImportLog log = new SaxImportManager(graph, scope, user, importer, handler)
-                    .setProperties(propertyFile)
+                    .withProperties(propertyFile)
                     .setTolerant(tolerant)
                     .importFiles(paths, getLogMessage(logMessage).orNull());
 

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/AbstractImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/AbstractImporter.java
@@ -37,32 +37,20 @@ public abstract class AbstractImporter<T> {
     private static final String NODE_PROPERTIES = "allowedNodeProperties.csv";
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractImporter.class);
+    private static final Joiner stringJoiner = Joiner.on("\n\n").skipNulls();
+
     protected final PermissionScope permissionScope;
     protected final FramedGraph<?> framedGraph;
     protected final GraphManager manager;
     protected final ImportLog log;
     protected final T documentContext;
-    protected List<ImportCallback> createCallbacks = new LinkedList<ImportCallback>();
-    protected List<ImportCallback> updateCallbacks = new LinkedList<ImportCallback>();
-    protected List<ImportCallback> unchangedCallbacks = new LinkedList<ImportCallback>();
+    protected List<ImportCallback> callbacks = new LinkedList<ImportCallback>();
 
     private NodeProperties pc;
-    private Joiner stringJoiner = Joiner.on("\n\n").skipNulls();
 
     protected void handleCallbacks(Mutation<? extends AccessibleEntity> mutation) {
-        switch (mutation.getState()) {
-            case CREATED:
-                for (ImportCallback cb: createCallbacks)
-                    cb.itemImported(mutation.getNode());
-                break;
-            case UPDATED:
-                for (ImportCallback cb: updateCallbacks)
-                    cb.itemImported(mutation.getNode());
-                break;
-            case UNCHANGED:
-                for (ImportCallback cb: unchangedCallbacks)
-                    cb.itemImported(mutation.getNode());
-                break;
+        for (ImportCallback callback : callbacks) {
+            callback.itemImported(mutation);
         }
     }
 
@@ -82,55 +70,37 @@ public abstract class AbstractImporter<T> {
     /**
      * Constructor.
      *
-     * @param framedGraph
-     * @param permissionScope
-     * @param log
-     * @param documentContext
+     * @param graph     the framed graph
+     * @param scope     the permission scope
+     * @param log       the log object
+     * @param context   the document context
      */
-    public AbstractImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, ImportLog log,
-            T documentContext) {
-        this.permissionScope = permissionScope;
-        this.framedGraph = framedGraph;
+    public AbstractImporter(FramedGraph<?> graph, PermissionScope scope, ImportLog log,
+            T context) {
+        this.permissionScope = scope;
+        this.framedGraph = graph;
         this.log = log;
-        this.documentContext = documentContext;
-        manager = GraphManagerFactory.getInstance(framedGraph);
+        this.documentContext = context;
+        manager = GraphManagerFactory.getInstance(graph);
     }
 
     /**
      * Constructor without a document context.
-     * @param framedGraph
-     * @param permissionScope
-     * @param log
+     * @param graph the graph
+     * @param scope the permission scope
+     * @param log   the logger object
      */
-    public AbstractImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, ImportLog log) {
-        this(framedGraph, permissionScope, log, null);
+    public AbstractImporter(FramedGraph<?> graph, PermissionScope scope, ImportLog log) {
+        this(graph, scope, log, null);
     }
 
     /**
      * Add a callback to run when an item is created.
      *
-     * @param cb
+     * @param callback a callback function object
      */
-    public void addCreationCallback(final ImportCallback cb) {
-        createCallbacks.add(cb);
-    }
-
-    /**
-     * Add a callback to run when an item is updated.
-     *
-     * @param cb
-     */
-    public void addUpdateCallback(final ImportCallback cb) {
-        updateCallbacks.add(cb);
-    }
-
-    /**
-     * Add a callback to run when an item is left unchanged.
-     *
-     * @param cb
-     */
-    public void addUnchangedCallback(final ImportCallback cb) {
-        unchangedCallbacks.add(cb);
+    public void addCallback(final ImportCallback callback) {
+        callbacks.add(callback);
     }
 
     /**
@@ -157,7 +127,7 @@ public abstract class AbstractImporter<T> {
     /**
      * Extract a list of DatePeriod bundles from an item's data.
      *
-     * @param data
+     * @param data  the raw map of date data
      * @return returns a List of Maps with DatePeriod.START_DATE and DatePeriod.END_DATE values
      */
     public abstract Iterable<Map<String, Object>> extractDates(T data);
@@ -167,9 +137,9 @@ public abstract class AbstractImporter<T> {
      * only properties that have the multivalued-status can actually be multivalued. all other properties will be
      * flattened by this method.
      *
-     * @param key
-     * @param value
-     * @param entity - the EntityClass with which this frameMap must comply
+     * @param key       a property key
+     * @param value     a property value
+     * @param entity    the EntityClass with which this frameMap must comply
      */
     protected Object changeForbiddenMultivaluedProperties(String key, Object value, EntityClass entity) {
         if (pc == null) {

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvImportManager.java
@@ -10,6 +10,7 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.persistence.ActionManager;
+import eu.ehri.project.persistence.Mutation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,26 +54,23 @@ public class CsvImportManager extends XmlImportManager {
             XmlImporter importer = importerClass.getConstructor(FramedGraph.class, PermissionScope.class,
                     ImportLog.class).newInstance(framedGraph, permissionScope, log);
             logger.debug("importer of class " + importer.getClass());
-            importer.addCreationCallback(new ImportCallback() {
-                @Override
-                public void itemImported(AccessibleEntity item) {
-                    logger.info("Item created: {}", item.getId());
-                    eventContext.addSubjects(item);
-                    log.addCreated();
-                }
-            });
-            importer.addUpdateCallback(new ImportCallback() {
-                @Override
-                public void itemImported(AccessibleEntity item) {
-                    logger.info("Item updated: {}", item.getId());
-                    eventContext.addSubjects(item);
-                    log.addUpdated();
-                }
-            });
-            importer.addUnchangedCallback(new ImportCallback() {
-                @Override
-                public void itemImported(AccessibleEntity item) {
-                    log.addUnchanged();
+
+            importer.addCallback(new ImportCallback() {
+                public void itemImported(Mutation<? extends AccessibleEntity> mutation) {
+                    switch (mutation.getState()) {
+                        case CREATED:
+                            logger.info("Item created: {}", mutation.getNode().getId());
+                            eventContext.addSubjects(mutation.getNode());
+                            log.addCreated();
+                            break;
+                        case UPDATED:
+                            logger.info("Item updated: {}", mutation.getNode().getId());
+                            eventContext.addSubjects(mutation.getNode());
+                            log.addUpdated();
+                            break;
+                        default:
+                            log.addUnchanged();
+                    }
                 }
             });
 

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/ImportCallback.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/ImportCallback.java
@@ -1,6 +1,7 @@
 package eu.ehri.project.importers;
 
 import eu.ehri.project.models.base.AccessibleEntity;
+import eu.ehri.project.persistence.Mutation;
 
 /**
  * Functor class
@@ -9,5 +10,5 @@ import eu.ehri.project.models.base.AccessibleEntity;
  * 
  */
 public interface ImportCallback {
-    public void itemImported(final AccessibleEntity item);
+    public void itemImported(final Mutation<? extends AccessibleEntity> mutation);
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/SaxImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/SaxImportManager.java
@@ -1,5 +1,7 @@
 package eu.ehri.project.importers;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.exceptions.ValidationError;
@@ -7,11 +9,11 @@ import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.exceptions.InvalidInputFormatError;
 import eu.ehri.project.importers.exceptions.InvalidXmlDocument;
 import eu.ehri.project.importers.properties.XmlImportProperties;
-import eu.ehri.project.models.VirtualUnit;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.persistence.ActionManager;
+import eu.ehri.project.persistence.Mutation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -22,6 +24,7 @@ import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,25 +37,28 @@ public class SaxImportManager extends XmlImportManager implements ImportManager 
 
     private static final Logger logger = LoggerFactory.getLogger(SaxImportManager.class);
 
-    private AbstractImporter<Map<String, Object>> importer;
-    private Class<? extends AbstractImporter> importerClass;
-    Class<? extends SaxXmlHandler> handlerClass;
-    private XmlImportProperties properties;
-    private VirtualUnit virtualcollection;
+    private final Class<? extends AbstractImporter> importerClass;
+    private final Class<? extends SaxXmlHandler> handlerClass;
+    private final Optional<XmlImportProperties> properties;
+    private final List<ImportCallback> extraCallbacks;
 
     /**
      * Constructor.
      *
-     * @param framedGraph
-     * @param permissionScope
-     * @param actioner
+     * @param graph     the framed graph
+     * @param scope     the permission scope
+     * @param actioner  the actioner
      */
-    public SaxImportManager(FramedGraph<? extends TransactionalGraph> framedGraph,
-            final PermissionScope permissionScope, final Actioner actioner,
-            Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
-        super(framedGraph, permissionScope, actioner);
+    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+            final PermissionScope scope, final Actioner actioner,
+            Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
+            Optional<XmlImportProperties> properties,
+            List<ImportCallback> callbacks) {
+        super(graph, scope, actioner);
         this.importerClass = importerClass;
         this.handlerClass = handlerClass;
+        this.properties = properties;
+        this.extraCallbacks = Lists.newArrayList(callbacks);
         logger.info("importer used: " + importerClass);
         logger.info("handler used: " + handlerClass);
     }
@@ -60,23 +66,51 @@ public class SaxImportManager extends XmlImportManager implements ImportManager 
     /**
      * Constructor.
      *
-     * @param framedGraph
-     * @param permissionScope
-     * @param actioner
+     * @param graph     the framed graph
+     * @param scope     a permission scope
+     * @param actioner  the actioner
      */
-    public SaxImportManager(FramedGraph<? extends TransactionalGraph> framedGraph,
-            final PermissionScope permissionScope, final Actioner actioner,
-            Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass, XmlImportProperties properties) {
-        this(framedGraph, permissionScope, actioner, importerClass, handlerClass);
-        this.properties=properties;
+    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+            final PermissionScope scope, final Actioner actioner,
+            Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
+            List<ImportCallback> callbacks) {
+        this(graph, scope, actioner, importerClass, handlerClass, Optional.<XmlImportProperties>absent(), callbacks);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param graph     the framed graph
+     * @param scope     a permission scope
+     * @param actioner  the actioner
+     */
+    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+            final PermissionScope scope, final Actioner actioner,
+            Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
+            XmlImportProperties properties) {
+        this(graph, scope, actioner, importerClass, handlerClass, Optional.fromNullable(properties),
+                Lists.<ImportCallback>newArrayList());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param graph     the framed graph
+     * @param scope     a permission scope
+     * @param actioner  the actioner
+     */
+    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+            final PermissionScope scope, final Actioner actioner,
+            Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
+        this(graph, scope, actioner, importerClass, handlerClass, Lists.<ImportCallback>newArrayList());
     }
 
     /**
      * Import XML from the given InputStream, as part of the given action.
      *
-     * @param ios
-     * @param eventContext
-     * @param log
+     * @param ios           an input stream
+     * @param eventContext  the event context
+     * @param log           a logger object
      * @throws IOException
      * @throws ValidationError
      * @throws InputParseError
@@ -88,38 +122,37 @@ public class SaxImportManager extends XmlImportManager implements ImportManager 
             InputParseError, InvalidXmlDocument, InvalidInputFormatError {
 
         try {
-            importer = importerClass.getConstructor(FramedGraph.class, PermissionScope.class,
+            AbstractImporter<Map<String, Object>> importer = importerClass.getConstructor(FramedGraph.class, PermissionScope.class,
                     ImportLog.class).newInstance(framedGraph, permissionScope, log);
             
-            
-            importer.addCreationCallback(new ImportCallback() {
-                public void itemImported(AccessibleEntity item) {
-                    logger.info("Item created: {}", item.getId());
-                    eventContext.addSubjects(item);
-                    log.addCreated();
-                }
-            });
-            importer.addUpdateCallback(new ImportCallback() {
-                public void itemImported(AccessibleEntity item) {
-                    logger.info("Item updated: {}", item.getId());
-                    eventContext.addSubjects(item);
-                    log.addUpdated();
-                }
-            });
-            importer.addUnchangedCallback(new ImportCallback() {
-                @Override
-                public void itemImported(AccessibleEntity item) {
-                    log.addUnchanged();
+            for (ImportCallback callback : extraCallbacks) {
+                importer.addCallback(callback);
+            }
+
+            // Add housekeeping callbacks for the log object...
+            importer.addCallback(new ImportCallback() {
+                public void itemImported(Mutation<? extends AccessibleEntity> mutation) {
+                    switch (mutation.getState()) {
+                        case CREATED:
+                            logger.info("Item created: {}", mutation.getNode().getId());
+                            eventContext.addSubjects(mutation.getNode());
+                            log.addCreated();
+                            break;
+                        case UPDATED:
+                            logger.info("Item updated: {}", mutation.getNode().getId());
+                            eventContext.addSubjects(mutation.getNode());
+                            log.addUpdated();
+                            break;
+                        default:
+                            log.addUnchanged();
+                    }
                 }
             });
             //TODO decide which handler to use, HandlerFactory? now part of constructor ...
-            SaxXmlHandler handler;
-            if(properties == null){
-              handler = handlerClass.getConstructor(AbstractImporter.class).newInstance(importer);
-            }else{
-              handler = handlerClass.getConstructor(AbstractImporter.class, XmlImportProperties.class).newInstance(importer, properties);
-                
-            }
+            SaxXmlHandler handler = properties.isPresent()
+                    ? handlerClass.getConstructor(AbstractImporter.class, XmlImportProperties.class)
+                            .newInstance(importer, properties.get())
+                    : handlerClass.getConstructor(AbstractImporter.class).newInstance(importer);
 
             SAXParserFactory spf = SAXParserFactory.newInstance();
             spf.setNamespaceAware(false);
@@ -153,20 +186,18 @@ public class SaxImportManager extends XmlImportManager implements ImportManager 
         }
     }
 
-    public SaxImportManager setProperties(XmlImportProperties properties) {
-        return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass, properties);
+    public SaxImportManager withProperties(XmlImportProperties properties) {
+        return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass,
+                Optional.<XmlImportProperties>of(properties), extraCallbacks);
     }
 
-    public SaxImportManager setProperties(String properties) {
+    public SaxImportManager withProperties(String properties) {
         if (properties == null) {
-            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass, null);
+            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass);
         } else {
             XmlImportProperties xmlImportProperties = new XmlImportProperties(properties);
-            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass, xmlImportProperties);
+            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass,
+                    Optional.<XmlImportProperties>of(xmlImportProperties), extraCallbacks);
         }
-    }
-    
-    public void setVirtualCollection(VirtualUnit virtualcollection) {
-        this.virtualcollection=virtualcollection;
     }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/XmlImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/XmlImportManager.java
@@ -37,15 +37,15 @@ abstract public class XmlImportManager implements ImportManager {
     /**
      * Constructor.
      *
-     * @param framedGraph
-     * @param permissionScope
-     * @param actioner
+     * @param graph     the framed graph
+     * @param scope     the permission scope
+     * @param actioner  the actioner
      */
     public XmlImportManager(
-            FramedGraph<? extends TransactionalGraph> framedGraph,
-            final PermissionScope permissionScope, final Actioner actioner) {
-        this.framedGraph = framedGraph;
-        this.permissionScope = permissionScope;
+            FramedGraph<? extends TransactionalGraph> graph,
+            final PermissionScope scope, final Actioner actioner) {
+        this.framedGraph = graph;
+        this.permissionScope = scope;
         this.actioner = actioner;
     }
 
@@ -69,8 +69,8 @@ abstract public class XmlImportManager implements ImportManager {
     /**
      * Import a Description file by specifying its path.
      *
-     * @param filePath
-     * @param logMessage
+     * @param filePath      a path to a description XML file
+     * @param logMessage    the log message
      *
      * @throws IOException
      * @throws ValidationError
@@ -89,8 +89,8 @@ abstract public class XmlImportManager implements ImportManager {
     /**
      * Import a file, creating a new action with the given log message.
      *
-     * @param ios
-     * @param logMessage
+     * @param ios           an input stream object
+     * @param logMessage    the log message
      * @return an ImportLog for the given InputStream
      *
      * @throws IOException
@@ -126,8 +126,8 @@ abstract public class XmlImportManager implements ImportManager {
     /**
      * Import multiple files in the same batch/transaction.
      *
-     * @param paths
-     * @param logMessage
+     * @param paths         a list of file paths to description objects
+     * @param logMessage    a log message
      *
      * @throws IOException
      * @throws ValidationError

--- a/scripts/ruby/lib/ukraineimporter.rb
+++ b/scripts/ruby/lib/ukraineimporter.rb
@@ -51,20 +51,18 @@ module Ehri
             importer = Importers::UkrainianUnitImporter.new(Graph, repo, log)
             @importerlookup[repo_code] = importer
 
-            importer.add_creation_callback do |item|
-              puts "Created item: #{item.get_id}"
-              ctx.add_subjects item
-              log.add_created
-            end
-
-            importer.add_update_callback do |item|
-              puts "Updated item: #{item.get_id}"
-              ctx.add_subjects item
-              log.add_updated
-            end
-
-            importer.add_unchanged_callback do |item|
-              log.add_unchanged
+            importer.add_callback do |mutation|
+              case mutation.get_state
+                when Persistence::MutationState::CREATED
+                  puts "Created item: #{mutation.get_node.get_id}"
+                  ctx.add_subjects mutation.get_node
+                  log.add_created
+                when Persistence::MutationState::UPDATED
+                  puts "Updated item: #{mutation.get_node.get_id}"
+                  ctx.add_subjects mutation.get_node
+                  log.add_updated
+                else log.add_unchanged
+              end
             end
           end
 
@@ -75,7 +73,7 @@ module Ehri
             puts e.get_message
           end
         end
-        return log
+        log
       end
 
       def import

--- a/scripts/ruby/lib/ushmmimporter.rb
+++ b/scripts/ruby/lib/ushmmimporter.rb
@@ -37,43 +37,24 @@ module Ehri
 
         importer = Importers::IcaAtomEadImporter.new(Graph, scope, log)
 
-        importer.add_creation_callback do |item|
-          puts "Created item: #{item.get_id}"
-          event.add_subjects item
-          log.add_created
+        importer.add_callback do |mutation|
+          case mutation.get_state
+            when Persistence::MutationState::CREATED
+              puts "Created item: #{mutation.get_node.get_id}"
+              event.add_subjects mutation.get_node
+              log.add_created
+            when Persistence::MutationState::UPDATED
+              puts "Updated item: #{mutation.get_node.get_id}"
+              event.add_subjects mutation.get_node
+              log.add_updated
+            else log.add_unchanged
+          end
 
           if log.get_changed > 0 and log.get_changed % COMMIT_MAX == 0
             Graph.get_base_graph.commit
           end
-
           children.each do |cxml|
-            import_with_scope(cxml, item, event, log)
-          end
-        end
-
-        importer.add_update_callback do |item|
-          puts "Updated item: #{item.get_id}"
-          event.add_subjects item
-          log.add_updated
-
-          if log.get_changed > 0 and log.get_changed % COMMIT_MAX == 0
-            Graph.get_base_graph.commit
-          end
-
-          children.each do |cxml|
-            import_with_scope(cxml, item, event, log)
-          end
-        end
-
-        importer.add_unchanged_callback do |item|
-          log.add_unchanged
-
-          if log.get_changed > 0 and log.get_changed % COMMIT_MAX == 0
-            Graph.get_base_graph.commit
-          end
-
-          children.each do |cxml|
-            import_with_scope(cxml, item, event, log)
+            import_with_scope(cxml, mutation.get_node, event, log)
           end
         end
 


### PR DESCRIPTION
- the three types of callback passed in to the import managers
  have been collapsed to one that takes a mutation
- additional constructor added to SaxImportManager to allow providing
  additional callbacks for import events
- some cleanups around the way properties files are specified on the command line importers
