### PR TITLE
CsvAuthoritativeItemImportes will actually create AuthoritativeItems 

### DIFF
--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
-public abstract class CsvAuthoritativeItemImporter extends MapImporter {
+public class CsvAuthoritativeItemImporter extends MapImporter {
 
 //    private final XmlImportProperties p = new XmlImportProperties("csvconcept.properties");
 
@@ -46,9 +46,9 @@ public abstract class CsvAuthoritativeItemImporter extends MapImporter {
 
         BundleDAO persister = getPersister();
 
-        Bundle unit = new Bundle(EntityClass.CVOC_CONCEPT, extractUnit(itemData));
+        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData));
 
-        Bundle descBundle = new Bundle(EntityClass.CVOC_CONCEPT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.CVOC_CONCEPT_DESCRIPTION));
+        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
 
         unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
@@ -83,22 +83,7 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
         return item;
     }
 
-    private String getName(Map<String, Object> itemData) {
-        // FIXME: This all sucks
-        String firstName = (String) itemData.get("Firstname");
-        String lastName = (String) itemData.get("Lastname");
-        if (firstName == null && lastName == null) {
-            return null;
-        }
-        String name = "";
-        if (lastName != null) {
-            name = lastName;
-        }
-        if (firstName != null) {
-            name = firstName + " " + name;
-        }
-        return name;
-    }
+  
 
     protected Map<String, Object> extractUnitDescription(Map<String, Object> itemData, EntityClass entityClass) {
         Map<String, Object> item = new HashMap<String, Object>();

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EadImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EadImporter.java
@@ -99,7 +99,7 @@ public class EadImporter extends EaImporter {
             for(String u : unknowns.keySet()){
                 unknownProperties.append(u);
             }
-            logger.debug("Unknown Properties found: " + unknownProperties.toString());
+            logger.info("Unknown Properties found: " + unknownProperties.toString());
             descBundle = descBundle.withRelation(Ontology.HAS_UNKNOWN_PROPERTY, new Bundle(EntityClass.UNKNOWN_PROPERTY, unknowns));
         }
         // extractDocumentaryUnit does not throw ValidationError on missing ID
@@ -253,7 +253,7 @@ public class EadImporter extends EaImporter {
                         vocabulary = manager.getFrame(cvoc_id, Vocabulary.class);
                         for (Concept concept : vocabulary.getConcepts()) {
                         logger.debug("*********************" + concept.getId() + " " + concept.getIdentifier());
-                        if (concept.getIdentifier().equals(concept_id)) {
+                        if (concept.getIdentifier().equalsIgnoreCase(concept_id)) {
                             try {
                                 Bundle linkBundle = new Bundle(EntityClass.LINK)
                                         .withDataValue(Ontology.LINK_HAS_TYPE, rel.asVertex().getProperty("type").toString())
@@ -263,6 +263,7 @@ public class EadImporter extends EaImporter {
                                 unit.addLink(link);
                                 concept.addLink(link);
                                 link.addLinkBody(rel);
+                                logger.debug("link created between {} and {}", concept_id, concept.getId());
                             } catch (PermissionDenied ex) {
                                 logger.error(ex.getMessage());
                             }

--- a/ehri-importers/src/main/resources/bundesarchive.properties
+++ b/ehri-importers/src/main/resources/bundesarchive.properties
@@ -1,8 +1,10 @@
 #bundesarchiv specific
 descgrp/@encoding$Bestandsbeschreibung=archivalHistory
+descgrp/p/=archivalHistory
 did/unittitle/@encoding$Bestandsbezeichnung=name
 did/unitid/@encoding$Alte_Bestandssignatur=otherIdentifiers
 #did/unitdate/@encoding$Provenienzlaufzeit=parallelFormsOfName leave out, by mail dated 20141014
+did/unitdate/@encoding$Provenienzlaufzeit=IGNORE
 did/unitdate/@encoding$Bestandslaufzeit=unitDates
 bibliography/p/=sources
 #bibliography/@encoding=sources leave out, by mail dated 20141014

--- a/ehri-importers/src/main/resources/its-provenance.properties
+++ b/ehri-importers/src/main/resources/its-provenance.properties
@@ -16,6 +16,7 @@ processinfo/chronlist/chronitem/date/=IGNORE
 abstract/=scopeAndContent
 note/p/=extentAndMedium
 acqinfo/p/date/=acquisition
+acqinfo/note/p/=acquisition
 @normal=itsdatelabel
 did/unitdate/@itsdatelabel=unitDates
 did/unitdate/=IGNORE

--- a/ehri-importers/src/main/resources/jmp.properties
+++ b/ehri-importers/src/main/resources/jmp.properties
@@ -1,19 +1,16 @@
 #chi-specific properties:
-@encodinganalog=ifzlabel
-subject/@ifzlabel=notes
-collection_Titel
-did/unittitle/@ifzlabel$collection_Titel=name
-did/unittitle/@ifzlabel$Title=name
-did/unittitle/@ifzlabel$Titel=name
-did/unittitle/@ifzlabel$Bestandskurzbeschreibung=name
-did/unittitle/@ifzlabel$Bestand=name
-did/unittitle/@ifzlabel$Untertitel=parallelFormsOfName
-did/unitid/@ifzlabel$Signatur=IGNORE
-did/unitid/@ehrilabel$ehri_internal_id=IGNORE
-did/unitid/@ehrilabel$ehri_structure=IGNORE
-did/origination/=creatorAccessPoint
-dao/@href=ref
-@href=href
+@role=jmprole
+controlaccess/geogname/=placeAccessPoint
+controlaccess/geogname/@jmprole=relType
+did/unitid/@jmptype$No_of_the_evidence_ID_NAD=IGNORE
+did/unitid/@jmptype$\u010c\u00edslo_eviden\u010dn\u00edho_listu_NAD=IGNORE
+did/langmaterial/language/=IGNORE
+controlaccess/head/=IGNORE
+otherfindaid/bibref/=findingAids
+repository/corpname/=IGNORE
+#ehri-preprocessing properties:
+@type=jmptype
+did/unitid/@jmptype$JMP_unique_identifier=objectIdentifier
 #maintenanceEvents
 revisiondesc/change/=maintenanceEvent
 revisiondesc/change/date/=date
@@ -21,18 +18,16 @@ revisiondesc/change/item/=source
 profiledesc/=maintenanceEvent
 profiledesc/creation/=source
 profiledesc/creation/date/=date
+profiledesc/langusage/language/=languageUsed
 #ehri processing
 filedesc/titlestmt/author/=author
 eadheader/eadid/=sourceFileId
-#ehri-preprocessing properties:
-@label=ehrilabel
-did/unitid/@ehrilabel$ehri_main_identifier=objectIdentifier
-did/unitid/@ehrilabel$ehri_multiple_identifier=otherIdentifiers
 #generic ead properties:
+#maybe change to did/unittitle/@ehrilabel$ehri_title=name
+did/unittitle/=name
 odd/=notes
 odd/p/=notes
 did/unitdate/=unitDates
-profiledesc/creation/date/=creationDate
 profiledesc/descrules/=rulesAndConventions
 profiledesc/langusage/language/@languagecode=languageCode
 accruals/p/=accruals
@@ -52,6 +47,7 @@ did/physdesc/physfacet/=extentAndMedium
 altformavail/p/=locationOfCopies
 originalsloc/p/=locationOfOriginals
 did/note/p/=notes
+archdesc/note/p/=notes
 relatedmaterial/=relatedUnitsOfDescription
 relatedmaterial/p/=relatedUnitsOfDescription
 langmaterial/language/@languagecode=languageOfMaterial
@@ -80,7 +76,6 @@ controlaccess/subject/=subjectAccessPoint
 controlaccess/persname/=personAccessPoint
 controlaccess/famname/=familyAccessPoint
 controlaccess/corpname/=corporateBodyAccessPoint
-controlaccess/geogname/=placeAccessPoint
 controlaccess/genreform/=genreAccessPoint
 controlaccess/p/subject/=subjectAccessPoint
 controlaccess/p/persname/=personAccessPoint

--- a/ehri-importers/src/main/resources/vc_ara.properties
+++ b/ehri-importers/src/main/resources/vc_ara.properties
@@ -1,19 +1,16 @@
-#chi-specific properties:
-@encodinganalog=ifzlabel
-subject/@ifzlabel=notes
-collection_Titel
-did/unittitle/@ifzlabel$collection_Titel=name
-did/unittitle/@ifzlabel$Title=name
-did/unittitle/@ifzlabel$Titel=name
-did/unittitle/@ifzlabel$Bestandskurzbeschreibung=name
-did/unittitle/@ifzlabel$Bestand=name
-did/unittitle/@ifzlabel$Untertitel=parallelFormsOfName
-did/unitid/@ifzlabel$Signatur=IGNORE
-did/unitid/@ehrilabel$ehri_internal_id=IGNORE
-did/unitid/@ehrilabel$ehri_structure=IGNORE
-did/origination/=creatorAccessPoint
-dao/@href=ref
-@href=href
+#ara vc specific stuff
+profiledesc/langusage/=IGNORE
+repository/=locationOfOriginals
+abstract/=scopeAndContent
+@encodinganalog=vclabel
+unittitle/@vclabel$title=name
+unittitle/@vclabel$authorized_form_of_name=name
+unittitle/@vclabel$parallel_form_of_name=parallelFormsOfName
+#ehri vc stuff
+@label=ehrilabel
+did/unitid/@ehrilabel$ehri_main_identifier=objectIdentifier
+did/repository/@ehrilabel$ehri_repository_vc=vcRepository
+#maintenanceEvents
 #maintenanceEvents
 revisiondesc/change/=maintenanceEvent
 revisiondesc/change/date/=date
@@ -21,16 +18,12 @@ revisiondesc/change/item/=source
 profiledesc/=maintenanceEvent
 profiledesc/creation/=source
 profiledesc/creation/date/=date
-#ehri processing
-filedesc/titlestmt/author/=author
+profiledesc/langusage/language/=languageUsed
+# standard stuff
 eadheader/eadid/=sourceFileId
-#ehri-preprocessing properties:
-@label=ehrilabel
-did/unitid/@ehrilabel$ehri_main_identifier=objectIdentifier
-did/unitid/@ehrilabel$ehri_multiple_identifier=otherIdentifiers
-#generic ead properties:
-odd/=notes
-odd/p/=notes
+titlestmt/author/=author
+origination/corpname/=creators
+origination/persname/=creators
 did/unitdate/=unitDates
 profiledesc/creation/date/=creationDate
 profiledesc/descrules/=rulesAndConventions
@@ -60,7 +53,8 @@ phystech/p/=physicalCharacteristics
 scopecontent/=scopeAndContent
 scopecontent/p/=scopeAndContent
 arrangement/p/=systemOfArrangement
-bibliography/p/=sources
+bibliography/p/=bibliography
+bibliography/@encoding=bibliographyTypes
 archdesc/@levelOfDesc=levelOfDescription
 c01/@levelOfDesc=levelOfDescription
 c02/@levelOfDesc=levelOfDescription
@@ -73,21 +67,8 @@ c08/@levelOfDesc=levelOfDescription
 c09/@levelOfDesc=levelOfDescription
 processinfo/p/=processInfo
 processinfo/=processInfo
-did/origination/persname/=creatorAccessPoint
-did/origination/corpname/=creatorAccessPoint
-did/origination/name/=creatorAccessPoint
 controlaccess/subject/=subjectAccessPoint
-controlaccess/persname/=personAccessPoint
-controlaccess/famname/=familyAccessPoint
-controlaccess/corpname/=corporateBodyAccessPoint
-controlaccess/geogname/=placeAccessPoint
-controlaccess/genreform/=genreAccessPoint
-controlaccess/p/subject/=subjectAccessPoint
-controlaccess/p/persname/=personAccessPoint
-controlaccess/p/famname/=familyAccessPoint
-controlaccess/p/corpname/=corporateBodyAccessPoint
-controlaccess/p/geogname/=placeAccessPoint
-controlaccess/p/genreform/=genreAccessPoint
 #attributes
 @level=levelOfDesc
 @langcode=languagecode
+# TODO: langmaterial

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CsvAuthItemImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CsvAuthItemImporterTest.java
@@ -1,0 +1,64 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package eu.ehri.project.importers;
+
+import eu.ehri.project.models.base.AccessibleEntity;
+import eu.ehri.project.models.cvoc.AuthoritativeSet;
+import java.io.InputStream;
+
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
+ */
+public class CsvAuthItemImporterTest extends AbstractImporterTest{
+    
+    private static final Logger logger = LoggerFactory.getLogger(CsvAuthItemImporterTest.class);
+    protected final String SINGLE_EAD = "wien_victims.csv";
+
+    @Test
+    public void testImportItemsT() throws Exception {
+        AuthoritativeSet authoritativeSet = manager.getFrame("auths", AuthoritativeSet.class);
+        int voccount = toList(authoritativeSet.getAuthoritativeItems()).size();
+        assertEquals(2, voccount);
+        logger.debug("number of items: " + voccount);
+        
+        final String logMessage = "Importing some subjects";
+      
+        int count = getNodeCount(graph);
+        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
+        
+         List<VertexProxy> graphState1 = getGraphState(graph);
+        ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser, CsvAuthoritativeItemImporter.class).importFile(ios, logMessage);
+        printGraph(graph);
+        
+ // After...
+       List<VertexProxy> graphState2 = getGraphState(graph);
+       GraphDiff diff = diffGraph(graphState1, graphState2);
+       diff.printDebug(System.out);
+        System.out.println(Iterables.toList(authoritativeSet.getAuthoritativeItems()));
+        /*
+         * 9 Item
+         * 9 ItemDesc
+         * 10 more import Event links (1 for every Unit, 1 for the User)
+         * 1 more import Event
+         */
+        assertEquals(count+29, getNodeCount(graph));
+        assertEquals(voccount + 9, toList(authoritativeSet.getAuthoritativeItems()).size());
+
+        // Check permission scopes are correct.
+        for (AccessibleEntity subject : log.getAction().getSubjects()) {
+            assertEquals(authoritativeSet, subject.getPermissionScope());
+        }
+        
+    }
+}

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IfzTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IfzTest.java
@@ -30,11 +30,12 @@ public class IfzTest extends AbstractImporterTest{
     
     protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "ifz_ED.xml";
-    protected final String ARCHDESC = "ED",
-            C01 = "ED 457",
-            C02_01 = "ED 457 / 185",
-            C02_02 = "ED 457 / 186";
-    DocumentaryUnit archdesc, c1, c2_1, c2_2;
+    protected final String ARCHDESC = "G",
+            C01 = "G_1",
+            C02 = "G_2",
+            C03_01 = "G 35 / 1",
+            C03_02 = "MB 35 / 10";
+    DocumentaryUnit archdesc, c1, c2, c3_1, c3_2;
     int origCount=0;
             
     @Test
@@ -55,19 +56,18 @@ public class IfzTest extends AbstractImporterTest{
        GraphDiff diff = diffGraph(graphState1, graphState2);
        diff.printDebug(System.out);
         
-//        printGraph(graph);
+        printGraph(graph);
         // How many new nodes will have been created? We should have
         /** 
-         * event links: 5
-         * relationship: 19
-         * documentaryUnit: 4
-         * documentDescription: 4
-         * unknown property: 2
+         * null: 6
+         * relationship: 11
+         * documentaryUnit: 5
+         * documentDescription: 5
+         * maintenanceEvent: 6
          * systemEvent: 1
-         * maintenanceEvent: 1
-         * datePeriod: 2
+         * 1 date
          */
-        int newCount = origCount + 38;
+        int newCount = origCount + 35;
         assertEquals(newCount, getNodeCount(graph));
         
         archdesc = graph.frame(
@@ -76,17 +76,17 @@ public class IfzTest extends AbstractImporterTest{
         c1 = graph.frame(
                 getVertexByIdentifier(graph,C01),
                 DocumentaryUnit.class);
-        c2_1 = graph.frame(
-                getVertexByIdentifier(graph,C02_01),
+        c2 = graph.frame(
+                getVertexByIdentifier(graph,C02),
                 DocumentaryUnit.class);
-        c2_2 = graph.frame(
-                getVertexByIdentifier(graph,C02_02),
+        c3_2 = graph.frame(
+                getVertexByIdentifier(graph,C03_02),
                 DocumentaryUnit.class);
 
         // Test ID generation is correct
-        assertEquals("nl-r1-ed-ed-457", c1.getId());
-        assertEquals(c1.getId() + "-ed-457-185", c2_1.getId());
-        assertEquals(c1.getId() + "-ed-457-186", c2_2.getId());
+        assertEquals("nl-r1-g-g-1", c1.getId());
+        assertEquals(c1.getId() + "-g-2", c2.getId());
+        assertEquals(c2.getId() + "-mb-35-10", c3_2.getId());
 
         /**
          * Test titles
@@ -105,25 +105,11 @@ public class IfzTest extends AbstractImporterTest{
         
         // There should be one DocumentDescription for the (only) <c01>
         for(DocumentDescription dd : c1.getDocumentDescriptions()){
-            assertEquals("Lohmeier, Cornelia", dd.getName());
+            assertEquals("Internationale u. ausländische Gerichtsorte", dd.getName());
             assertEquals("deu", dd.getLanguageOfDescription());
             assertEquals("series", dd.asVertex().getProperty("levelOfDescription"));
         }
 
-        // There should be one DocumentDescription for the (second) <c02>
-        for(DocumentDescription dd : c2_2.getDocumentDescriptions()){
-            assertEquals(C02_02, dd.getName());
-            assertEquals("deu", dd.getLanguageOfDescription());
-            assertEquals("file", dd.asVertex().getProperty("levelOfDescription"));
-            assertEquals("www.ifz-muenchen.de/archiv/ED_0066_0001_0000.pdf", dd.asVertex().getProperty("ref"));
-        }
-    //Band
-        for(DocumentDescription dd : c2_1.getDocumentDescriptions()){
-            assertEquals("Dachau, III", dd.getName());
-            assertEquals("deu", dd.getLanguageOfDescription());
-            assertEquals("file", dd.asVertex().getProperty("levelOfDescription"));
-            assertEquals("Band", dd.asVertex().getProperty("extentAndMedium"));
-        }
 
         /**
          * Test hierarchy
@@ -133,12 +119,12 @@ public class IfzTest extends AbstractImporterTest{
             assertEquals(C01, du.getIdentifier());
         }
 //    //test dates
-        for(DocumentDescription d : c2_1.getDocumentDescriptions()){
-        	// Single date is just a string
+        for(DocumentDescription d : c3_2.getDocumentDescriptions()){
+        	// Single date is just a string 1945/1957
         	assertFalse(d.asVertex().getPropertyKeys().contains("unitDates"));
         	for (DatePeriod dp : d.getDatePeriods()){
-        		assertEquals("1991-01-01", dp.getStartDate());
-        		assertEquals("2008-12-31", dp.getEndDate());
+        		assertEquals("1945-01-01", dp.getStartDate());
+        		assertEquals("1957-12-31", dp.getEndDate());
         	}
         }
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Jmp130Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Jmp130Test.java
@@ -1,0 +1,91 @@
+package eu.ehri.project.importers;
+
+import com.tinkerpop.blueprints.Vertex;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.models.DocumentDescription;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.Repository;
+import eu.ehri.project.models.base.AccessibleEntity;
+import java.io.InputStream;
+import java.util.List;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.junit.Assert.*;
+
+/**
+ * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
+ */
+public class Jmp130Test extends AbstractImporterTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(Jmp130Test.class);
+    protected final String SINGLE_EAD = "JMP-130.xml";
+    // Depends on fixtures
+    protected final String TEST_REPO = "r1";
+    // Depends on hierarchical-ead.xml
+
+    protected final String FONDS = "COLLECTION.JMP.ARCHIVE/130";
+
+    @Test
+    public void testImportItemsT() throws Exception {
+
+        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
+        
+        final String logMessage = "Importing JMP EAD";
+
+        int count = getNodeCount(graph);
+        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
+        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("jmp.properties"));
+        
+        importManager.setTolerant(Boolean.TRUE);
+        
+        List<VertexProxy> graphState1 = getGraphState(graph);
+        ImportLog log = importManager.importFile(ios, logMessage);
+        printGraph(graph);
+        
+ // After...
+       List<VertexProxy> graphState2 = getGraphState(graph);
+       GraphDiff diff = diffGraph(graphState1, graphState2);
+       diff.printDebug(System.out);
+
+        /**
+         * null: 2
+         * relationship: 5
+         * documentaryUnit: 1
+         * documentDescription: 1
+         * maintenanceEvent: 1
+         * systemEvent: 1
+         * datePeriod: 1
+         */
+       
+
+
+        printGraph(graph);
+        int newCount = count + 12 ;
+        assertEquals(newCount, getNodeCount(graph));
+
+        Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY, FONDS);
+        assertTrue(docs.iterator().hasNext());
+        DocumentaryUnit fonds = graph.frame(getVertexByIdentifier(graph, FONDS), DocumentaryUnit.class);
+
+        for(DocumentDescription d : fonds.getDocumentDescriptions()){
+            for(String key : d.asVertex().getPropertyKeys()){
+                System.out.println(key);
+            }
+            System.out.println(d.asVertex().getProperty("languageOfMaterial").toString());
+            assertTrue(d.asVertex().getProperty("languageOfMaterial").toString().startsWith("[ces"));
+        }
+
+        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        for (AccessibleEntity subject : subjects) {
+            logger.info("identifier: " + subject.getId());
+        }
+
+        assertEquals(1, subjects.size());
+        assertEquals(log.getChanged(), subjects.size());
+
+        // Check permission scopes
+        assertEquals(agent, fonds.getPermissionScope());
+    }
+}

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/VC_ARAImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/VC_ARAImporterTest.java
@@ -1,0 +1,56 @@
+package eu.ehri.project.importers;
+
+import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.models.DocumentDescription;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.Repository;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
+ */
+public class VC_ARAImporterTest extends AbstractImporterTest{
+    
+       protected final String SINGLE_EAD = "araEad.xml";
+       protected final String VC_EAD = "araVcEad.xml";
+
+       // Depends on fixtures
+    protected final String TEST_REPO ="r1";
+
+    @Test
+    public void testImportItemsT() throws Exception {
+
+        final String logMessage = "Importing a single EAD";
+
+        int origCount = getNodeCount(graph);
+        System.out.println(origCount);
+        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("ara.properties"))
+                .setTolerant(Boolean.TRUE);
+        
+                 // Before...
+       List<VertexProxy> graphState1 = getGraphState(graph);
+        ImportLog log = importManager.importFile(ios, logMessage);
+        printGraph(graph);
+        
+ // After...
+       List<VertexProxy> graphState2 = getGraphState(graph);
+       GraphDiff diff = diffGraph(graphState1, graphState2);
+       diff.printDebug(System.out);
+
+        
+        printGraph(graph);
+       
+        InputStream ios_vc = ClassLoader.getSystemResourceAsStream(VC_EAD);
+        importManager = new SaxImportManager(graph, repository, validUser, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc_ara.properties"))
+                .setTolerant(Boolean.TRUE);
+
+ImportLog log_vc = importManager.importFile(ios_vc, logMessage);
+        
+    }
+
+}

--- a/ehri-importers/src/test/resources/BA_split.xml
+++ b/ehri-importers/src/test/resources/BA_split.xml
@@ -53,7 +53,8 @@
     </did>
     <descgrp encodinganalog="Bestandsbeschreibung">
       <p>Bestandsgeschichte</p>
-      <p>Im September/ Oktober 1962 gelangte aus den Sammlungen des ehemaligen Berlin Document Center Berlin u. a. ein großer Bestand an Schriftgut des Reichsschatzmeisters der NSDAP in das Bundesarchiv. Weitere Abgaben durch das Berlin Document Center folgten in den Jahren1978, 1980 und 1988.</p>
+      <p>Im September/ Oktober 1962</p>
+      <p>gelangte aus den Sammlungen des ehemaligen Berlin Document Center Berlin u. a. ein großer Bestand an Schriftgut des Reichsschatzmeisters der NSDAP in das Bundesarchiv. Weitere Abgaben durch das Berlin Document Center folgten in den Jahren1978, 1980 und 1988.</p>
     </descgrp>
     <processinfo encodinganalog="Erschließungszustand">
       <p>Online-Findbuch (2011)</p>

--- a/ehri-importers/src/test/resources/JMP-130.xml
+++ b/ehri-importers/src/test/resources/JMP-130.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ead SYSTEM "ead/ead.dtd">
+<?xml-stylesheet type="text/css" href="eadprint.css"?>
+<?xml-stylesheet type="text/xsl" href="eadprint-su.xsl"?>
+<ead>
+  <eadheader countryencoding="UTF-8" langencoding="iso639-2b" dateencoding="iso8601" relatedencoding="MARC21">
+    <eadid countrycode="CZ" identifier="COLLECTION.JMP.ARCHIVE/130_eng">COLLECTION.JMP.ARCHIVE/130_eng</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>Jewish Religious Community of Slaný</titleproper>
+        <author>Archives of the Jewish Museum in Prague</author>
+      </titlestmt>
+      <publicationstmt>
+        <date normal="20150310">10. 03. 2015</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>Export from the collections management system of the Jewish Museum in Prague<date normal="20150310">10. 03. 2015</date></creation>
+      <langusage>
+        <language scriptcode="Latn" langcode="eng">English</language>
+      </langusage>
+    </profiledesc>
+  </eadheader>
+  <archdesc level="fonds">
+    <did>
+      <unittitle>Jewish Religious Community of Slaný</unittitle>
+      <unitid type="JMP_unique_identifier">COLLECTION.JMP.ARCHIVE/130</unitid>
+      <unitid type="No_of_the_evidence_ID_NAD">130</unitid>
+      <unitdate>1828 - 1945</unitdate>
+      <repository>
+        <corpname authfilenumber="PERSON.JMP.7039" source="personlist-JMP">Archiv Židovského muzea v Praze</corpname>
+      </repository>
+      <origination>
+        <corpname authfilenumber="ORGANISATION.JMP.7471" source="organisationlist-JMP">Jewish Religious Community Slaný</corpname>
+      </origination>
+      <langmaterial label="Language(s)">
+        <language langcode="cze">Czech</language>
+        <language langcode="ger">German</language>
+        <language langcode="heb">Hebrew</language>
+      </langmaterial>
+      <physdesc>
+        <extent>7,7 Meter</extent>
+      </physdesc>
+    </did>
+    <scopecontent>
+      <scopecontent>
+        <p>This fonds contains the community's statutes including amendments (1865–1896), files registers, meeting minutes, election records, personnel records, authority notifications, various correspondence, financial and tax files, synagogue seats records, documents relating to the construction of a synagogue, a list of synagogue objects, the 1898 statutes and records of the local burial society, burial lists, and fragmentary files relating to the local Jewish school and several Jewish associations. The fonds also includes a large collection of documents from 1939–1945 relating to the racial persecution of the Jewish population: circulars, decrees and ordinances, registration of the Jewish population, work assignment records, registration and surrendering of Jewish property, travel permits, and files on emigration and deportation. There are also materials relating to the affiliated community of Kralupy nad Vltavou: meeting minutes, correspondence and fragmentary files, including burial society records (burial lists maintained until 1942).</p>
+      </scopecontent>
+    </scopecontent>
+    <controlaccess>
+      <controlaccess>
+        <head>Places</head>
+        <geogname authfilenumber="PLACE.ČSÚ.532819" role="describes">Slaný</geogname>
+        <geogname authfilenumber="PLACE.ČSÚ.532819" role="creation">Slaný</geogname>
+        <geogname authfilenumber="PLACE.ČSÚ.534951" role="describes">Kralupy nad Vltavou</geogname>
+        <geogname authfilenumber="PLACE.ČSÚ.534951" role="creation">Kralupy nad Vltavou</geogname>
+      </controlaccess>
+    </controlaccess>
+    <otherfindaid>
+      <bibref>Dolista K. – Heřman J., Židovská náboženská obec Slaný 1828 - 1945, Prozatímní inventární seznam, 1971, 12 s., ev. č. 130.</bibref>
+    </otherfindaid>
+    <dsc/>
+  </archdesc>
+</ead>

--- a/ehri-importers/src/test/resources/araEad.xml
+++ b/ehri-importers/src/test/resources/araEad.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" audience="external">
+    <eadheader>
+        <eadid countrycode="BE">BE / ADVN / AC559</eadid>
+        <filedesc>
+            <titlestmt>
+                <titleproper/>
+                <author> Gertjan Desmet </author>
+            </titlestmt>
+        </filedesc>
+        <profiledesc>
+            <creation>EHRI created this EAD based on the text file of the book "P. FALEK ALHADEFF &amp; G. DESMET, P.-A. TALLIER (dir.), Mekorot
+                Hayeda. Bronnen voor de geschiedenis van de Joden in België (19de-20ste eeuw) - Sources pour l’histoire des Juifs en Belgique
+                (19-20ème siècles), Brussel, Algemeen Rijksarchief – Archives Générales du Royaume, 2014." <date>2015-02-12 11:29:20</date>
+            </creation>
+            <langusage>
+                <language langcode="dut" scriptcode="Latn">Dutch</language>
+            </langusage>
+        </profiledesc>
+    </eadheader>
+    <frontmatter/>
+    <archdesc level="fonds">
+        <did>
+            <unitid label="ehri_main_identifier">BE / ADVN / AC559</unitid>
+            <unitid label="institution_identifier">AC559</unitid>
+            <unittitle>Archief Vrij Historisch Onderzoek.</unittitle>
+            <unitdate>ca. jaren 1980-1990</unitdate>
+            <physdesc>
+                <extent>1,5 s.m.</extent>
+            </physdesc>
+            <origination> Vrij Historisch Onderzoek </origination>
+            <repository label="ehri_repository_vc" altrender="ADVN">be-002093</repository>
+        </did>
+        <scopecontent>
+            <p> Dit bestand zou voornamelijk stukken bevatten die typisch zijn voor verenigingsarchief. In het bijzonder zou het vooral gaan om
+                stukken inzake de redactie van de verschillende publicaties van VHO, en om correspondentie met betrekking tot de gerechtelijke
+                vervolgingen van VHO-verantwoordelijken. </p>
+        </scopecontent>
+        <controlaccess>
+            <subject authfilenumber="?tema=329" source="ehri-skos">antisemitisme</subject>
+            <subject>extreemrechts</subject>
+            <subject authfilenumber="?tema=1223" source="ehri-skos">negationisme</subject>
+        </controlaccess>
+        <otherfindaid>
+            <p> Geen. </p>
+        </otherfindaid>
+        <processinfo>
+            <p>EHRI has made a selection of relevant fonds based on subject and content, excluding non-holocaust relevant material.</p>
+        </processinfo>
+        <dsc/>
+    </archdesc>
+</ead>

--- a/ehri-importers/src/test/resources/araVcEad.xml
+++ b/ehri-importers/src/test/resources/araVcEad.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd" audience="external">
+    <eadheader>
+        <eadid countrycode="BE">ARA#BE</eadid>
+        <filedesc>
+            <titlestmt>
+                <titleproper/>
+                <author>ARA</author>
+            </titlestmt>
+        </filedesc>
+        <profiledesc>
+            <creation>EHRI created this EAD based on the text file of the Jewish archival sources Belgium guide "Bronnen voor de geschiedenis van de Joden in België (19de-20ste eeuw) - Sources pour l’histoire des Juifs en Belgique (19-20ème siècles)"
+                    <date>2015-02-18T00:26:03.01+02:00</date></creation>
+            <langusage>Multilingual finding aid written in <language langcode="dut" scriptcode="Latn">Dutch</language></langusage>
+        </profiledesc>
+    </eadheader>
+    <frontmatter/>
+    <archdesc level="recordgrp">
+        <did>
+            <unitid label="ehri_main_identifier">ARA</unitid>
+            <unittitle encodinganalog="title">ARA</unittitle>
+        </did>
+        <dsc>
+            <c01 level="recordgrp">
+                <did>
+                    <unitid label="ehri_main_identifier">B.</unitid>
+                    <unittitle encodinganalog="title">Privaatrechtelijke archiefvormers - Producteurs d’archives privées</unittitle>
+                </did>
+                <c02 level="recordgrp">
+                    <did>
+                        <unitid label="ehri_main_identifier">B.1</unitid>
+                        <unittitle encodinganalog="title">Particuliere organisaties met een ideologisch en politiek doel - Organisations particulières
+                            à but idéologique et politique</unittitle>
+                    </did>
+                    <c03 level="recordgrp">
+                        <did>
+                            <unitid label="ehri_main_identifier">Vrij Historisch Onderzoek</unitid>
+                            <unittitle encodinganalog="authorized_form_of_name"> Vrij Historisch Onderzoek </unittitle>
+                            <unittitle encodinganalog="parallel_form_of_name"/>
+                        </did>
+                        <bioghist encodinganalog="history">
+                            <p> Vrij Historisch Onderzoek (VHO) werd in 1985 opgericht door Siegfried Verbeke. De organisatie pretendeert
+                                wetenschappelijk onderzoek te doen naar de Shoah en fungeert als een van de grootste uitgeverijen van zgn.
+                                ‘revisionistische’ literatuur. In werkelijkheid wordt in de pseudowetenschappelijke uitgaven van het VHO de Holocaust
+                                geminimaliseerd of ontkend. In België werden de verantwoordelijken van VHO in 2004 en 2008 tot zware straffen
+                                veroordeeld wegens inbreuken op de negationismewet en de antiracismewet. Ook in Nederland en Duitsland werd Siegfried
+                                Verbeke vervolgd en veroordeeld voor gelijkaardige feiten. </p>
+                        </bioghist>
+                        <bibliography>
+                            <bibref/>
+                        </bibliography>
+                        <c04 level="fonds">
+                            <did>
+                                <unitid label="ehri_main_identifier">BE / ADVN / AC559</unitid>
+                                <repository label="ehri_repository_vc" altrender="ADVN">r1</repository>
+                            </did>
+                        </c04>
+                    </c03>
+                </c02>
+            </c01>
+        </dsc>
+    </archdesc>
+</ead>

--- a/ehri-importers/src/test/resources/ifz_ED.xml
+++ b/ehri-importers/src/test/resources/ifz_ED.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" audience="external">
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink"
+    audience="external" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
     <eadheader>
-        <eadid countrycode="DE">ED 457</eadid>
+        <eadid countrycode="DE">G</eadid>
         <filedesc>
             <titlestmt>
                 <titleproper/>
@@ -9,20 +10,50 @@
             </titlestmt>
         </filedesc>
         <profiledesc>
-            <creation>
-                <date>2014-08-19 17:50:23</date>
-                EHRI created this EAD based on the Faust-output and selection from the IfZ Muenchen.
-            </creation>
+            <creation>EHRI created this EAD based on the Faust-output and selection from the IfZ München
+                <date>2015-03-04T09:17:24.331+02:00</date></creation>
             <langusage>
-                <language langcode="ger" scriptcode="Latn">German</language>
+                <language scriptcode="Latn" langcode="ger">German</language>
             </langusage>
         </profiledesc>
+        <revisiondesc>
+            <change>
+                <date>2015-03-04 19:03:22</date>
+                <item>EHRI has choosen the ehri_internal_id to be the unitid with label ehri_main_identifier if none were given. If multiple
+                    ehri_main_identifier were given, their label was renamed to ehri_multiple_identifier</item>
+            </change>
+            <change>
+                <date>2015/03/04 19:03:17</date>
+                <item>EHRI added a unitid with label "ehri_internal_identifier" to give every node a unique id.</item>
+            </change>
+            <change>
+                <date>2015-03-04 19:03:11</date>
+                <item>EHRI added a unitid with label "ehri_structure" to indicate the structure of the EAD file on every c-node. This is done to make
+                    comparisons of two versions of the same EAD (as indicated by the eadid) possible.</item>
+            </change>
+
+            <change>
+                <date>2015-03-04 19:03:07</date>
+                <item>EHRI added a unitid with label "ehri_main_identifier" to indicate the identifier provided by the institution that EHRI will use
+                    as the identifier of the unit.</item>
+            </change>
+            <change>
+                <date>the date</date>
+                <item>preprocessing transformation</item>
+                <item>another transformation</item>
+            </change>
+        </revisiondesc>
     </eadheader>
     <frontmatter/>
     <archdesc level="recordgrp">
         <did>
-            <unitid>ED</unitid>
-            <unittitle>TO BE FILLED</unittitle>
+            <unitid label="ehri_internal_id">0</unitid>
+            <unitid label="ehri_structure">0</unitid>
+            <unittitle encodinganalog="collection_Titel">TO BE FILLED</unittitle>
+
+
+
+            <unitid label="ehri_main_identifier">G</unitid>
         </did>
         <scopecontent>
             <p>TO BE FILLED</p>
@@ -33,139 +64,80 @@
         <dsc>
             <c01 level="series">
                 <did>
-                    <unitid encodinganalog="Signatur from the gesamt.xml"
-                                                                    identifier="the internal db nr from the bestandsang.xml">ED 457
-                    </unitid>
-                    <unittitle encodinganalog="Bestand from the gesamt.xml">Lohmeier, Cornelia</unittitle>
+                    <unitid label="ehri_internal_id">1</unitid>
+                    <unitid label="ehri_structure">0.0</unitid>
+                    <unittitle encodinganalog="collection_Titel">Internationale u. ausländische Gerichtsorte</unittitle>
+
+                    <unitid label="ehri_main_identifier">G_1</unitid>
                 </did>
-                <bioghist encodinganalog="Vita">
-                    <p/>
+                                <bioghist encodinganalog="Vita">
+                    <p>Dietrich Eckart1868-1923Dramatiker, Chefredakteur des Völkischen Beobachters ab 1920 Vgl. die Biographie Eckarts auf der Seite
+                        des Deutschen Historischen Museums:</p>
                 </bioghist>
                 <scopecontent encodinganalog="Zum_Bestand">
-                    <p/>
+                    <p>Durch einen Zufallsfund in einer anderen Abgabe liegt dem Archiv des Instituts für Zeitgeschichte eine handschriftliche Version
+                        des Gedichts "Sturm, Sturm, Sturm ... Deutschland erwache" von D. Eckart vor, daneben ein Flugblatt Eckarts, welches er noch
+                        als Herausgeber der (antisemitischen) Wochenschrift "Auf gut deutsch" verfasste. Weitere Autographen Eckarts finden sich im
+                        Portal Kalliope (http://kalliope.staatsbibliothek-berlin.de/), in der Zentralennachlassdatenbank des Bundesarchivs wird ebd.
+                        auf einen Nachlass Eckarts verwiesen.</p>
                 </scopecontent>
                 <userestrict encodinganalog="Bestandsnutzung">
-                    <p/>
+                    <p>Benutzung gemäß aktuell gültiger Benutzungsordnung des Archivs des Instituts für Zeitgeschichte.</p>
                 </userestrict>
-                <c02 level="file">
+
+                <c02 level="series">
                     <did>
-                        <unitid encodinganalog="Bandnummer" identifier="the internal db nr">ED 457 / 185</unitid>
-                        <unittitle encodinganalog="Titel">Dachau, III</unittitle>
-                        <unitdate encodinganalog="Laufzeit">1991/2008</unitdate>
-                        <physdesc encodinganalog="Art">Band</physdesc>
-                        <origination encodinganalog="Autor"/>
+                        <unitid label="ehri_internal_id">2</unitid>
+                        <unitid label="ehri_structure">0.0.0</unitid>
+                        <unittitle encodinganalog="collection_Titel">US-Militärgericht Dachau</unittitle>
+
+                        <unitid label="ehri_main_identifier">G_2</unitid>
                     </did>
-                    <bioghist encodinganalog="Bestandskurzbeschreibung">
-                        <p>Cornelia Lohmeier // Diplompsychologin // Korrespondenz, Protokolle,
-                            programmatische Schriften Deutsche Jungdemokraten Bayern und Bund, FDP
-                            Bayern und Bund, Sammlung 7. Jugendbericht der Bundesregierung,
-                            Internationale Jugendbegegnungsstätte Dachau, Materialsammlung
-                            Gleichstellungspolitik und Stadtplanung München, Rechtsextremismus und
-                            Antifaschismus, Bürgerrechte, Bayerisches Polizeiaufgabengesetz, 1969-2008.
-                            - Originale, 209 Bände.
-                        </p>
-                    </bioghist>
-                    <scopecontent encodinganalog="Enthält">
-                        <p>Protokolle, Konzepte und Broschüren, 1991-2008, von und über die Arbeit des
-                            Förderverein Internationale Jugendbegegnungsstätte Dachau.
-                        </p>
-                    </scopecontent>
-                    <scopecontent encodinganalog="Darin_auch">
-                        <p/>
-                    </scopecontent>
-                    <controlaccess>
-                        <head>Thesaurus</head>
-                        <subject encodinganalog="Thesaurus">5(reg.; Orte in der BRD,
-                            alphabet.)
-                        </subject>
-                        <subject encodinganalog="Thesaurus">politische Bildung</subject>
-                        <subject encodinganalog="Thesaurus">Pädagogik [u. Didaktik]</subject>
-                        <subject encodinganalog="Thesaurus">Konzentrationslager/Folgeprobleme
-                            [KZs/Folge]
-                        </subject>
-                        <subject encodinganalog="Thesaurus">Kultur[arbeit]</subject>
-                    </controlaccess>
-                    <controlaccess>
-                        <head>Sachregister</head>
-                        <subject encodinganalog="Sachregister">Förderverein für Internationale
-                            Jugendbegegnung und Gedenkstättenarbeit in Dachau e.V.
-                        </subject>
-                        <subject encodinganalog="Sachregister"> Internationale Jugendbegegnungsstätte
-                            Dachau
-                        </subject>
-                        <subject encodinganalog="Sachregister"> 
-                        </subject>
-                    </controlaccess>
-                    <controlaccess>
-                        <head>Personen</head>
-                        <persname encodinganalog="Personenregister">Lohmeier, Cornelia</persname>
-                    </controlaccess>
-                    <controlaccess>
-                        <head>Beruf</head>
-                        <subject encodinganalog="Beruf"/>
-                    </controlaccess>
-                </c02>
-                <c02 level="file">
-                    <did>
-                        <unitid encodinganalog="Bandnummer" identifier="the internal db nr">ED 457 / 186</unitid>
-                        <unittitle encodinganalog="Titel" />
-                        <unitdate encodinganalog="Laufzeit">1987/2004</unitdate>
-                        <physdesc encodinganalog="Art">Band</physdesc>
-                                                                        
-                    </did>
-                    <bioghist encodinganalog="Bestandskurzbeschreibung">
-                        <p>Cornelia Lohmeier // Diplompsychologin // Korrespondenz, Protokolle,
-                            programmatische Schriften Deutsche Jungdemokraten Bayern und Bund, FDP
-                            Bayern und Bund, Sammlung 7. Jugendbericht der Bundesregierung,
-                            Internationale Jugendbegegnungsstätte Dachau, Materialsammlung
-                            Gleichstellungspolitik und Stadtplanung München, Rechtsextremismus und
-                            Antifaschismus, Bürgerrechte, Bayerisches Polizeiaufgabengesetz, 1969-2008.
-                            - Originale, 209 Bände.
-                        </p>
-                    </bioghist>
-                    <scopecontent encodinganalog="Enthält">
-                        <p>Presse Förderverein Internationale Jugendbegegnungsstätte Dachau und
-                            Informationsmaterial andere Konzentrationslager-Gedenkstätten,
-                            1987-2004.
-                        </p>
-                    </scopecontent>
-                    <scopecontent encodinganalog="Darin_auch">
-                        <p/>
-                    </scopecontent>
-                    <controlaccess>
-                        <head>Thesaurus</head>
-                        <subject encodinganalog="Thesaurus">5(reg.; Orte in der BRD,
-                            alphabet.)
-                        </subject>
-                        <subject encodinganalog="Thesaurus">politische Bildung</subject>
-                        <subject encodinganalog="Thesaurus">Pädagogik [u. Didaktik]</subject>
-                        <subject encodinganalog="Thesaurus">Konzentrationslager/Folgeprobleme
-                            [KZs/Folge]
-                        </subject>
-                        <subject encodinganalog="Thesaurus">Kultur[arbeit]</subject>
-                    </controlaccess>
-                    <controlaccess>
-                        <head>Sachregister</head>
-                        <subject encodinganalog="Sachregister">Förderverein für Internationale
-                            Jugendbegegnung und Gedenkstättenarbeit in Dachau e.V.
-                        </subject>
-                        <subject encodinganalog="Sachregister"> Internationale Jugendbegegnungsstätte
-                            Dachau
-                        </subject>
-                        <subject encodinganalog="Sachregister"> Internationale Jugendbegegnungsstätte
-                            Auschwitz
-                        </subject>
-                        <subject encodinganalog="Sachregister"> KZ-Gedenkstätte
-                            Bergen-Belsen
-                        </subject>
-                        <subject encodinganalog="Sachregister"> Arbeitsgemeinschaft Bergen-Belsen
-                            e.V.
-                        </subject>
-                        <subject encodinganalog="Sachregister"> Gesellschaft für Politische
-                            Aufklärung, Sekretariat Innsbruck
-                        </subject>
-                    </controlaccess>
-                    <dao xlink:type="simple" xlink:href="www.ifz-muenchen.de/archiv/ED_0066_0001_0000.pdf"/>
+                    <c03 level="file">
+                        <did>
+                            <unitid label="ehri_internal_id">3</unitid>
+                            <unitid label="ehri_structure">0.0.0.0</unitid>
+                            <unitid encodinganalog="Signatur" identifier="82026">G 35 / 1</unitid>
+                            <unitdate encodinganalog="Datierungsangaben">Tatzeit: Dezember 1944</unitdate>
+                        <unittitle encodinganalog="Titel">Bilanz des SS-Konzern</unittitle>
+                        <unittitle encodinganalog="Untertitel">Ein dokumentarischer Tatsachenbericht</unittitle>
+
+
+
+                            <unitid label="ehri_main_identifier">G 35 / 1</unitid>
+                        </did>
+                        <controlaccess>
+                            <subject encodinganalog="Thesaurus">2(Belgien u. Nordfrankreich)</subject>
+                            <subject encodinganalog="Thesaurus">2(Albanien [ab 8.9.1943])</subject>
+                            <subject encodinganalog="Thesaurus">1. Leibstandarte Adolf Hitler [LSSAH]</subject>
+                            <subject encodinganalog="Thesaurus">USA</subject>
+                            <subject encodinganalog="Thesaurus">9(Ardennenoffensive, 16.12.1944-5.1.1945)</subject>
+                            <subject encodinganalog="Thesaurus">Anklage</subject>
+                            <subject encodinganalog="Thesaurus">Verfahren</subject>
+                            <subject encodinganalog="Thesaurus">Schwäbisch Hall</subject>
+                            <subject encodinganalog="Thesaurus">Zeugen</subject>
+                            <subject encodinganalog="Thesaurus">Malmedy</subject>
+                        </controlaccess>
+                        <odd>
+                            <p altrender="ZustSTA">Zuständige Staatsanwaltschaft: General Military Government Co</p>
+                        </odd>
+                    </c03>
+                    <c03 level="file">
+                        <did>
+                            <unitid label="ehri_internal_id">4</unitid>
+                            <unitid label="ehri_structure">0.0.0.1</unitid>
+                            <unitid encodinganalog="Signatur" identifier="64130">MB 35 / 10</unitid>
+                            <unittitle encodinganalog="Titel">Dachauer Flossenbürg-Hauptprozess</unittitle>
+<unitdate encodinganalog="Laufzeit">1945/1957</unitdate>
+
+
+                            <unitid label="ehri_main_identifier">MB 35 / 10</unitid>
+                        </did>
+                        <controlaccess>
+                            <subject encodinganalog="Thesaurus">Dachau</subject>
+                        </controlaccess>
+
+                    </c03>                
                 </c02>
             </c01>
         </dsc>

--- a/ehri-importers/src/test/resources/logback-test.xml
+++ b/ehri-importers/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <logger name="eu.ehri.project.importers" level="${ehri.test.log.level:-info}" />
+  <logger name="eu.ehri.project.importers" level="${ehri.test.log.level:-debug}" />
   <logger name="eu.ehri" level="${ehri.log.level:-info}" />
 
   <root level="DEBUG">

--- a/ehri-importers/src/test/resources/logback-test.xml
+++ b/ehri-importers/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <logger name="eu.ehri.project.importers" level="${ehri.test.log.level:-debug}" />
+  <logger name="eu.ehri.project.importers" level="${ehri.test.log.level:-info}" />
   <logger name="eu.ehri" level="${ehri.log.level:-info}" />
 
   <root level="DEBUG">

--- a/ehri-importers/src/test/resources/wien_victims.csv
+++ b/ehri-importers/src/test/resources/wien_victims.csv
@@ -1,0 +1,10 @@
+id;name
+PERSON.ITI.1001378;Stricker, Robert (* 16.8.1879)
+PERSON.ITI.1144092;Prochnik, Robert (* 15.11.1915)
+PERSON.ITI.1145704;Murmelstein, Benjamin (* 9.6.1905)
+PERSON.ITI.1274651;Brunner, Alois (* 26.10.1867)
+PERSON.ITI.342720;Eppstein, Paul (* 4.3.1902)
+PERSON.ITI.708280;Baeck, Leo (* 23.5.1873)
+PERSON.ITI.848732;Boschan, Julius (* 13.2.1896)
+PERSON.ITI.864878;Fasal, Erich Ferdinand (* 10.11.1909)
+PERSON.ITI.874290;Friedmann, Desider (* 24.11.1880)


### PR DESCRIPTION
this will help to prevent the creation of HistoricalAgents in a CVoc