### PR TITLE
Make checkstyle check for licence header in java files

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3,14 +3,21 @@
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-	<!-- Require Javadoc for each package in a package-info.java file -->
-    <module name="JavadocPackage"/>
-	<module name="TreeWalker">
-		<!-- Require Javadoc for each type -->
-		<module name="JavadocType">
-            <property name="authorFormat" value="(Mike Bryant \(http(s)?://github.com/mikesname(/)?\)|Ben Companjen \(http(s)?://github.com/bencomp(/)?\)|Linda Reijnhoudt \(http(s)?://github.com/lindareijnhoudt(/)?\)|Paul Boon \(http(s)?://github.com/(paulboon|PaulBoon)(/)?\))"/>
+    <!-- Require Javadoc for each package in a package-info.java file -->
+    <module name="JavadocPackage" />
+    <module name="Header">
+        <property name="headerFile" value="java.header" />
+        <property name="ignoreLines" value="2" />
+        <property name="fileExtensions" value="java" />
+    </module>
+    <module name="TreeWalker">
+        <!-- Require Javadoc for each type -->
+        <module name="JavadocType">
+            <property name="severity" value="warning"/>
+            <property name="authorFormat"
+                value="(Mike Bryant \(http(s)?://github.com/mikesname(/)?\)|Ben Companjen \(http(s)?://github.com/bencomp(/)?\)|Linda Reijnhoudt \(http(s)?://github.com/lindareijnhoudt(/)?\)|Paul Boon \(http(s)?://github.com/(paulboon|PaulBoon)(/)?\))" />
         </module>
-		<module name="AvoidStarImport" />
-		<module name="EmptyBlock" />
-	</module>
+        <module name="AvoidStarImport" />
+        <module name="EmptyBlock" />
+    </module>
 </module>

--- a/java.header
+++ b/java.header
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2015 EHRI partners
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */


### PR DESCRIPTION
Add a checkstyle module `Header` to make sure eventually all source files have a reference to the EUPL (as required by #103). The header is defined in `java.header`, but the rule ignores line 2 as the copyright holder is undetermined/dependent on the author(s) of the file.