### PR TITLE
Prevent occasional transaction failures by locking the event chain root at TX start.

### DIFF
--- a/ehri-frames/src/main/java/eu/ehri/project/utils/TxCheckedNeo4jGraph.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/utils/TxCheckedNeo4jGraph.java
@@ -1,17 +1,39 @@
 package eu.ehri.project.utils;
 
 import com.tinkerpop.blueprints.impls.neo4j.Neo4jGraph;
+import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.persistence.ActionManager;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.IndexHits;
 
 import java.util.Map;
 
 /**
- * Created by mike on 18/06/13.
- *
- * Wraps Neo4jGraph and adds an extra method to allow asseting
+ * Wraps Neo4jGraph and adds an extra method to allow asserting
  * that it should not be in a transaction.
+ * <p/>
+ * When starting a transaction we also lock the top node of
+ * the graph-global action event chain in a assumption that graph modifications
+ * will be audited and thus modify this node's relationships. The default
+ * <a href="http://neo4j.com/docs/1.9/transactions-locking.html">Neo4j behaviour</a>
+ * is just to lock nodes which are changed, which can occasionally lead concurrent
+ * transactions to fail when the TXs attempt to modify the global action root relation
+ * simultaneously. This solution should trade concurrent write speed for less chance
+ * audited write actions will have TXs fail. Deadlocks should be detected and resolved
+ * by Neo4j by failing a TX, but this has not yet been observed in practice.
+ * <p/>
+ * NB: On a cleanly initialised graph the action chain root node should be
+ * node 0 but we cannot take this for granted. Instead we look the node
+ * up by name in the index and cache it for subsequent invocations.
  */
 public class TxCheckedNeo4jGraph extends Neo4jGraph {
+
+    private static final String INDEX_NAME = "entities";
+
+    private Node cachedEventChain = null;
+
     public TxCheckedNeo4jGraph(String directory) {
         super(directory);
     }
@@ -28,10 +50,31 @@ public class TxCheckedNeo4jGraph extends Neo4jGraph {
         super(directory, configuration);
     }
 
+    @Override
+    public void autoStartTransaction() {
+        Transaction transaction = tx.get();
+        if (transaction == null) {
+            transaction = getRawGraph().beginTx();
+            tx.set(transaction);
+            Node eventChain = getCachedEventChain();
+            if (eventChain != null) {
+                transaction.acquireWriteLock(eventChain);
+            }
+        }
+    }
+
+    /**
+     * Throw an exception if we're currently in a transaction
+     */
     public void checkNotInTransaction() {
         checkNotInTransaction("(no debug)");
     }
 
+    /**
+     * Throw an exception if we're currently in a transaction.
+     *
+     * @param msg a msg to use in the exception
+     */
     public void checkNotInTransaction(String msg) {
         if (tx.get() != null) {
             rollback();
@@ -39,7 +82,27 @@ public class TxCheckedNeo4jGraph extends Neo4jGraph {
         }
     }
 
+    /**
+     * Checks if the graph is currently in a transaction.
+     *
+     * @return whether a transaction is held in this thread.
+     */
     public boolean isInTransaction() {
         return tx.get() != null;
+    }
+
+    // Helper - look up the event chain in the index and cache it.
+    private Node getCachedEventChain() {
+        if (cachedEventChain == null) {
+            IndexHits<Node> entities = getRawGraph().index()
+                    .forNodes(INDEX_NAME).get(EntityType.ID_KEY, ActionManager
+                            .GLOBAL_EVENT_ROOT);
+            try {
+                cachedEventChain = entities.getSingle();
+            } finally {
+                entities.close();
+            }
+        }
+        return cachedEventChain;
     }
 }


### PR DESCRIPTION
Because we have a single, serialized audit event log in the graph, this
somewhat limits the extent to which concurrent graph modifications can
take place. Certain actions, such as watching items or following
users can happily work concurrently because they do not modify the event
log, but adding, modifying, or deleting data actions effectively need to hold a
lock on the event chain.

Unfortunately, Neo4j does not know that most transactions modify the
global event root, so it doesn't lock this node. This means that logged
concurrent transactions sometimes fail because they try to modify the
event root's head relationship and then discover it's already been changed
by another thread. This doesn't lead to any data corruption since the
transaction is just rolled back, but it does inconvenience the user.

This fix is an attempt to find a better balance, given that:

 - we do not ever expect a lot of write activity on the graph
 - nearly all graph modifying actions alter the global event log

What it does is override the default Blueprints/Neo4j implementation's
behaviour when starting a transaction and manually obtains a lock on the
event root node. I have tested this with a whole load of concurrent
modifying requests and it works very nicely. There is in theory a risk
of more deadlocks (since we're locking) but Neo4j should detect these
automatically.

I've not particularly happy with the precise way the root node is located,
since it depends on index implementation details that are not exposed by
lower layers, namely the name of the single manual graph index ("entities").