### PR TITLE
Add a default logback-test.xml

### DIFF
--- a/ehri-importers/src/test/resources/logback-test.xml
+++ b/ehri-importers/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="eu.ehri.project.importers" level="${ehri.test.log.level:-info}" />
+  <logger name="eu.ehri" level="${ehri.log.level:-info}" />
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This is so the CI system doesn't use the default, which is set to debug and this produces a stupendous amount of information.