### PR TITLE
Refactor ImporterManagers + tests (fixes #14)

### DIFF
--- a/ehri-importers/src/main/java/eu/ehri/project/importers/AbstractImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/AbstractImporter.java
@@ -77,7 +77,6 @@ public abstract class AbstractImporter<T> {
      * @param graph     the framed graph
      * @param scope     the permission scope
      * @param log       the log object
-     * @param context   the document context
      */
     public AbstractImporter(FramedGraph<?> graph, PermissionScope scope, ImportLog log) {
         this.permissionScope = scope;

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvImportManager.java
@@ -26,21 +26,19 @@ import java.util.Map;
  * 
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
-public class CsvImportManager extends XmlImportManager {
+public class CsvImportManager extends AbstractImportManager {
 
     public static final Character VALUE_DELIMITER = ';';
 
     private static final Logger logger = LoggerFactory.getLogger(CsvImportManager.class);
-    private Class<? extends AbstractImporter> importerClass;
 
     public CsvImportManager(FramedGraph<? extends TransactionalGraph> framedGraph,
             final PermissionScope permissionScope, final Actioner actioner, Class<? extends AbstractImporter> importerClass) {
-        super(framedGraph, permissionScope, actioner);
-        this.importerClass = importerClass;
+        super(framedGraph, permissionScope, actioner, importerClass);
     }
 
     /**
-     * Import XML from the given InputStream, as part of the given action.
+     * Import CSV from the given InputStream, as part of the given action.
      *
      * @param ios The input stream
      * @param eventContext The event context in which the ingest is happening

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/MapImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/MapImporter.java
@@ -119,7 +119,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
      * Extract an Iterable of representations of maintenance events from the itemData.
      * 
      * @param itemData a Map containing raw properties of a unit
-     * @return
+     * @return a List of node representations of maintenance events (may be empty)
      */
     @Override
     public Iterable<Map<String, Object>> extractMaintenanceEvent(Map<String, Object> itemData)  {
@@ -136,21 +136,22 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
     }
     
     /**
-     * Extract a representations of maintenance events from the maintenanceEvent data.
+     * Convert a representation of a maintenance event from the maintenanceEvent data,
+     * using property names from MaintenanceEvent.
      * 
-     * @param event
-     * @return 
+     * @param event a Map of event properties
+     * @return a correct node representation of a single maintenance event
      */
     @Override
     public Map<String, Object> getMaintenanceEvent(Map<String, Object> event) {
         Map<String, Object> me = new HashMap<String, Object>();
-        for (String eventkey : event.keySet()) {
-            if (eventkey.equals("maintenanceEvent/type")) {
-                me.put(MaintenanceEvent.EVENTTYPE, event.get(eventkey));
-            } else if (eventkey.equals("maintenanceEvent/agentType")) {
-                me.put(MaintenanceEvent.AGENTTYPE, event.get(eventkey));
+        for (Entry<String, Object> eventEntry : event.entrySet()) {
+            if (eventEntry.getKey().equals("maintenanceEvent/type")) {
+                me.put(MaintenanceEvent.EVENTTYPE, eventEntry.getValue());
+            } else if (eventEntry.getKey().equals("maintenanceEvent/agentType")) {
+                me.put(MaintenanceEvent.AGENTTYPE, eventEntry.getValue());
             } else {
-                me.put(eventkey, event.get(eventkey));
+                me.put(eventEntry.getKey(), eventEntry.getValue());
             }
         }
         if (!me.containsKey(MaintenanceEvent.EVENTTYPE)) {

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/SaxImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/SaxImportManager.java
@@ -33,11 +33,10 @@ import java.util.Map;
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class SaxImportManager extends XmlImportManager implements ImportManager {
+public class SaxImportManager extends AbstractImportManager {
 
     private static final Logger logger = LoggerFactory.getLogger(SaxImportManager.class);
 
-    private final Class<? extends AbstractImporter> importerClass;
     private final Class<? extends SaxXmlHandler> handlerClass;
     private final Optional<XmlImportProperties> properties;
     private final List<ImportCallback> extraCallbacks;
@@ -54,8 +53,7 @@ public class SaxImportManager extends XmlImportManager implements ImportManager 
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             Optional<XmlImportProperties> properties,
             List<ImportCallback> callbacks) {
-        super(graph, scope, actioner);
-        this.importerClass = importerClass;
+        super(graph, scope, actioner, importerClass);
         this.handlerClass = handlerClass;
         this.properties = properties;
         this.extraCallbacks = Lists.newArrayList(callbacks);
@@ -117,6 +115,7 @@ public class SaxImportManager extends XmlImportManager implements ImportManager 
      * @throws InvalidInputFormatError
      * @throws InvalidXmlDocument
      */
+    @Override
     protected void importFile(InputStream ios, final ActionManager.EventContext eventContext,
             final ImportLog log) throws IOException, ValidationError,
             InputParseError, InvalidXmlDocument, InvalidInputFormatError {

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
@@ -4,11 +4,16 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
+
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.test.AbstractFixtureTest;
+
+import org.junit.After;
+import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +24,36 @@ import java.io.PrintStream;
  */
 public class AbstractImporterTest extends AbstractFixtureTest {
     private static final Logger logger = LoggerFactory.getLogger(AbstractImporterTest.class);
+
+    /**
+     * Shared import manager
+     */
+    protected AbstractImportManager importManager;
+    protected Repository repository;
+    // Depends on fixtures
+    protected final String TEST_REPO = "r1";
+
+    /**
+     * Calls setUp in superclass and initialises the repository
+     */
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        repository = manager.getFrame(TEST_REPO, Repository.class);
+    }
+
+    /**
+     * Resets the shared import manager after a Test.
+     * @throws Exception 
+     */
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        logger.debug("Cleaning up after test: reset importManager");
+        importManager = null;
+    }
 
     protected void printGraph(FramedGraph<?> graph) {
         int vcount = 0;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/DansEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/DansEadImporterTest.java
@@ -29,13 +29,12 @@ public class DansEadImporterTest extends AbstractImporterTest{
     @Test
     public void testImportItemsT() throws Exception {
 
-         Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing a single EAD";
 
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        XmlImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("dansead.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("dansead.properties"))
                 .setTolerant(Boolean.TRUE);
         ImportLog log = importManager.importFile(ios, logMessage);
         printGraph(graph);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/FinlandXmlImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/FinlandXmlImporterTest.java
@@ -18,7 +18,7 @@ public class FinlandXmlImporterTest extends AbstractImporterTest{
        protected final String SINGLE_EAD = "EHRI-test-ead-fin.xml";
        protected final String SINGLE_EAD_ENG = "EHRI-test-ead.xml";
     // Depends on fixtures
-    protected final String TEST_REPO = "r1",
+    protected final String
             C1 = "VAKKA-326611.KA",
             C2 = "VAKKA-3058288.KA";
     
@@ -27,13 +27,12 @@ public class FinlandXmlImporterTest extends AbstractImporterTest{
     @Test
     public void testImportItemsT() throws Exception {
 
-         Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing a single EAD";
 
         int count = getNodeCount(graph);
         System.out.println(count);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        XmlImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("finlandead.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("finlandead.properties"))
                 .setTolerant(Boolean.TRUE);
         // Before...
 //       List<VertexProxy> graphState1 = getGraphState(graph);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadImporterTest.java
@@ -38,7 +38,7 @@ public class IcaAtomEadImporterTest extends AbstractImporterTest{
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        XmlImportManager importManager = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        AbstractImportManager importManager = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .setTolerant(Boolean.TRUE);
         ImportLog log = importManager.importFile(ios, logMessage);
 //        printGraph(graph);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
@@ -34,13 +34,11 @@ public class ItsTest extends AbstractImporterTest {
     protected final String GESTAPO = "its-gestapo-preprocessed.xml";
     protected final String GESTAPO_WHOLE = "its-gestapo-whole.xml";
     protected final String IMPORTED_ITEM_ID = "DE ITS [OuS 1.1.7]";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
+    
     DocumentaryUnit archdesc, c1, c2, c7_1, c7_2;
 
     @Test
     public void testItsImportEsterwegen() throws Exception {
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing a single EAD by ItsTest";
 
         int origCount = getNodeCount(graph);
@@ -51,9 +49,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        XmlImportManager sim = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-holdingguides.properties")).setTolerant(Boolean.TRUE);
-        ImportLog log_en = sim.importFile(ios, logMessage);
-        ImportLog log_de = sim.importFile(ios2, logMessage);
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-holdingguides.properties")).setTolerant(Boolean.TRUE);
+        ImportLog log_en = importManager.importFile(ios, logMessage);
+        ImportLog log_de = importManager.importFile(ios2, logMessage);
 
 // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -127,12 +125,11 @@ public class ItsTest extends AbstractImporterTest {
         assertEquals(logMessage, actions.get(0).getLogMessage());
 
         // Check scope is correct...
-        assertEquals(agent, unit.getPermissionScope());
+        assertEquals(repository, unit.getPermissionScope());
     }
 
     @Test
     public void testGestapo() throws ItemNotFound, IOException, ValidationError, InputParseError {
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing the gestapo (provenance) EAD by ItsTest";
 
         int origCount = getNodeCount(graph);
@@ -142,9 +139,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        XmlImportManager sim = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-findingaids.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-findingaids.properties"))
                 .setTolerant(Boolean.TRUE);
-        ImportLog log_en = sim.importFile(ios, logMessage);
+        ImportLog log_en = importManager.importFile(ios, logMessage);
 
 // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -205,7 +202,6 @@ public class ItsTest extends AbstractImporterTest {
     @Test
     @Ignore
     public void testGestapoWhole() throws ItemNotFound, IOException, ValidationError, InputParseError {
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing the gestapo (provenance) EAD by ItsTest";
 
         int origCount = getNodeCount(graph);
@@ -215,9 +211,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        XmlImportManager sim = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-findingaids.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-findingaids.properties"))
                 .setTolerant(Boolean.TRUE);
-        ImportLog log_en = sim.importFile(ios, logMessage);
+        ImportLog log_en = importManager.importFile(ios, logMessage);
 
 // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -241,7 +237,6 @@ public class ItsTest extends AbstractImporterTest {
 
     @Test
     public void testEsterwegenWhole() throws ItemNotFound, IOException, ValidationError, InputParseError {
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing the esterwegen (pertinence) EAD by ItsTest";
 
         int origCount = getNodeCount(graph);
@@ -251,9 +246,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        XmlImportManager sim = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-findingaids.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-findingaids.properties"))
                 .setTolerant(Boolean.TRUE);
-        ImportLog log_en = sim.importFile(ios, logMessage);
+        ImportLog log_en = importManager.importFile(ios, logMessage);
 
 // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/WienerLibraryTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/WienerLibraryTest.java
@@ -36,7 +36,7 @@ public class WienerLibraryTest extends AbstractImporterTest {
     private static final Logger logger = LoggerFactory.getLogger(WienerLibraryTest.class);
 
     protected final String SINGLE_EAD = "8342_ehriID_wpath_mainids.xml";
-    protected final String TEST_REPO = "r1";
+
     protected final String FONDS_LEVEL = "Ctop level fonds";
     protected final String SUBFONDS_LEVEL = "C00001";
     protected final String C2 = "C00002";
@@ -68,12 +68,12 @@ public class WienerLibraryTest extends AbstractImporterTest {
 //        logger.info("number of events on event: " + toList(ctx.getSystemEvent().getHistory()).size());
 //        logger.info("size : " + toList(validUser.getActions()).size());
 //        
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
+
         final String logMessage = "Importing a single EAD";
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        XmlImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, 
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, 
                 new XmlImportProperties("wienerlib.properties"))
                 .setTolerant(Boolean.FALSE);
         ImportLog log = importManager.importFile(ios, logMessage);
@@ -143,7 +143,7 @@ public class WienerLibraryTest extends AbstractImporterTest {
         }
 
         // Check permission scopes
-        assertEquals(agent, fonds_unit.getPermissionScope());
+        assertEquals(repository, fonds_unit.getPermissionScope());
         assertEquals(fonds_unit, c1.getPermissionScope());
         assertEquals(c1, c2.getPermissionScope());
         assertEquals(c2, c2_1.getPermissionScope());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
@@ -37,7 +37,6 @@ public class YadVashemTest extends AbstractImporterTest{
 
     @Test
     public void testWithExistingDescription() throws Exception{
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing a single EAD";
         DocumentaryUnit m19 = manager.getFrame("nl-r1-m19", DocumentaryUnit.class);
         
@@ -50,7 +49,7 @@ public class YadVashemTest extends AbstractImporterTest{
        List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_C1);
-        XmlImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
                 .setTolerant(Boolean.TRUE);
         ImportLog log = importManager.importFile(ios, logMessage);
 //        printGraph(graph);
@@ -74,7 +73,6 @@ public class YadVashemTest extends AbstractImporterTest{
     @Test 
     public void testImportItemsT() throws Exception {
 
-         Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         final String logMessage = "Importing a single EAD";
 
         int count = getNodeCount(graph);
@@ -87,7 +85,7 @@ public class YadVashemTest extends AbstractImporterTest{
        List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        XmlImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
                 .setTolerant(Boolean.TRUE);
         ImportLog log = importManager.importFile(ios, logMessage);
 //        printGraph(graph);


### PR DESCRIPTION
XmlImportManager -> AbstractImportManager

In #14 the hierarchy of `Importer`s and `ImportManager`s is discussed and deemed strange.
For example, the `CsvImportManager` is a subclass of `XmlImportManager`. This has been
changed by renaming the `XmlImportManager` to `AbstractImportManager` - it had not much to
do with XML anyway, so this makes sense.

Some tests that referenced the `AbstractImportManager` have been refactored to use the
instance in the `AbstractImporterTest`, which now also has

```
protected Repository repository;
// Depends on fixtures
protected final String TEST_REPO = "r1";
```

and `setUp()` and `tearDown()` methods to support test setup (`@Before`) and tearing down
(`@After`).

Added or updated javadoc comments in several locations.

Remove old javadoc param, add more javadoc in Importers