### PR TITLE
Revert "Increased default/max recursive traversals to deal with deeply nested collections"

### DIFF
--- a/ehri-frames/src/main/java/eu/ehri/project/models/annotations/Fetch.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/annotations/Fetch.java
@@ -21,43 +21,21 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Fetch {
-    public static final int DEFAULT_TRAVERSALS = 15;
+    public static final int DEFAULT_TRAVERSALS = 5;
 
     /**
      * Default number of traversals to make on @Fetch'ed relations.
      * 
-     * @return the depth to which this relationship should be traversed
+     * @return
      */
     int depth() default DEFAULT_TRAVERSALS;
 
-    /**
-     * Only traverse this relationship at the specified depth. Ignored
-     * if the depth is < 0.
-     *
-     * @return the depth at which this relation should be traversed
-     */
     int ifDepth() default -1;
 
-    /**
-     * Only traverse this relationship when not doing 'lite' serialization,
-     * e.g. when we want maximum detail.
-     *
-     * @return boolean switch
-     */
     boolean whenNotLite() default false;
 
-    /**
-     * Override lite/full serialization modes and always serialize
-     * this relationship.
-     *
-     * @return boolean switch
-     */
     boolean full() default false;
 
-    /**
-     * The key name of the serialized relationship.
-     *
-     * @return the name used in output data
-     */
     String value();
+
 }


### PR DESCRIPTION


Perhaps unsurprisingly, this seems to cause some nasty behaviour when
serializing lots of links which are deeply nested. Rollback until a
better fix can be devised.

Better fix on the way.