### PR TITLE
Improvements to frame serialization config to fix #114.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,27 +60,27 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-cmdline</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -90,7 +90,7 @@
                 <dependency>
                     <groupId>ehri-project</groupId>
                     <artifactId>ehri-extension-sparql</artifactId>
-                    <version>0.9-SNAPSHOT</version>
+                    <version>0.9.1-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/ehri-cmdline/pom.xml
+++ b/ehri-cmdline/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cmdline</artifactId>
     <name>Command Line Tools</name>
     <description>Command line tools for interacting with the backend graph DB.</description>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
 
         <!-- RDF export -->

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-extension-sparql/pom.xml
+++ b/ehri-extension-sparql/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ehri-extension-sparql</artifactId>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
 
     <name>Web Service SparQL Extension</name>
     <description>SparQL endpoint for web service.</description>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -109,14 +109,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/ehri-extension/pom.xml
+++ b/ehri-extension/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>
     <description>Web service layer exposed via a Neo4j extension.</description>
 
     <artifactId>ehri-extension</artifactId>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
 
     <!-- TODO add license info and more -->
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-frames</artifactId>
     <packaging>jar</packaging>
 
 
-    <version>0.9-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
 
     <name>EHRI Core API</name>
     <description>Java API for data access and permissions.</description>
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>

--- a/ehri-frames/src/main/java/eu/ehri/project/models/Annotation.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/Annotation.java
@@ -34,7 +34,7 @@ public interface Annotation extends AnnotatableEntity, AccessibleEntity, Promota
      *
      * @return an annotator frame
      */
-    @Fetch(value = Ontology.ANNOTATOR_HAS_ANNOTATION, depth = 1)
+    @Fetch(value = Ontology.ANNOTATOR_HAS_ANNOTATION, numLevels = 0)
     @Adjacency(label = Ontology.ANNOTATOR_HAS_ANNOTATION, direction = Direction.IN)
     public Annotator getAnnotator();
 
@@ -42,7 +42,6 @@ public interface Annotation extends AnnotatableEntity, AccessibleEntity, Promota
      * Set the annotator of this annotation.
      *
      * @param annotator an annotator frame
-     * @return
      */
     @Adjacency(label = Ontology.ANNOTATOR_HAS_ANNOTATION, direction = Direction.IN)
     public void setAnnotator(final Annotator annotator);
@@ -53,7 +52,7 @@ public interface Annotation extends AnnotatableEntity, AccessibleEntity, Promota
      *
      * @return an iterable of annotatable items
      */
-    @Fetch(Ontology.ANNOTATES_PART)
+    @Fetch(value = Ontology.ANNOTATES_PART, numLevels = 1)
     @Adjacency(label = Ontology.ANNOTATION_ANNOTATES_PART)
     public Iterable<AnnotatableEntity> getTargetParts();
 
@@ -62,7 +61,7 @@ public interface Annotation extends AnnotatableEntity, AccessibleEntity, Promota
      *
      * @return an iterable of annotatable items
      */
-    @Fetch(Ontology.ANNOTATES)
+    @Fetch(value = Ontology.ANNOTATES, numLevels = 1)
     @Adjacency(label = Ontology.ANNOTATION_ANNOTATES)
     public Iterable<AnnotatableEntity> getTargets();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/Link.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/Link.java
@@ -22,14 +22,14 @@ import eu.ehri.project.models.base.TemporalEntity;
 @EntityType(EntityClass.LINK)
 public interface Link extends AccessibleEntity, AnnotatableEntity, Promotable, TemporalEntity {
 
-    @Fetch(Ontology.LINK_HAS_LINKER)
+    @Fetch(value = Ontology.LINK_HAS_LINKER, numLevels = 0)
     @Adjacency(label = Ontology.LINK_HAS_LINKER)
     public UserProfile getLinker();
 
     @Adjacency(label = Ontology.LINK_HAS_LINKER)
     public void setLinker(final Accessor accessor);
 
-    @Fetch(ifDepth = 0, value = Ontology.LINK_HAS_TARGET)
+    @Fetch(value = Ontology.LINK_HAS_TARGET, ifLevel = 0, numLevels = 1)
     @Adjacency(label = Ontology.LINK_HAS_TARGET)
     public Iterable<LinkableEntity> getLinkTargets();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/PermissionGrant.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/PermissionGrant.java
@@ -18,15 +18,15 @@ import eu.ehri.project.models.base.PermissionScope;
 @EntityType(EntityClass.PERMISSION_GRANT)
 public interface PermissionGrant extends Frame {
 
-    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_SUBJECT, depth=1)
+    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_SUBJECT, ifBelowLevel = 1, numLevels = 1)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_SUBJECT)
     public Accessor getSubject();
 
-    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_GRANTEE, depth=1)
+    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_GRANTEE, ifBelowLevel = 1, numLevels = 1)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_GRANTEE)
     public Accessor getGrantee();
     
-    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_TARGET, depth=1)
+    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_TARGET, ifBelowLevel = 1, numLevels = 1)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_TARGET)
     public Iterable<PermissionGrantTarget> getTargets();
 
@@ -40,7 +40,7 @@ public interface PermissionGrant extends Frame {
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_PERMISSION)
     public void setPermission(final Permission permission);
 
-    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_SCOPE, depth=1)
+    @Fetch(value = Ontology.PERMISSION_GRANT_HAS_SCOPE, ifBelowLevel = 1, numLevels = 0)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_SCOPE)
     public PermissionScope getScope();
     

--- a/ehri-frames/src/main/java/eu/ehri/project/models/VirtualUnit.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/VirtualUnit.java
@@ -130,7 +130,7 @@ public interface VirtualUnit extends AbstractUnit {
      *
      * @return a user or group frame
      */
-    @Fetch(Ontology.VC_HAS_AUTHOR)
+    @Fetch(value = Ontology.VC_HAS_AUTHOR, numLevels = 0)
     @Adjacency(label = Ontology.VC_HAS_AUTHOR, direction = Direction.OUT)
     public Accessor getAuthor();
 
@@ -139,7 +139,6 @@ public interface VirtualUnit extends AbstractUnit {
      *
      * @param accessor a user or group frame
      */
-    @Fetch(Ontology.VC_HAS_AUTHOR)
     @JavaHandler
     public void setAuthor(final Accessor accessor);
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/annotations/Fetch.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/annotations/Fetch.java
@@ -6,36 +6,57 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 
- * <pre>
- *   public class MyEntity {
- *      &064;Fetch
- *      &064;Adjacency(label="hasDate")
- *      public Iterator<DatePeriod> getDates();
- *   }
- * </pre>
- * 
  * Marks the entity pointed to by the framed Adjacency as one that should
  * typically be fetched and displayed along with the master object.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Fetch {
-    public static final int DEFAULT_TRAVERSALS = 5;
+    public static final int DEFAULT_TRAVERSALS = 10;
 
     /**
-     * Default number of traversals to make on @Fetch'ed relations.
-     * 
-     * @return
+     * Only serialize this relationship if the depth of traversal
+     * is below this value. The default value is {@value #DEFAULT_TRAVERSALS}.
+     *
+     * @return the level below which this relationship should be traversed
      */
-    int depth() default DEFAULT_TRAVERSALS;
+    int ifBelowLevel() default DEFAULT_TRAVERSALS;
 
-    int ifDepth() default -1;
+    /**
+     * Only traverse this relationship at the specified level. Ignored
+     * if the level is < 0.
+     *
+     * @return the level at which this relation should be traversed
+     */
+    int ifLevel() default -1;
 
+    /**
+     * The number of levels this relationship should traverse
+     * from the current item. i.e. if this item is at level N
+     * the serialization of it's relations should stop at level
+     * N + {@code Fetch.numLevels()}.
+     */
+    int numLevels() default -1;
+
+    /**
+     * Only serialize this relation when not serializing in
+     * 'lite' mode.
+     * @return to serialize or not
+     */
     boolean whenNotLite() default false;
 
+    /**
+     * Always serialize in full mode, regardless of whether
+     * lite serialization is enabled.
+     *
+     * @return override lite mode serialization
+     */
     boolean full() default false;
 
+    /**
+     * The name of the relation when serialized.
+     *
+     * @return the relation name
+     */
     String value();
-
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/AccessibleEntity.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/AccessibleEntity.java
@@ -17,7 +17,7 @@ import static eu.ehri.project.models.utils.JavaHandlerUtils.hasEdge;
 
 public interface AccessibleEntity extends PermissionGrantTarget, VersionedEntity, AnnotatableEntity {
 
-    @Fetch(value = Ontology.IS_ACCESSIBLE_TO, depth = 1)
+    @Fetch(value = Ontology.IS_ACCESSIBLE_TO, ifBelowLevel = 1)
     @Adjacency(label = Ontology.IS_ACCESSIBLE_TO)
     public Iterable<Accessor> getAccessors();
 
@@ -49,7 +49,7 @@ public interface AccessibleEntity extends PermissionGrantTarget, VersionedEntity
     @JavaHandler
     public Iterable<SystemEvent> getHistory();
 
-    @Fetch(value = Ontology.ENTITY_HAS_LIFECYCLE_EVENT, ifDepth = 0)
+    @Fetch(value = Ontology.ENTITY_HAS_LIFECYCLE_EVENT, ifLevel = 0)
     @JavaHandler
     public SystemEvent getLatestEvent();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/Description.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/Description.java
@@ -36,7 +36,7 @@ public interface Description extends NamedEntity, AccessibleEntity {
      * method if @Fetch serialized only if the description
      * is at the top level of the requested subtree.
      */
-    @Fetch(value = Ontology.DESCRIPTION_FOR_ENTITY, ifDepth=0)
+    @Fetch(value = Ontology.DESCRIPTION_FOR_ENTITY, ifLevel =0)
     @Adjacency(label = Ontology.DESCRIPTION_FOR_ENTITY)
     public DescribedEntity getDescribedEntity();    
 
@@ -63,7 +63,7 @@ public interface Description extends NamedEntity, AccessibleEntity {
     public void addUndeterminedRelationship(final UndeterminedRelationship relationship);
 
     @Dependent
-    @Fetch(value = Ontology.HAS_UNKNOWN_PROPERTY, ifDepth = 1, whenNotLite = true)
+    @Fetch(value = Ontology.HAS_UNKNOWN_PROPERTY, ifLevel = 1, whenNotLite = true)
     @Adjacency(label = Ontology.HAS_UNKNOWN_PROPERTY)
     public Iterable<UnknownProperty> getUnknownProperties();
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/Promotable.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/Promotable.java
@@ -18,11 +18,11 @@ import static eu.ehri.project.models.utils.JavaHandlerUtils.*;
 public interface Promotable extends AccessibleEntity {
     public static final String PROMOTION_SCORE = "_promotionScore";
 
-    @Fetch(Ontology.PROMOTED_BY)
+    @Fetch(value = Ontology.PROMOTED_BY, numLevels = 1)
     @Adjacency(label = Ontology.PROMOTED_BY, direction = Direction.OUT)
     public Iterable<UserProfile> getPromoters();
 
-    @Fetch(Ontology.DEMOTED_BY)
+    @Fetch(value = Ontology.DEMOTED_BY, numLevels = 1)
     @Adjacency(label = Ontology.DEMOTED_BY, direction = Direction.OUT)
     public Iterable<UserProfile> getDemoters();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/events/SystemEvent.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/events/SystemEvent.java
@@ -60,7 +60,7 @@ public interface SystemEvent extends AccessibleEntity {
      *
      * @return A user profile instance
      */
-    @Fetch(Ontology.EVENT_HAS_ACTIONER)
+    @Fetch(value = Ontology.EVENT_HAS_ACTIONER, numLevels = 1)
     @JavaHandler
     public Actioner getActioner();
 
@@ -78,7 +78,7 @@ public interface SystemEvent extends AccessibleEntity {
      *
      * @return an iterable of version nodes
      */
-    @Fetch(value = Ontology.VERSION_HAS_EVENT, ifDepth = 0)
+    @Fetch(value = Ontology.VERSION_HAS_EVENT, ifLevel = 0)
     @Adjacency(label = Ontology.VERSION_HAS_EVENT, direction = Direction.IN)
     public Iterable<Version> getPriorVersions();
 
@@ -88,7 +88,7 @@ public interface SystemEvent extends AccessibleEntity {
      *
      * @return an item frame
      */
-    @Fetch(value = Ontology.EVENT_HAS_FIRST_SUBJECT, ifDepth = 0)
+    @Fetch(value = Ontology.EVENT_HAS_FIRST_SUBJECT, ifLevel = 0)
     @JavaHandler
     public AccessibleEntity getFirstSubject();
 
@@ -98,7 +98,7 @@ public interface SystemEvent extends AccessibleEntity {
      *
      * @return the event scope
      */
-    @Fetch(value = Ontology.EVENT_HAS_SCOPE, ifDepth = 0)
+    @Fetch(value = Ontology.EVENT_HAS_SCOPE, ifLevel = 0)
     @Adjacency(label = Ontology.EVENT_HAS_SCOPE, direction = Direction.OUT)
     public Frame getEventScope();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/events/Version.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/events/Version.java
@@ -58,7 +58,7 @@ public interface Version extends AccessibleEntity {
      *
      * @return a system event instance
      */
-    @Fetch(value = Ontology.VERSION_HAS_EVENT, ifDepth = 0)
+    @Fetch(value = Ontology.VERSION_HAS_EVENT, ifLevel = 0)
     @Adjacency(label = Ontology.VERSION_HAS_EVENT, direction = Direction.OUT)
     public SystemEvent getTriggeringEvent();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -498,7 +498,7 @@ public final class Bundle {
      *
      * @return A list of property keys for the bundle's type
      */
-    public Iterable<String> getPropertyKeys() {
+    public Collection<String> getPropertyKeys() {
         return ClassUtils.getPropertyKeys(type.getEntityClass());
     }
 
@@ -507,7 +507,7 @@ public final class Bundle {
      *
      * @return A list of unique property keys for the bundle's type
      */
-    public Iterable<String> getUniquePropertyKeys() {
+    public Collection<String> getUniquePropertyKeys() {
         return ClassUtils.getUniquePropertyKeys(type.getEntityClass());
     }
 
@@ -596,6 +596,20 @@ public final class Bundle {
      */
     public boolean hasGeneratedId() {
         return temp;
+    }
+
+    /**
+     * The depth of this bundle tree, i.e. the number
+     * of levels of relationships beneath this one.
+     *
+     * @return the number of levels
+     */
+    public int depth() {
+        int depth = 0;
+        for (Bundle rel : relations.values()) {
+            depth = Math.max(depth, 1 + rel.depth());
+        }
+        return depth;
     }
 
     /**

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/Serializer.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/Serializer.java
@@ -417,7 +417,7 @@ public final class Serializer {
         int newMax = max == -1
                 ? currentMaxDepth
                 : Math.min(currentDepth + max, currentMaxDepth);
-        logger.info("Current depth {}, fetch levels: {}, current max: {}, new max: {}, {}", currentDepth, max,
+        logger.trace("Current depth {}, fetch levels: {}, current max: {}, new max: {}, {}", currentDepth, max,
                 currentMaxDepth, newMax, fetchMethod.getName());
         return newMax;
     }

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/Serializer.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/Serializer.java
@@ -126,7 +126,7 @@ public final class Serializer {
 
     /**
      * Constructor which allows specifying whether to serialize non-dependent relations
-     * and the depth of traversal.
+     * and the level of traversal.
      *
      * @param graph         The framed graph
      * @param dependentOnly Only serialize dependent nodes
@@ -212,7 +212,7 @@ public final class Serializer {
      */
     public <T extends Frame> Bundle vertexFrameToBundle(T item)
             throws SerializationError {
-        return vertexToBundle(item.asVertex(), 0, false);
+        return vertexToBundle(item.asVertex(), 0, maxTraversals, false);
     }
 
     /**
@@ -225,7 +225,7 @@ public final class Serializer {
      */
     public Bundle vertexFrameToBundle(Vertex item)
             throws SerializationError {
-        return vertexToBundle(item, 0, false);
+        return vertexToBundle(item, 0, maxTraversals, false);
     }
 
     /**
@@ -321,7 +321,7 @@ public final class Serializer {
      * @return A data bundle
      * @throws SerializationError
      */
-    private Bundle vertexToBundle(Vertex item, int depth, boolean lite)
+    private Bundle vertexToBundle(Vertex item, int depth, int maxDepth, boolean lite)
             throws SerializationError {
         try {
             EntityClass type = EntityClass.withName((String) item
@@ -333,7 +333,7 @@ public final class Serializer {
                     .setId(id)
                     .addData(getVertexData(item, type, lite))
                     .addRelations(getRelationData(item,
-                            depth, lite, type.getEntityClass()))
+                            depth, maxDepth, lite, type.getEntityClass()))
                     .addMetaData(getVertexMeta(item));
             if (!lite) {
                 builder.addMetaData(getVertexMeta(item))
@@ -346,16 +346,16 @@ public final class Serializer {
         }
     }
 
-    private Bundle fetch(Frame frame, int depth, boolean isLite) throws SerializationError {
+    private Bundle fetch(Frame frame, int depth, int maxDepth, boolean isLite) throws SerializationError {
         if (cache != null) {
             String key = frame.getId() + depth + isLite;
             if (cache.containsKey(key))
                 return cache.get(key);
-            Bundle bundle = vertexToBundle(frame.asVertex(), depth, isLite);
+            Bundle bundle = vertexToBundle(frame.asVertex(), depth, maxDepth, isLite);
             cache.put(key, bundle);
             return bundle;
         }
-        return vertexToBundle(frame.asVertex(), depth, isLite);
+        return vertexToBundle(frame.asVertex(), depth, maxDepth, isLite);
     }
 
     // TODO: Profiling shows that (unsurprisingly) this method is a
@@ -364,9 +364,9 @@ public final class Serializer {
     // whereever possible. Unfortunately the use of @JavaHandler Frame
     // annotations will make this difficult.
     private ListMultimap<String, Bundle> getRelationData(
-            Vertex item, int depth, boolean lite, Class<?> cls) {
+            Vertex item, int depth, int maxDepth, boolean lite, Class<?> cls) {
         ListMultimap<String, Bundle> relations = ArrayListMultimap.create();
-        if (depth < maxTraversals) {
+        if (depth < maxDepth) {
             Map<String, Method> fetchMethods = ClassUtils.getFetchMethods(cls);
             logger.trace(" - Fetch methods: {}", fetchMethods);
             for (Map.Entry<String, Method> entry : fetchMethods.entrySet()) {
@@ -377,6 +377,8 @@ public final class Serializer {
                         || shouldSerializeLite(method);
 
                 if (shouldTraverse(relationName, method, depth, isLite)) {
+                    int nextDepth = depth + 1;
+                    int nextMaxDepth = getNewMaxDepth(method, nextDepth, maxDepth);
                     logger.trace("Fetching relation: {}, depth {}, {}",
                             relationName, depth, method.getName());
                     try {
@@ -386,13 +388,13 @@ public final class Serializer {
                         // be a single Frame, or a Iterable<Frame>.
                         if (result instanceof Iterable<?>) {
                             for (Object d : (Iterable<?>) result) {
-                                relations.put(relationName, fetch((Frame) d, depth + 1, isLite));
+                                relations.put(relationName, fetch((Frame) d, nextDepth, nextMaxDepth, isLite));
                             }
                         } else {
                             // This relationship could be NULL if, e.g. a
                             // collection has no holder.
                             if (result != null) {
-                                relations.put(relationName, fetch((Frame) result, depth + 1, isLite));
+                                relations.put(relationName, fetch((Frame) result, nextDepth, nextMaxDepth, isLite));
                             }
                         }
                     } catch (Exception e) {
@@ -409,55 +411,63 @@ public final class Serializer {
         return relations;
     }
 
-    /**
-     * Determine how to serialize the properties of an item. We use lite serialization if:
-     *  - it's not a dependent relation
-     *  - it doesn't have the full property set on the fetch annotation
-     */
+    private int getNewMaxDepth(Method fetchMethod, int currentDepth, int currentMaxDepth) {
+        Fetch fetchProps = fetchMethod.getAnnotation(Fetch.class);
+        int max = fetchProps.numLevels();
+        int newMax = max == -1
+                ? currentMaxDepth
+                : Math.min(currentDepth + max, currentMaxDepth);
+        logger.info("Current depth {}, fetch levels: {}, current max: {}, new max: {}, {}", currentDepth, max,
+                currentMaxDepth, newMax, fetchMethod.getName());
+        return newMax;
+    }
+
     private boolean shouldSerializeLite(Method method) {
         Dependent dep = method.getAnnotation(Dependent.class);
         Fetch fetch = method.getAnnotation(Fetch.class);
         return dep == null && (fetch == null || !fetch.full());
     }
 
-    private boolean shouldTraverse(String relationName, Method method, int depth, boolean lite) {
+    private boolean shouldTraverse(String relationName, Method method, int level, boolean lite) {
         // In order to avoid @Fetching the whole graph we track the
         // depth parameter and increase it for every traversal.
         // However the @Fetch annotation can also specify a maximum
-        // depth of traversal beyong which we don't serialize.
+        // level of traversal beyond which we don't serialize.
         Fetch fetchProps = method.getAnnotation(Fetch.class);
         Dependent dep = method.getAnnotation(Dependent.class);
 
-        if (fetchProps == null)
+        if (fetchProps == null) {
             return false;
+        }
 
         if (dependentOnly && dep == null) {
             logger.trace(
-                    "Terminating fetch dependent only is specified: {}, depth {}, limit {}, {}",
-                    relationName, depth, fetchProps.depth());
+                    "Terminating fetch dependent only is specified: {}, ifBelowLevel {}, limit {}, {}",
+                    relationName, level, fetchProps.ifBelowLevel());
             return false;
         }
 
         if (lite && fetchProps.whenNotLite()) {
             logger.trace(
-                    "Terminating fetch because it specifies whenNotLite: {}, depth {}, limit {}, {}",
-                    relationName, depth, fetchProps.depth());
+                    "Terminating fetch because it specifies whenNotLite: {}, ifBelowLevel {}, limit {}, {}",
+                    relationName, level, fetchProps.ifBelowLevel());
             return false;
         }
 
-        if (depth >= fetchProps.depth()) {
+        if (level >= fetchProps.ifBelowLevel()) {
             logger.trace(
-                    "Terminating fetch because depth exceeded depth on fetch clause: {}, depth {}, limit {}, {}",
-                    relationName, depth, fetchProps.depth());
+                    "Terminating fetch because level exceeded ifBelowLevel on fetch clause: {}, ifBelowLevel {}, " +
+                            "limit {}, {}",
+                    relationName, level, fetchProps.ifBelowLevel());
             return false;
         }
 
-        // If the fetch should only be serialized at a certain depth and
+        // If the fetch should only be serialized at a certain ifBelowLevel and
         // we've exceeded that, don't serialize.
-        if (fetchProps.ifDepth() != -1 && depth > fetchProps.ifDepth()) {
+        if (fetchProps.ifLevel() != -1 && level > fetchProps.ifLevel()) {
             logger.trace(
-                    "Terminating fetch because ifDepth clause found on {}, depth {}, {}",
-                    relationName, depth);
+                    "Terminating fetch because ifLevel clause found on {}, ifBelowLevel {}, {}",
+                    relationName, level);
             return false;
         }
         return true;

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/utils/BundlePath.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/utils/BundlePath.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import eu.ehri.project.persistence.Bundle;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -29,11 +30,13 @@ final class BundlePath {
 
     private final List<PathSection> sections;
     private final Optional<String> terminus;
+    private final BundlePath prev;
 
-    private BundlePath(List<PathSection> sections, Optional<String> terminus) {
+    private BundlePath(List<PathSection> sections, Optional<String> terminus, BundlePath prev) {
         Preconditions.checkNotNull(terminus);
         this.sections = ImmutableList.copyOf(sections);
         this.terminus = terminus;
+        this.prev = prev;
     }
 
     public String getTerminus() {
@@ -61,7 +64,7 @@ final class BundlePath {
             throw new NoSuchElementException();
         List<PathSection> ns = Lists.newArrayList(sections);
         ns.remove(0);
-        return new BundlePath(ns, terminus);
+        return new BundlePath(ns, terminus, this);
     }
 
     public static BundlePath fromString(String path) {
@@ -74,9 +77,9 @@ final class BundlePath {
         // the pattern something[1]
         try {
             sections.add(PathSection.fromString(terminus));
-            return new BundlePath(sections, Optional.<String>absent());
+            return new BundlePath(sections, Optional.<String>absent(), null);
         } catch (Exception e) {
-            return new BundlePath(sections, Optional.of(terminus));
+            return new BundlePath(sections, Optional.of(terminus), null);
         }
     }
     

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/utils/BundleUtils.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/utils/BundleUtils.java
@@ -208,7 +208,7 @@ public class BundleUtils {
                         path.next(), op);
             } catch (IndexOutOfBoundsException e) {
                 throw new BundleIndexError(String.format(
-                        "Relation index '%s[%s]' not found", section.getPath(),
+                        "Relation index '%s[%s]' not found", path.next(),
                         section.getIndex()));
             }
         }
@@ -278,9 +278,10 @@ public class BundleUtils {
         PathSection section = path.current();
         BundlePath next = path.next();
 
-        if (!bundle.hasRelations(section.getPath()))
+        if (section.getIndex() != -1 && !bundle.hasRelations(section.getPath())) {
             throw new BundlePathError(String.format(
                     "Relation path '%s' not found", section.getPath()));
+        }
         ListMultimap<String, Bundle> allRelations = ArrayListMultimap
                 .create(bundle.getRelations());
         try {

--- a/ehri-frames/src/main/java/eu/ehri/project/views/Query.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/Query.java
@@ -614,7 +614,7 @@ public final class Query<E extends AccessibleEntity> implements Scoped<Query> {
     /**
      * Create a filter that limits the selected nodes to with a particular depth
      * of a relationship chain. For example, if a set of nodes form a
-     * hierachical relationship such as:
+     * hierarchical relationship such as:
      * <p/>
      * child -[childOf]-> parent -[childOf]-> grandparent
      * <p/>

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -113,7 +113,6 @@ public class BundleTest {
                 .withDataValue(Ontology.DATE_PERIOD_START_DATE, "1900-01-01")
                 .withDataValue(Ontology.DATE_PERIOD_END_DATE, "2000-01-01");
         Bundle currentDp = BundleUtils.getBundle(bundle1, "describes[0]/hasDate[0]");
-        System.out.println("CURRENT: " + currentDp);
         Bundle b1_2 = BundleUtils
                 .setBundle(bundle1, "describes[0]/hasDate[-1]", currentDp);
         Bundle b1_3 = BundleUtils.setBundle(b1_2, "describes[0]/hasDate[0]", dp);
@@ -230,6 +229,16 @@ public class BundleTest {
         Bundle bundle2 = bundle.removeRelation(
                 Ontology.DESCRIPTION_FOR_ENTITY, relations.get(0));
         assertFalse(bundle2.hasRelations(Ontology.DESCRIPTION_FOR_ENTITY));
+    }
+
+    @Test
+    public void testBundleDepth() throws Exception {
+        assertEquals(1, bundle.depth());
+        Bundle dp = new Bundle(EntityClass.DATE_PERIOD)
+                .withDataValue(Ontology.DATE_PERIOD_START_DATE, "1900-01-01")
+                .withDataValue(Ontology.DATE_PERIOD_END_DATE, "2000-01-01");
+        Bundle deeperBundle = BundleUtils.setBundle(bundle, "describes[0]/hasDate[-1]", dp);
+        assertEquals(2, deeperBundle.depth());
     }
 
     @Test

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/SerializerTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/SerializerTest.java
@@ -2,6 +2,7 @@ package eu.ehri.project.persistence;
 
 import com.google.common.collect.Lists;
 import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.Link;
 import eu.ehri.project.models.VirtualUnit;
 import eu.ehri.project.persistence.utils.BundleUtils;
 import eu.ehri.project.test.AbstractFixtureTest;
@@ -39,8 +40,8 @@ public class SerializerTest extends AbstractFixtureTest {
             BundleUtils.get(serialized, "heldBy[0]/describes[0]/hasAddress[0]/streetAddress");
             fail("Default serializer should not serialize addresses in repository descriptions");
         } catch (BundleUtils.BundlePathError e) {
+            // okay
         }
-
     }
 
     @Test
@@ -82,6 +83,23 @@ public class SerializerTest extends AbstractFixtureTest {
         assertEquals("vcd1",
                 BundleUtils.get(serializedVc1, "describes[0]/identifier"));
         
+    }
+
+    @Test
+    public void testMaxFetchDepth() throws Exception {
+        Link link1 = manager.getFrame("link3", Link.class);
+        Serializer serializer = new Serializer.Builder(graph).build();
+        Bundle serialized = serializer.vertexFrameToBundle(link1);
+        Bundle target0 = BundleUtils.getBundle(serialized, "hasLinkTarget[0]");
+        assertEquals(1, target0.depth());
+        assertEquals("c3",
+                BundleUtils.get(serialized, "hasLinkTarget[0]/identifier"));
+        try {
+            BundleUtils.getBundle(serialized, "hasLinkTarget[0]/childOf[0]/describes[0]");
+            fail("Max ifBelowLevel serialization should ignore childOf relation for item c3");
+        } catch (BundleUtils.BundlePathError e) {
+            // okay
+        }
     }
 
     @Test

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/utils/BundleUtilsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/utils/BundleUtilsTest.java
@@ -83,6 +83,17 @@ public class BundleUtilsTest extends AbstractFixtureTest {
     }
 
     @Test
+    public void testSetNestedNodeAtNewPath() throws Exception {
+        Bundle bundle = Bundle.fromData(getTestBundle());
+        Bundle dateBundle = BundleUtils.getBundle(bundle,
+                "describes[0]/hasDate[0]").withDataValue("testattr", "testval");
+        Bundle newBundle = BundleUtils.setBundle(bundle,
+                "describes[0]/hasDate[0]/newPath[-1]", dateBundle);
+        Assert.assertEquals("testval", BundleUtils.get(newBundle,
+                "describes[0]/hasDate[0]/newPath[0]/testattr"));
+    }
+
+    @Test
     public void testInsertNestedNode() throws Exception {
         // Using -1 for insert means to append at the end of
         // the current relationship set...

--- a/ehri-frames/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-frames/src/test/resources/fixtures/testdata.yaml
@@ -524,6 +524,19 @@
      hasLinkBody: ur1
      hasLinker: mike
 
+ - id: link3
+   type: link
+   data:
+     type: associative
+     body: Test access point link
+   relationships:
+     hasLinkTarget:
+      - c3
+      - a1
+     hasLinkBody: ur1
+     hasLinker: mike
+
+
 --- # Permission grants
 
 # Allow user Reto to create doc units within r1 scope

--- a/ehri-importers/pom.xml
+++ b/ehri-importers/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-importers</artifactId>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
 
     <name>Import Tools</name>
     <description>Classes for importing data.</description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.9.1-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
     <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>


### PR DESCRIPTION
Add a way to limit the relative depth of traversal for individual
serialized relationships. Currently, fetching auto-serialized rels
recurses until a global default depth is reached. This can lead to
some pathological cases with higher depth levels, however, as well
as resulting in a lot of unnecessary data being transferred. A good
example of this is targets for links and notes: we only need the top-
level item itself in 99.9% of cases, not the whole tree and full context.
With higher depth levels, fetching all links for an item could lead to an
enormous amount of data being transferred, most of it unnecessary.

This problem is particularly acute when there's an erroneous relationship
loop, such as with #115. These loops shouldn't happen, but neither should
their occurence break things.

With this patch we can specify a relative depth limit for the target
relationship of a link (or annotation) node, so they only descend to one
level below the target (which will typically be the description for a
described item.)

Also bump version by a point since this is a fairly significant change,
albeit one that does not break any tests.

Additional tweaks:

 - add depth() method to bundle to assist in testing
 - add some more tests

Conflicts:
	ehri-frames/src/main/java/eu/ehri/project/models/annotations/Fetch.java