### PR TITLE
Improvements to serialization of metadata values and various model cleanups

### DIFF
--- a/ehri-extension/src/main/java/eu/ehri/extension/AdminResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AdminResource.java
@@ -9,17 +9,10 @@ import com.tinkerpop.blueprints.util.io.graphson.GraphSONWriter;
 import eu.ehri.project.acl.AclManager;
 import eu.ehri.project.acl.PermissionType;
 import eu.ehri.project.definitions.Ontology;
-import eu.ehri.project.models.Country;
-import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Group;
-import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.UserProfile;
-import eu.ehri.project.models.VirtualUnit;
 import eu.ehri.project.models.base.Accessor;
-import eu.ehri.project.models.cvoc.AuthoritativeSet;
-import eu.ehri.project.models.cvoc.Concept;
-import eu.ehri.project.models.cvoc.Vocabulary;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.Crud;
 import eu.ehri.project.views.ViewFactory;
@@ -59,50 +52,6 @@ public class AdminResource extends AbstractRestResource {
 
     public AdminResource(@Context GraphDatabaseService database) {
         super(database);
-    }
-
-    /**
-     * Update the childCount property on hierarchical items with the number of
-     * children they contain.
-     *
-     * @throws Exception
-     */
-    @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("/_rebuildChildCache")
-    public Response rebuildChildCache() throws Exception {
-        graph.getBaseGraph().checkNotInTransaction();
-        try {
-            for (DocumentaryUnit unit : manager.getFrames(EntityClass.DOCUMENTARY_UNIT, DocumentaryUnit.class)) {
-                unit.updateChildCountCache();
-            }
-            for (Repository repository : manager.getFrames(EntityClass.REPOSITORY, Repository.class)) {
-                repository.updateChildCountCache();
-            }
-            for (Country country : manager.getFrames(EntityClass.COUNTRY, Country.class)) {
-                country.updateChildCountCache();
-            }
-            for (Group group : manager.getFrames(EntityClass.GROUP, Group.class)) {
-                group.updateChildCountCache();
-            }
-            for (Concept concept : manager.getFrames(EntityClass.CVOC_CONCEPT, Concept.class)) {
-                concept.updateChildCountCache();
-            }
-            for (Vocabulary vocabulary : manager.getFrames(EntityClass.CVOC_VOCABULARY, Vocabulary.class)) {
-                vocabulary.updateChildCountCache();
-            }
-            for (AuthoritativeSet set : manager.getFrames(EntityClass.AUTHORITATIVE_SET, AuthoritativeSet.class)) {
-                set.updateChildCountCache();
-            }
-            for (VirtualUnit vu : manager.getFrames(EntityClass.VIRTUAL_UNIT, VirtualUnit.class)) {
-                vu.updateChildCountCache();
-            }
-
-            graph.getBaseGraph().commit();
-            return Response.status(Status.OK).build();
-        } finally {
-            cleanupTransaction();
-        }
     }
 
     /**

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/AdminRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/AdminRestClientTest.java
@@ -23,14 +23,6 @@ import static eu.ehri.extension.AdminResource.ENDPOINT;
 public class AdminRestClientTest extends BaseRestClientTest {
 
     @Test
-    public void testHouseKeeping() throws Exception {
-        WebResource resource = client.resource(ehriUri(ENDPOINT, "_rebuildChildCache"));
-        ClientResponse response = resource.accept(MediaType.APPLICATION_JSON)
-                .type(MediaType.APPLICATION_JSON).post(ClientResponse.class);
-        assertStatus(OK, response);
-    }
-
-    @Test
     public void testCreateDefaultUser() throws Exception {
         // Create
         WebResource resource = client.resource(ehriUri(ENDPOINT, "createDefaultUserProfile"));

--- a/ehri-frames/src/main/java/eu/ehri/project/models/Country.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/Country.java
@@ -9,6 +9,7 @@ import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Mandatory;
+import eu.ehri.project.models.annotations.Meta;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.IdentifiableEntity;
 import eu.ehri.project.models.base.ItemHolder;
@@ -41,6 +42,7 @@ public interface Country extends IdentifiableEntity, AccessibleEntity,
      *
      * @return the repository count
      */
+    @Meta(CHILD_COUNT)
     @JavaHandler
     public long getChildCount();
 
@@ -61,34 +63,17 @@ public interface Country extends IdentifiableEntity, AccessibleEntity,
     public void addRepository(final Repository repository);
 
     /**
-     * Update/reset the cache of the number of repositories
-     * in this country.
-     */
-    @JavaHandler
-    public void updateChildCountCache();
-
-    /**
      * Implementation of complex methods.
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, Country {
 
-        public void updateChildCountCache() {
-            it().setProperty(CHILD_COUNT, gremlin().in(Ontology.REPOSITORY_HAS_COUNTRY).count());
-        }
-
         public long getChildCount() {
-            Long count = it().getProperty(CHILD_COUNT);
-            if (count == null) {
-                count = gremlin().in(Ontology.DOC_HELD_BY_REPOSITORY).count();
-            }
-            return count;
+            return gremlin().inE(Ontology.REPOSITORY_HAS_COUNTRY).count();
         }
 
         public void addRepository(final Repository repository) {
-            if (JavaHandlerUtils.addSingleRelationship(repository.asVertex(), it(),
-                    Ontology.REPOSITORY_HAS_COUNTRY)) {
-                updateChildCountCache();
-            }
+            JavaHandlerUtils.addSingleRelationship(repository.asVertex(), it(),
+                    Ontology.REPOSITORY_HAS_COUNTRY);
         }
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/DocumentaryUnit.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/DocumentaryUnit.java
@@ -12,6 +12,7 @@ import com.tinkerpop.pipes.util.Pipeline;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Fetch;
+import eu.ehri.project.models.annotations.Meta;
 import eu.ehri.project.models.base.AbstractUnit;
 import eu.ehri.project.models.utils.JavaHandlerUtils;
 import org.slf4j.Logger;
@@ -76,6 +77,7 @@ public interface DocumentaryUnit extends AbstractUnit {
      *
      * @return the number of immediate child items
      */
+    @Meta(CHILD_COUNT)
     @JavaHandler
     public long getChildCount();
 
@@ -97,12 +99,6 @@ public interface DocumentaryUnit extends AbstractUnit {
     public Iterable<DocumentaryUnit> getAllChildren();
 
     /**
-     * Update/reset the cache of child items at the lower level.
-     */
-    @JavaHandler
-    public void updateChildCountCache();
-
-    /**
      * Get the description items for this documentary unit.
      *
      * @return a iterable of document descriptions
@@ -115,16 +111,8 @@ public interface DocumentaryUnit extends AbstractUnit {
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, DocumentaryUnit {
 
-        public void updateChildCountCache() {
-            it().setProperty(CHILD_COUNT, gremlin().in(Ontology.DOC_IS_CHILD_OF).count());
-        }
-
         public long getChildCount() {
-            Long count = it().getProperty(CHILD_COUNT);
-            if (count == null) {
-                count = gremlin().in(Ontology.DOC_IS_CHILD_OF).count();
-            }
-            return count;
+            return gremlin().inE(Ontology.DOC_IS_CHILD_OF).count();
         }
 
         public Iterable<DocumentaryUnit> getChildren() {
@@ -132,10 +120,8 @@ public interface DocumentaryUnit extends AbstractUnit {
         }
 
         public void addChild(final DocumentaryUnit child) {
-            if (JavaHandlerUtils
-                    .addSingleRelationship(child.asVertex(), it(), Ontology.DOC_IS_CHILD_OF)) {
-                updateChildCountCache();
-            }
+            JavaHandlerUtils
+                    .addSingleRelationship(child.asVertex(), it(), Ontology.DOC_IS_CHILD_OF);
         }
 
         public Iterable<DocumentaryUnit> getAllChildren() {

--- a/ehri-frames/src/main/java/eu/ehri/project/models/annotations/Meta.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/annotations/Meta.java
@@ -1,0 +1,24 @@
+package eu.ehri.project.models.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that marks a Frame method as serializable
+ * metadata. This should only be applied on methods that
+ * return scalar values.
+ *
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Meta {
+    /**
+     * The name of the serialized metadata value.
+     *
+     * @return a string
+     */
+    String value();
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/Watchable.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/Watchable.java
@@ -1,8 +1,12 @@
 package eu.ehri.project.models.base;
 
 import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Adjacency;
+import com.tinkerpop.frames.modules.javahandler.JavaHandler;
+import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import eu.ehri.project.models.UserProfile;
+import eu.ehri.project.models.annotations.Meta;
 
 import static eu.ehri.project.definitions.Ontology.USER_WATCHING_ITEM;
 
@@ -10,6 +14,20 @@ import static eu.ehri.project.definitions.Ontology.USER_WATCHING_ITEM;
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public interface Watchable extends AccessibleEntity {
+    String WATCHED_COUNT = "watchedBy";
+
     @Adjacency(label = USER_WATCHING_ITEM, direction = Direction.IN)
     public Iterable<UserProfile> getWatchers();
+
+    @Meta(WATCHED_COUNT)
+    @JavaHandler
+    public long getWatchedCount();
+
+    abstract class Impl implements JavaHandlerContext<Vertex>, Watchable {
+
+        @Override
+        public long getWatchedCount() {
+            return gremlin().inE(USER_WATCHING_ITEM).count();
+        }
+    }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
@@ -43,35 +43,17 @@ public interface AuthoritativeSet extends AccessibleEntity, IdentifiableEntity,
     public void addItem(final AuthoritativeItem item);
 
     /**
-     * Update the cache for the number of items within
-     * this set.
-     */
-    @JavaHandler
-    public void updateChildCountCache();
-
-    /**
      * Implementation of complex methods.
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, AuthoritativeSet {
 
-        public void updateChildCountCache() {
-            it().setProperty(CHILD_COUNT, gremlin().in(Ontology.ITEM_IN_AUTHORITATIVE_SET).count());
-        }
-
         public long getChildCount() {
-            Long count = it().getProperty(CHILD_COUNT);
-            if (count == null) {
-                count = gremlin().in(Ontology.ITEM_IN_AUTHORITATIVE_SET).count();
-            }
-            return count;
+            return gremlin().inE(Ontology.ITEM_IN_AUTHORITATIVE_SET).count();
         }
 
         public void addItem(final AuthoritativeItem item) {
-            if (JavaHandlerUtils.addSingleRelationship(item.asVertex(), it(),
-                    Ontology.ITEM_IN_AUTHORITATIVE_SET)) {
-                updateChildCountCache();
-            }
+            JavaHandlerUtils.addSingleRelationship(item.asVertex(), it(),
+                    Ontology.ITEM_IN_AUTHORITATIVE_SET);
         }
     }
-    
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/events/SystemEvent.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/events/SystemEvent.java
@@ -60,7 +60,7 @@ public interface SystemEvent extends AccessibleEntity {
      *
      * @return A user profile instance
      */
-    @Fetch(value = Ontology.EVENT_HAS_ACTIONER, numLevels = 1)
+    @Fetch(value = Ontology.EVENT_HAS_ACTIONER, numLevels = 0)
     @JavaHandler
     public Actioner getActioner();
 

--- a/ehri-frames/src/test/java/eu/ehri/project/models/CountryTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/CountryTest.java
@@ -5,6 +5,7 @@ import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.persistence.BundleDAO;
 import eu.ehri.project.test.AbstractFixtureTest;
 import eu.ehri.project.test.TestData;
+import eu.ehri.project.views.ViewFactory;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -21,7 +22,16 @@ public class CountryTest extends AbstractFixtureTest {
                 .create(Bundle.fromData(TestData.getTestAgentBundle()), Repository.class);
         country.addRepository(repo);
         // 2 nl repositories in the fixtures, plus the one we just made...
-        assertEquals(3L, (long) country.getChildCount());
+        assertEquals(3L, country.getChildCount());
+    }
+
+    @Test
+    public void testGetChildCountOnDeletion() throws Exception {
+        Country country = manager.getFrame("nl", Country.class);
+        Repository repo = manager.getFrame("r1", Repository.class);
+        assertEquals(2L, country.getChildCount());
+        ViewFactory.getCrudNoLogging(graph, Repository.class).delete("r1", validUser);
+        assertEquals(1L, country.getChildCount());
     }
 
     @Test

--- a/ehri-frames/src/test/java/eu/ehri/project/models/UserProfileTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/UserProfileTest.java
@@ -28,14 +28,14 @@ public class UserProfileTest extends AbstractFixtureTest {
         assertTrue(Iterables.isEmpty(validUser.getFollowing()));
         validUser.addFollowing(follower);
         // Get count caching
-        assertEquals(1L, validUser.asVertex().getProperty(UserProfile.FOLLOWING_COUNT));
-        assertEquals(1L, follower.asVertex().getProperty(UserProfile.FOLLOWER_COUNT));
+        assertEquals(1L, validUser.getFollowingCount());
+        assertEquals(1L, follower.getFollowerCount());
         assertFalse(Iterables.isEmpty(validUser.getFollowing()));
         assertTrue(Iterables.contains(validUser.getFollowing(), follower));
         validUser.removeFollowing(follower);
         assertTrue(Iterables.isEmpty(validUser.getFollowing()));
-        assertEquals(0L, validUser.asVertex().getProperty(UserProfile.FOLLOWING_COUNT));
-        assertEquals(0L, follower.asVertex().getProperty(UserProfile.FOLLOWER_COUNT));
+        assertEquals(0L, validUser.getFollowingCount());
+        assertEquals(0L, follower.getFollowerCount());
     }
 
     @Test
@@ -64,13 +64,14 @@ public class UserProfileTest extends AbstractFixtureTest {
         assertFalse(validUser.isWatching(watched));
         validUser.addWatching(watched);
         assertTrue(validUser.isWatching(watched));
-        assertEquals(1L, validUser.asVertex().getProperty(UserProfile.WATCHING_COUNT));
-        assertEquals(1L, watched.asVertex().getProperty(UserProfile.WATCHED_COUNT));
+        assertEquals(1L, validUser.getWatchingCount());
+        assertTrue(Iterables.contains(watched.getWatchers(), validUser));
+        assertEquals(1L, watched.getWatchedCount());
         assertTrue(Iterables.contains(validUser.getWatching(), watched));
         validUser.removeWatching(watched);
         assertFalse(validUser.isWatching(watched));
-        assertEquals(0L, validUser.asVertex().getProperty(UserProfile.WATCHING_COUNT));
-        assertEquals(0L, watched.asVertex().getProperty(UserProfile.WATCHED_COUNT));
+        assertEquals(0L, validUser.getWatchingCount());
+        assertEquals(0L, watched.getWatchedCount());
     }
 
     @Test


### PR DESCRIPTION
Previously, the number of child items an `ItemHolder` has was cached in
a property. Due to the limitations of Frames, the code to do this had
to be repeated in a very ugly way. Also, while I'm not sure how much slower,
if at all, counting relationships is compared to looking up a property is,
but I doubt it's worth the additional complexity.

Also, with the caching there was inevitably issues with invalidation,
which turned out to be an actual problem.

This patch introduces a `@Meta(name)` annotation that can be affixed
to frame methods that return scalar values, which will be automatically
included in the bundle meta section.

Testing performance of full-graph serialization show neglibable performance
difference for the same functionality. Fetching watched count, however, adds
a small overhead, but one that can be elsewhere offset.