### PR TITLE
Tweak slugification algorithm and add ID regeneration tools.

### DIFF
--- a/ehri-extension/src/test/java/eu/ehri/extension/test/ToolsRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/ToolsRestClientTest.java
@@ -11,6 +11,8 @@ import javax.ws.rs.core.MediaType;
 import static com.sun.jersey.api.client.ClientResponse.Status.OK;
 import static org.junit.Assert.assertEquals;
 import static eu.ehri.extension.ToolsResource.ENDPOINT;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Test admin REST functions.
  *
@@ -53,5 +55,43 @@ public class ToolsRestClientTest extends BaseRestClientTest {
                 .type(MediaType.APPLICATION_JSON).post(ClientResponse.class);
         assertStatus(OK, response);
         assertEquals("2", response.getEntity(String.class));
+    }
+
+    @Test
+    public void testRegenerateId() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "_regenerateId", "c1"))
+                .queryParam("commit", "true");
+        ClientResponse response = resource.post(ClientResponse.class);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertEquals(1, out.split("\r\n|\r|\n").length);
+        assertTrue(out.contains("nl-r1-c1"));
+    }
+
+    @Test
+    public void testRegenerateIdsForScope() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "_regenerateIdsForScope", "r1"))
+                .queryParam("commit", "true");
+        ClientResponse response = resource.post(ClientResponse.class);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertEquals(2, out.split("\r\n|\r|\n").length);
+        assertTrue(out.contains("nl-r1-c1"));
+        assertTrue(out.contains("nl-r1-c4"));
+    }
+
+    @Test
+    public void testRegenerateIdsForType() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT,
+                "_regenerateIdsForType", "documentaryUnit"))
+                .queryParam("commit", "true");
+        ClientResponse response = resource.post(ClientResponse.class);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertEquals(4, out.split("\r\n|\r|\n").length);
+        assertTrue(out.contains("nl-r1-c1"));
+        assertTrue(out.contains("nl-r1-c1-c2"));
+        assertTrue(out.contains("nl-r1-c1-c2-c3"));
+        assertTrue(out.contains("nl-r1-c4"));
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/core/GraphManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/core/GraphManager.java
@@ -210,6 +210,15 @@ public interface GraphManager {
      */
     public void setProperty(Vertex vertex, String key, Object value);
 
+    /**
+     * Rename an existing vertex, changing its ID.
+     *
+     * @param vertex the vertex
+     * @param vertex the old ID
+     * @param newId  the new ID
+     */
+    public void renameVertex(Vertex vertex, String oldId, String newId);
+
     // CRUD functions
 
     /**

--- a/ehri-frames/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
@@ -43,55 +43,56 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         return graph;
     }
 
-    public <T extends Frame> T cast(Frame frame, Class<T> cls) {
-        return graph.frame(frame.asVertex(), cls);
-    }
-
     public BlueprintsGraphManager(FramedGraph<T> graph) {
         this.graph = graph;
     }
 
+    @Override
+    public <T extends Frame> T cast(Frame frame, Class<T> cls) {
+        return graph.frame(frame.asVertex(), cls);
+    }
+
+    @Override
     public String getId(Vertex vertex) {
         return vertex.getProperty(EntityType.ID_KEY);
     }
 
-    public String getId(Frame frame) {
-        return getId(frame.asVertex());
-    }
-
+    @Override
     public String getType(Vertex vertex) {
         return vertex.getProperty(EntityType.TYPE_KEY);
     }
 
-    public String getType(Frame frame) {
-        return frame.getType();
-    }
-
+    @Override
     public EntityClass getEntityClass(Vertex vertex) {
         Preconditions.checkNotNull(vertex);
         return EntityClass.withName(getType(vertex));
     }
 
+    @Override
     public EntityClass getEntityClass(Frame frame) {
         Preconditions.checkNotNull(frame);
         return EntityClass.withName(frame.getType());
     }
 
+    @Override
     public boolean exists(String id) {
         Preconditions.checkNotNull(id,
                 "attempt determine existence of a vertex with a null id");
         return getIndex().count(EntityType.ID_KEY, id) > 0L;
     }
 
+    @Override
     public <T> T getFrame(String id, Class<T> cls) throws ItemNotFound {
         return graph.frame(getVertex(id), cls);
     }
 
+    @Override
     public <T> T getFrame(String id, EntityClass type, Class<T> cls)
             throws ItemNotFound {
         return graph.frame(getVertex(id, type), cls);
     }
 
+    @Override
     public <T> CloseableIterable<T> getFrames(EntityClass type, Class<T> cls) {
         CloseableIterable<Vertex> vertices = getVertices(type);
         try {
@@ -102,6 +103,7 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         }
     }
 
+    @Override
     public Vertex getVertex(String id) throws ItemNotFound {
         Preconditions
                 .checkNotNull(id, "attempt to fetch vertex with a null id");
@@ -115,6 +117,7 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         }
     }
 
+    @Override
     public Vertex getVertex(String id, EntityClass type) throws ItemNotFound {
         Preconditions
                 .checkNotNull(id, "attempt to fetch vertex with a null id");
@@ -125,10 +128,12 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         throw new ItemNotFound(id);
     }
 
+    @Override
     public CloseableIterable<Vertex> getVertices(EntityClass type) {
         return getIndex().get(EntityType.TYPE_KEY, type.getName());
     }
 
+    @Override
     public CloseableIterable<Vertex> getVertices(Iterable<String> ids) throws ItemNotFound {
         // Ugh, we don't want to remove duplicate results here
         // because that's not expected behaviour - if you give
@@ -140,6 +145,7 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         return new WrappingCloseableIterable<Vertex>(verts);
     }
 
+    @Override
     public CloseableIterable<Vertex> getVertices(String key, Object value, final EntityClass type) {
         // NB: This is rather annoying.
         CloseableIterable<Vertex> query = getIndex().get(key, value);
@@ -156,11 +162,13 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         return new WrappingCloseableIterable<Vertex>(elems);
     }
 
+    @Override
     public Vertex createVertex(String id, EntityClass type,
             Map<String, ?> data) throws IntegrityError {
         return createVertex(id, type, data, data.keySet());
     }
 
+    @Override
     public Vertex createVertex(String id, EntityClass type,
             Map<String, ?> data, Iterable<String> keys) throws IntegrityError {
         Preconditions
@@ -182,11 +190,13 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         return node;
     }
 
+    @Override
     public Vertex updateVertex(String id, EntityClass type,
             Map<String, ?> data) throws ItemNotFound {
         return updateVertex(id, type, data, data.keySet());
     }
 
+    @Override
     public Vertex updateVertex(String id, EntityClass type,
             Map<String, ?> data, Iterable<String> keys) throws ItemNotFound {
         Preconditions.checkNotNull(id, "null vertex ID given for item update");
@@ -228,16 +238,38 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         }
     }
 
+    @Override
+    public void renameVertex(Vertex vertex, String oldId, String newId) {
+        Preconditions.checkNotNull(vertex);
+        Preconditions.checkNotNull(newId);
+        Index<Vertex> index = getIndex();
+        index.remove(EntityType.ID_KEY, oldId, vertex);
+        vertex.setProperty(EntityType.ID_KEY, newId);
+        index.put(EntityType.ID_KEY, newId, vertex);
+    }
+
+    @Override
     public void deleteVertex(String id) throws ItemNotFound {
         deleteVertex(getVertex(id));
     }
 
+    @Override
     public void deleteVertex(Vertex vertex) {
         Index<Vertex> index = getIndex();
         for (String key : vertex.getPropertyKeys()) {
             index.remove(key, vertex.getProperty(key), vertex);
         }
         vertex.remove();
+    }
+
+    @Override
+    public void rebuildIndex() {
+        graph.getBaseGraph().dropIndex(INDEX_NAME);
+        Index<Vertex> index = graph.getBaseGraph().createIndex(INDEX_NAME, Vertex.class);
+        // index vertices
+        for (Vertex vertex : graph.getVertices()) {
+            reindex(index, vertex);
+        }
     }
 
     private <T extends Element> void replaceProperties(Index<T> index, T item,
@@ -301,17 +333,11 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
         return index;
     }
 
-    public void rebuildIndex() {
-        graph.getBaseGraph().dropIndex(INDEX_NAME);
-        Index<Vertex> index = graph.getBaseGraph().createIndex(INDEX_NAME, Vertex.class);
-
-        // index vertices
-        for (Vertex vertex : graph.getVertices()) {
-            for (String key : propertyKeysToIndex(vertex)) {
-                Object val = vertex.getProperty(key);
-                if (val != null) {
-                    index.put(key, val, vertex);
-                }
+    private void reindex(Index<Vertex> index, Vertex vertex) {
+        for (String key : propertyKeysToIndex(vertex)) {
+            Object val = vertex.getProperty(key);
+            if (val != null) {
+                index.put(key, val, vertex);
             }
         }
     }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/idgen/IdGenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/idgen/IdGenerator.java
@@ -14,11 +14,6 @@ import java.util.List;
 public interface IdGenerator {
 
     /**
-     * Handle an id collision by either a validation error depending
-     * on how the id was generated, or a RuntimeError.
-     *
-     *
-     *
      * @param scopeIds  The entity's parent scope identifiers
      * @param bundle The entity's bundle data
      * @return A set of errors

--- a/ehri-frames/src/main/java/eu/ehri/project/tools/IdRegenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/tools/IdRegenerator.java
@@ -1,0 +1,104 @@
+package eu.ehri.project.tools;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.tinkerpop.blueprints.TransactionalGraph;
+import com.tinkerpop.frames.FramedGraph;
+import eu.ehri.project.acl.SystemScope;
+import eu.ehri.project.core.GraphManager;
+import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.exceptions.SerializationError;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.base.AccessibleEntity;
+import eu.ehri.project.models.base.Frame;
+import eu.ehri.project.models.base.PermissionScope;
+import eu.ehri.project.persistence.Serializer;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Util class for re-generating the IDs for a given
+ * set of items.
+ *
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class IdRegenerator {
+    private final FramedGraph<? extends TransactionalGraph> graph;
+    private final GraphManager manager;
+    private final Serializer depSerializer;
+    private final boolean dryrun;
+
+    public IdRegenerator(FramedGraph<? extends TransactionalGraph> graph) {
+        this(graph, true);
+    }
+
+    private IdRegenerator(FramedGraph<? extends TransactionalGraph> graph, boolean dryrun) {
+        this.graph = graph;
+        this.manager = GraphManagerFactory.getInstance(graph);
+        this.depSerializer = new Serializer.Builder(graph).dependentOnly().build();
+        this.dryrun = dryrun;
+    }
+
+    public List<List<String>> reGenerateIds(PermissionScope scope, Iterable<? extends Frame> items) {
+        List<List<String>> remaps = Lists.newArrayList();
+        for (Frame item: items) {
+            Optional<List<String>> optionalRemap = reGenerateId(scope, item);
+            if (optionalRemap.isPresent()) {
+                remaps.add(optionalRemap.get());
+            }
+        }
+        return remaps;
+    }
+
+    public List<List<String>> reGenerateIds(Iterable<? extends AccessibleEntity> items) {
+        List<List<String>> remaps = Lists.newArrayList();
+        for (AccessibleEntity item: items) {
+            Optional<List<String>> optionalRemap = reGenerateId(item);
+            if (optionalRemap.isPresent()) {
+                remaps.add(optionalRemap.get());
+            }
+        }
+        return remaps;
+    }
+
+    public Optional<List<String>> reGenerateId(AccessibleEntity item) {
+        return reGenerateId(item.getPermissionScope(), item);
+    }
+
+    public Optional<List<String>> reGenerateId(PermissionScope permissionScope, Frame item) {
+        String currentId = item.getId();
+        Collection<String> idChain = Lists.newArrayList();
+        if (permissionScope != null && !permissionScope.equals(SystemScope.getInstance())) {
+            idChain.addAll(permissionScope.idPath());
+        }
+
+        EntityClass entityClass = manager.getEntityClass(item);
+        try {
+            String newId = entityClass.getIdgen().generateId(idChain, depSerializer.vertexFrameToBundle(item));
+            if (!newId.equals(currentId)) {
+                if (!dryrun) {
+                    manager.renameVertex(item.asVertex(), currentId, newId);
+                }
+                List<String> remap = Lists.newArrayList(currentId, newId);
+                return Optional.of(remap);
+            } else {
+                return Optional.absent();
+            }
+        } catch (SerializationError e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Obtain a re-generator that will actually perform the rename
+     * step.
+     *
+     * @param doIt whether to actually commit changes
+     *
+     * @return a new, more dangerous, re-generator
+     */
+    public IdRegenerator withActualRename(boolean doIt) {
+        return new IdRegenerator(graph, !doIt);
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
@@ -7,9 +7,7 @@ import java.text.Normalizer;
 
 /**
  * Class for handling slugification of strings, for use
- * in identifiers.
- *
- * This is largely adapted from <a href="https://github.com/slugify/slugify/blob/master/src/main/java/com/github/slugify/Slugify.java">Slugify on Github</a>.
+ * in global identifiers.
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
@@ -24,14 +22,11 @@ public class Slugify {
     }
 
     public static String slugify(String input, String replacement) {
-        String ret = StringUtils.trim(input);
-        if (StringUtils.isBlank(input)) {
-            return "";
-        }
-
-        ret = normalize(ret);
-        ret = removeDuplicateWhiteSpaces(ret);
-        return ret.replaceAll(" ", replacement).replaceAll("-+", replacement).toLowerCase();
+        return normalize(input)
+                .replaceAll("\\s+", replacement)            // whitespace
+                .replaceAll(replacement + "+", replacement) // replacements
+                .replaceAll("^\\W|\\W$", "")                // leading/trailing non alpha
+                .toLowerCase();
     }
 
     private static String normalize(String input) {
@@ -44,15 +39,6 @@ public class Slugify {
         return Normalizer.normalize(trans, Normalizer.Form.NFD)
                 .replaceAll("[^\\p{ASCII}]", "")
                 .replaceAll("[^a-zA-Z0-9- ]", DEFAULT_REPLACE);
-    }
-
-    private static String removeDuplicateWhiteSpaces(String input) {
-        String ret = StringUtils.trim(input);
-        if (StringUtils.isBlank(ret)) {
-            return "";
-        }
-
-        return ret.replaceAll("\\s+", " ");
     }
 }
 

--- a/ehri-frames/src/test/java/eu/ehri/project/models/utils/ClassUtilsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/utils/ClassUtilsTest.java
@@ -1,0 +1,68 @@
+package eu.ehri.project.models.utils;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.tinkerpop.blueprints.Direction;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class ClassUtilsTest extends AbstractFixtureTest {
+
+    @Test
+    public void testGetEntityType() throws Exception {
+        assertEquals(EntityClass.DOCUMENTARY_UNIT,
+                ClassUtils.getEntityType(DocumentaryUnit.class));
+    }
+
+    @Test
+    public void testGetDependentRelations() throws Exception {
+        Map<String,Direction> deps = Maps.newHashMap();
+        deps.put(Ontology.DESCRIPTION_FOR_ENTITY, Direction.IN);
+        assertEquals(deps, ClassUtils.getDependentRelations(DocumentaryUnit.class));
+    }
+
+    @Test
+    public void testGetFetchMethods() throws Exception {
+        Set<String> fetch = Sets.newHashSet(
+                Ontology.DESCRIPTION_FOR_ENTITY,
+                Ontology.DOC_HELD_BY_REPOSITORY,
+                Ontology.DOC_IS_CHILD_OF,
+                Ontology.ENTITY_HAS_LIFECYCLE_EVENT,
+                Ontology.IS_ACCESSIBLE_TO
+        );
+        assertEquals(fetch, ClassUtils.getFetchMethods(DocumentaryUnit.class).keySet());
+    }
+
+    @Test
+    public void testGetPropertyKeys() throws Exception {
+        Set<String> keys = Sets.newHashSet(
+                Ontology.IDENTIFIER_KEY,
+                EntityType.ID_KEY,
+                EntityType.TYPE_KEY
+        );
+        assertEquals(keys, ClassUtils.getPropertyKeys(DocumentaryUnit.class));
+    }
+
+    @Test
+    public void testGetMandatoryPropertyKeys() throws Exception {
+        Set<String> keys = Sets.newHashSet(
+                Ontology.IDENTIFIER_KEY
+        );
+        assertEquals(keys, ClassUtils.getMandatoryPropertyKeys(DocumentaryUnit.class));
+    }
+
+    @Test
+    public void testGetUniquePropertyKeys() throws Exception {
+        Set<String> keys = Sets.newHashSet();
+        assertEquals(keys, ClassUtils.getUniquePropertyKeys(DocumentaryUnit.class));
+    }
+}

--- a/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
@@ -2,6 +2,7 @@ package eu.ehri.project.tools;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
+import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
@@ -38,6 +39,50 @@ public class IdRegeneratorTest extends AbstractFixtureTest {
         assertEquals("nl-r1-c1", beforeAfter.get(1));
         // It shouldn't actually do anything by default...
         assertEquals("c1", doc.getId());
+    }
+
+    @Test(expected = IdRegenerator.IdCollisionError.class)
+    public void testReGenerateIdWithCollision() throws Exception {
+        DocumentaryUnit doc1 = manager.getFrame("c1", DocumentaryUnit.class);
+        DocumentaryUnit doc2 = manager.getFrame("c4", DocumentaryUnit.class);
+        // Give c4 its "natural" ID
+        Optional<List<String>> regen = idRegenerator
+                .withActualRename(true).reGenerateId(doc2);
+        assertTrue(regen.isPresent());
+        // Sneakily change the identifier property to trigger a collision
+        manager.setProperty(doc1.asVertex(), Ontology.IDENTIFIER_KEY, "c4");
+        idRegenerator.reGenerateId(doc1);
+    }
+
+    @Test
+    public void testCollisionMode() throws Exception {
+        DocumentaryUnit doc1 = manager.getFrame("c1", DocumentaryUnit.class);
+        DocumentaryUnit doc2 = manager.getFrame("c4", DocumentaryUnit.class);
+        // Give c4 its "natural" ID
+        Optional<List<String>> regen = idRegenerator
+                .withActualRename(true).reGenerateId(doc2);
+        assertTrue(regen.isPresent());
+        // Sneakily change the identifier property to trigger a collision
+        manager.setProperty(doc1.asVertex(), Ontology.IDENTIFIER_KEY, "c4");
+        Optional<List<String>> optionalCollision = idRegenerator
+                .collisionMode(true)
+                .reGenerateId(doc1);
+        assertTrue(optionalCollision.isPresent());
+    }
+
+    @Test
+    public void testReGenerateIdWSkippingCollisions() throws Exception {
+        DocumentaryUnit doc1 = manager.getFrame("c1", DocumentaryUnit.class);
+        DocumentaryUnit doc2 = manager.getFrame("c4", DocumentaryUnit.class);
+        // Give c4 its "natural" ID
+        Optional<List<String>> regen = idRegenerator
+                .withActualRename(true)
+                .reGenerateId(doc2);
+        assertTrue(regen.isPresent());
+        // Sneakily change the identifier property to trigger a collision
+        manager.setProperty(doc1.asVertex(), Ontology.IDENTIFIER_KEY, "c4");
+        assertFalse(idRegenerator
+                .skippingCollisions(true).reGenerateId(doc1).isPresent());
     }
 
     @Test

--- a/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
@@ -1,0 +1,80 @@
+package eu.ehri.project.tools;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.Repository;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class IdRegeneratorTest extends AbstractFixtureTest {
+
+    private IdRegenerator idRegenerator;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        idRegenerator = new IdRegenerator(graph);
+    }
+
+    @Test
+    public void testReGenerateId() throws Exception {
+        // It just so happens for this test that, for convenience reasons,
+        // the fixtures do not have the IDs that their IdGenerators would
+        // produce. So it's easy to test this.
+        DocumentaryUnit doc = manager.getFrame("c1", DocumentaryUnit.class);
+        Optional<List<String>> remap = idRegenerator.reGenerateId(doc);
+        assertTrue(remap.isPresent());
+        List<String> beforeAfter = remap.get();
+        assertEquals(2, beforeAfter.size());
+        assertEquals("c1", beforeAfter.get(0));
+        assertEquals("nl-r1-c1", beforeAfter.get(1));
+        // It shouldn't actually do anything by default...
+        assertEquals("c1", doc.getId());
+    }
+
+    @Test
+    public void testReGenerateIdWithExplicitScope() throws Exception {
+        DocumentaryUnit doc = manager.getFrame("c1", DocumentaryUnit.class);
+        Repository fakeScope = manager.getFrame("r2", Repository.class);
+        Optional<List<String>> remap = idRegenerator.reGenerateId(fakeScope, doc);
+        assertEquals("gb-r2-c1", remap.get().get(1));
+    }
+
+    @Test
+    public void testReGenerateIdWithRename() throws Exception {
+        DocumentaryUnit doc = manager.getFrame("c1", DocumentaryUnit.class);
+        Optional<List<String>> remap = idRegenerator.withActualRename(true).reGenerateId(doc);
+        assertEquals("nl-r1-c1", remap.get().get(1));
+        assertFalse(manager.exists("c1"));
+        assertTrue(manager.exists("nl-r1-c1"));
+        // It shouldn't actually do anything by default...
+        assertEquals(remap.get().get(1), doc.getId());
+        // Doing it again should do nothing...
+        assertFalse(idRegenerator.withActualRename(true)
+                .reGenerateId(doc).isPresent());
+    }
+
+    @Test
+    public void testReGenerateIds() throws Exception {
+        Iterable<DocumentaryUnit> docs = manager.getFrames(EntityClass.DOCUMENTARY_UNIT,
+                DocumentaryUnit.class);
+        List<List<String>> remaps = idRegenerator.reGenerateIds(docs);
+        assertEquals(4, remaps.size());
+        Map<String,String> remap = Maps.newHashMap();
+        for (List<String> rm : remaps) {
+            remap.put(rm.get(0), rm.get(1));
+        }
+        assertEquals("nl-r1-c1", remap.get("c1"));
+        assertEquals("nl-r1-c1-c2", remap.get("c2"));
+        assertEquals("nl-r1-c1-c2-c3", remap.get("c3"));
+        assertEquals("nl-r1-c4", remap.get("c4"));
+    }
+}

--- a/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
@@ -22,6 +22,12 @@ public class SlugifyTest {
     }
 
     @Test
+    public void removeLeadingTrailingDashes() {
+        String bad = "-foo-bad-";
+        assertEquals("foo-bad", Slugify.slugify(bad));
+    }
+
+    @Test
     public void removeMultiDashes() {
         String bad = "foo---bad";
         assertEquals("foo-bad", Slugify.slugify(bad));

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
@@ -83,7 +83,7 @@ public class ItsTest extends AbstractImporterTest {
         assertTrue(docs.iterator().hasNext());
         DocumentaryUnit unit = graph.frame(docs.iterator().next(), DocumentaryUnit.class);
 
-        assertEquals("nl-r1-de-its-ous-1-1-7-", unit.getId());
+        assertEquals("nl-r1-de-its-ous-1-1-7", unit.getId());
         // The arch has 1 c01 direct child (and 2 c02 "grandchildren", but these are not counted)
         for (DocumentaryUnit d : unit.getChildren()) {
             logger.debug("Child: " + d.getIdentifier());


### PR DESCRIPTION
 - slugify no longer allows leading or trailing non-alphanumeric chars
 - add an IdRegenerator helper class
 - add a couple of ways to call it from the web service
   - re-generate ID of a single item
   - re-generate IDs for all items within a given parent scope
   - re-generate IDs for all items of a given type
 - the web service endpoints output a tab separated old->new mapping
   which can be imported into the front-end SQL db to ensure it returns
   301 moved permanently where appropriate

This isn't intended just to fix mistakes. In Eddy they seem to change
the identifier fields much more then I expected which means the hierarchical
identifier gets a bit broken! It is also useful for fixing mistakes.