### PR TITLE
Short urls redux, squashed version of #105 with various tweaks

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,27 +60,27 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-cmdline</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -90,7 +90,7 @@
                 <dependency>
                     <groupId>ehri-project</groupId>
                     <artifactId>ehri-extension-sparql</artifactId>
-                    <version>0.9.1-SNAPSHOT</version>
+                    <version>0.9.2-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/assembly/src/main/assembly/unix.xml
+++ b/assembly/src/main/assembly/unix.xml
@@ -55,7 +55,6 @@
                 <include>com.google.guava:guava</include>
                 <include>net.sf.opencsv:opencsv</include>
                 <include>commons-cli:commons-cli</include>
-                <include>com.ibm.icu:icu4j</include>
                 <include>net.sourceforge.owlapi:owlapi-distribution</include>
                 <include>org.apache.jena:*</include>
                 <include>xerces:xercesImpl</include>

--- a/ehri-cmdline/pom.xml
+++ b/ehri-cmdline/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cmdline</artifactId>
     <name>Command Line Tools</name>
     <description>Command line tools for interacting with the backend graph DB.</description>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
 
         <!-- RDF export -->

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-extension-sparql/pom.xml
+++ b/ehri-extension-sparql/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ehri-extension-sparql</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
 
     <name>Web Service SparQL Extension</name>
     <description>SparQL endpoint for web service.</description>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -109,14 +109,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/ehri-extension/pom.xml
+++ b/ehri-extension/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>
     <description>Web service layer exposed via a Neo4j extension.</description>
 
     <artifactId>ehri-extension</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
 
     <!-- TODO add license info and more -->
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -306,8 +306,8 @@ public class ToolsResource extends AbstractRestResource {
     }
 
     /**
-     * Regenerate the hierarchical graph ID all items within the
-     * immediate permission scope (not all items recursively.)
+     * Regenerate the hierarchical graph ID for all items within the
+     * permission scope and lower levels.
      *
      * The default mode is to output items whose IDs would change, without
      * actually changing them. The {@code collisions} parameter will <b>only</b>
@@ -342,7 +342,7 @@ public class ToolsResource extends AbstractRestResource {
                     .withActualRename(commit)
                     .skippingCollisions(tolerant)
                     .collisionMode(collisions)
-                    .reGenerateIds(scope, scope.getContainedItems());
+                    .reGenerateIds(scope.getAllContainedItems());
             graph.getBaseGraph().commit();
             return makeCsv(lists);
         } finally {

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/DescriptionRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/DescriptionRestClientTest.java
@@ -45,7 +45,7 @@ public class DescriptionRestClientTest extends BaseRestClientTest {
         JsonNode idValue = rootNode
                 .path(Bundle.ID_KEY);
         assertFalse(idValue.isMissingNode());
-        assertEquals("nl-r1-c1-c2-en_another_description", idValue.getTextValue());
+        assertEquals("nl-r1-c1-c2.en-another_description", idValue.getTextValue());
 
         // Check the identifier is present and correct...
         JsonNode identValue = rootNode

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/DescriptionRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/DescriptionRestClientTest.java
@@ -45,7 +45,7 @@ public class DescriptionRestClientTest extends BaseRestClientTest {
         JsonNode idValue = rootNode
                 .path(Bundle.ID_KEY);
         assertFalse(idValue.isMissingNode());
-        assertEquals("nl-r1-c1-c2-en-another-description", idValue.getTextValue());
+        assertEquals("nl-r1-c1-c2-en_another_description", idValue.getTextValue());
 
         // Check the identifier is present and correct...
         JsonNode identValue = rootNode

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/ToolsRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/ToolsRestClientTest.java
@@ -75,8 +75,11 @@ public class ToolsRestClientTest extends BaseRestClientTest {
         ClientResponse response = resource.post(ClientResponse.class);
         String out = response.getEntity(String.class);
         assertStatus(OK, response);
-        assertEquals(2, out.split("\r\n|\r|\n").length);
+        System.out.println(out);
+        assertEquals(4, out.split("\r\n|\r|\n").length);
         assertTrue(out.contains("nl-r1-c1"));
+        assertTrue(out.contains("nl-r1-c1-c2"));
+        assertTrue(out.contains("nl-r1-c1-c2-c3"));
         assertTrue(out.contains("nl-r1-c4"));
     }
 

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/ToolsRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/ToolsRestClientTest.java
@@ -2,7 +2,6 @@ package eu.ehri.extension.test;
 
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
-import eu.ehri.extension.ToolsResource;
 import eu.ehri.project.definitions.Entities;
 import org.junit.Test;
 
@@ -75,7 +74,6 @@ public class ToolsRestClientTest extends BaseRestClientTest {
         ClientResponse response = resource.post(ClientResponse.class);
         String out = response.getEntity(String.class);
         assertStatus(OK, response);
-        System.out.println(out);
         assertEquals(4, out.split("\r\n|\r|\n").length);
         assertTrue(out.contains("nl-r1-c1"));
         assertTrue(out.contains("nl-r1-c1-c2"));
@@ -96,5 +94,18 @@ public class ToolsRestClientTest extends BaseRestClientTest {
         assertTrue(out.contains("nl-r1-c1-c2"));
         assertTrue(out.contains("nl-r1-c1-c2-c3"));
         assertTrue(out.contains("nl-r1-c4"));
+    }
+
+    @Test
+    public void testRegenerateDescriptionIds() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "_regenerateDescriptionIds"))
+                .queryParam("commit", "true");
+        ClientResponse response = resource.post(ClientResponse.class);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        // 2 Historical agent descriptions
+        // 4 Repository descriptions
+        // 6 Doc Unit descriptions (total 7, 1 is okay in fixtures)
+        assertEquals("12", out);
     }
 }

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-frames</artifactId>
     <packaging>jar</packaging>
 
 
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
 
     <name>EHRI Core API</name>
     <description>Java API for data access and permissions.</description>
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -181,11 +181,6 @@
             <artifactId>ehri-definitions</artifactId>
             <version>0.9.1-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>52.1</version>
-        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/SystemScope.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/SystemScope.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.models.PermissionGrant;
+import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Frame;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.models.utils.EmptyIterable;
@@ -58,13 +59,13 @@ public enum SystemScope implements PermissionScope {
     }
 
     @Override
-    public Iterable<Frame> getContainedItems() {
-        return new EmptyIterable<Frame>();
+    public Iterable<AccessibleEntity> getContainedItems() {
+        return new EmptyIterable<AccessibleEntity>();
     }
 
     @Override
-    public Iterable<Frame> getAllContainedItems() {
-        return new EmptyIterable<Frame>();
+    public Iterable<AccessibleEntity> getAllContainedItems() {
+        return new EmptyIterable<AccessibleEntity>();
     }
 
     @Override

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/Description.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/Description.java
@@ -28,6 +28,9 @@ public interface Description extends NamedEntity, AccessibleEntity {
     @Property(Ontology.LANGUAGE_OF_DESCRIPTION)
     public String getLanguageOfDescription();
 
+    @Property(Ontology.IDENTIFIER_KEY)
+    public String getDescriptionCode();
+
     @Property(Ontology.CREATION_PROCESS)
     public CreationProcess getCreationProcess();
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/ItemHolder.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/ItemHolder.java
@@ -4,7 +4,7 @@ package eu.ehri.project.models.base;
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public interface ItemHolder {
-    public static final String CHILD_COUNT = "_childCount";
+    public static final String CHILD_COUNT = "childCount";
 
     public long getChildCount();
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/PermissionScope.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/PermissionScope.java
@@ -21,23 +21,50 @@ import java.util.List;
  *
  */
 public interface PermissionScope extends IdentifiableEntity {
+
+    /**
+     * Get all permission grants that apply directly to this scope.
+     *
+     * @return an iterable of permission grant frames
+     */
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_SCOPE, direction = Direction.IN)
     public Iterable<PermissionGrant> getPermissionGrants();
 
+    /**
+     * Get an iterable of the parent and all the parents higher permission
+     * scopes, recursively.
+     *
+     * @return an iterable of parent scope items
+     */
     @JavaHandler
     public Iterable<PermissionScope> getPermissionScopes();
 
+    /**
+     * Get an iterable of all items immediately within this scope.
+     *
+     * @return an iterable of lower scoped items
+     */
     @Adjacency(label = Ontology.HAS_PERMISSION_SCOPE, direction = Direction.IN)
-    public Iterable<Frame> getContainedItems();
+    public Iterable<AccessibleEntity> getContainedItems();
 
+    /**
+     * Get an iterable of all items within this scope, recursively down
+     * to all lower levels.
+     *
+     * @return an iterable of lower scoped items to all depths
+     */
     @JavaHandler
-    public Iterable<Frame> getAllContainedItems();
+    public Iterable<AccessibleEntity> getAllContainedItems();
 
+    /**
+     * Get the path of the permission scope as an ordered collection of strings.
+     * @return an ordered Collection of Strings that forms the 'path'.
+     */
     @JavaHandler
     public Collection<String> idPath();
 
     abstract class Impl implements JavaHandlerContext<Vertex>, PermissionScope {
-        public Iterable<Frame> getAllContainedItems() {
+        public Iterable<AccessibleEntity> getAllContainedItems() {
             return frameVertices(gremlin().as("n")
                     .in(Ontology.HAS_PERMISSION_SCOPE)
                     .loop("n", JavaHandlerUtils.noopLoopFunc, JavaHandlerUtils.noopLoopFunc));

--- a/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
@@ -3,6 +3,7 @@ package eu.ehri.project.models.idgen;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ListMultimap;
 import eu.ehri.project.persistence.Bundle;
+import eu.ehri.project.utils.Slugify;
 
 import java.util.Collection;
 import static eu.ehri.project.definitions.Ontology.IDENTIFIER_KEY;
@@ -19,8 +20,12 @@ public enum DescriptionIdGenerator implements IdGenerator {
 
     INSTANCE;
 
+    public static final String DESCRIPTION_SEPARATOR = ".";
+
     private static final Joiner idJoiner = Joiner
             .on(IdGeneratorUtils.HIERARCHY_SEPARATOR).skipNulls();
+
+    public static final Joiner descriptionJoiner = Joiner.on(DESCRIPTION_SEPARATOR);
 
     public ListMultimap<String,String> handleIdCollision(Collection<String> scopeIds, Bundle bundle) {
         return IdGeneratorUtils.handleIdCollision(scopeIds, LANGUAGE_OF_DESCRIPTION,
@@ -36,7 +41,7 @@ public enum DescriptionIdGenerator implements IdGenerator {
      * @return The calculated identifier
      */
     public String generateId(Collection<String> scopeIds, Bundle bundle) {
-        return IdGeneratorUtils.generateId(scopeIds, bundle, getIdBase(bundle));
+        return descriptionJoiner.join(IdGeneratorUtils.joinPath(scopeIds), getIdBase(bundle));
     }
 
     /**
@@ -49,9 +54,12 @@ public enum DescriptionIdGenerator implements IdGenerator {
     public String getIdBase(Bundle bundle) {
         String lang = bundle.getDataValue(LANGUAGE_OF_DESCRIPTION);
         String ident = bundle.getDataValue(IDENTIFIER_KEY);
-        if (ident != null && ident.trim().isEmpty()) {
-            ident = null;
+        String identSlug = ident != null
+            ? Slugify.slugify(ident, IdGeneratorUtils.SLUG_REPLACE)
+            : null;
+        if (identSlug != null && identSlug.trim().isEmpty()) {
+            identSlug = null;
         }
-        return idJoiner.join(lang, ident);
+        return idJoiner.join(lang, identSlug);
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
@@ -38,8 +38,10 @@ public enum DescriptionIdGenerator implements IdGenerator {
 
     /**
      * Return the base data for the id, sans scoping.
+     * If the bundle contains a language of description, it comes first.
+     * If the bundle has a non-empty identifier, it is used too.
      * @param bundle The entity's bundle.
-     * @return The base id string.
+     * @return The base id string, consisting of language code and/or identifier.
      */
     public String getIdBase(Bundle bundle) {
         String lang = bundle.getDataValue(LANGUAGE_OF_DESCRIPTION);

--- a/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
@@ -19,6 +19,9 @@ public enum DescriptionIdGenerator implements IdGenerator {
 
     INSTANCE;
 
+    private static final Joiner idJoiner = Joiner
+            .on(IdGeneratorUtils.HIERARCHY_SEPARATOR).skipNulls();
+
     public ListMultimap<String,String> handleIdCollision(Collection<String> scopeIds, Bundle bundle) {
         return IdGeneratorUtils.handleIdCollision(scopeIds, LANGUAGE_OF_DESCRIPTION,
                 getIdBase(bundle));
@@ -49,7 +52,6 @@ public enum DescriptionIdGenerator implements IdGenerator {
         if (ident != null && ident.trim().isEmpty()) {
             ident = null;
         }
-        return Joiner.on(IdGeneratorUtils.HIERARCHY_SEPARATOR)
-                .skipNulls().join(lang, ident);
+        return idJoiner.join(lang, ident);
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/idgen/DescriptionIdGenerator.java
@@ -5,14 +5,12 @@ import com.google.common.collect.ListMultimap;
 import eu.ehri.project.persistence.Bundle;
 
 import java.util.Collection;
-import java.util.List;
-
 import static eu.ehri.project.definitions.Ontology.IDENTIFIER_KEY;
 import static eu.ehri.project.definitions.Ontology.LANGUAGE_OF_DESCRIPTION;
 
 /**
  * Generates an ID for nodes which represent Descriptions, where
- * The graph id is a combination of the parent scopes, plus the description
+ * the graph id is a combination of the parent scopes, plus the description
  * language code, plus an optional description identifier (say, 'alt').
  * 
  * @author Mike Bryant (http://github.com/mikesname)
@@ -49,7 +47,7 @@ public enum DescriptionIdGenerator implements IdGenerator {
         if (ident != null && ident.trim().isEmpty()) {
             ident = null;
         }
-        return Joiner.on(IdGeneratorUtils.SEPARATOR)
+        return Joiner.on(IdGeneratorUtils.HIERARCHY_SEPARATOR)
                 .skipNulls().join(lang, ident);
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/models/idgen/IdGeneratorUtils.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/idgen/IdGeneratorUtils.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -31,6 +30,8 @@ public class IdGeneratorUtils {
      */
     public static final String HIERARCHY_SEPARATOR = "-";
     public static final String SLUG_REPLACE = "_";
+
+    private static final Joiner hierarchyJoiner = Joiner.on(HIERARCHY_SEPARATOR);
 
     protected final static Logger logger = LoggerFactory.getLogger(IdGeneratorUtils.class);
 
@@ -117,6 +118,6 @@ public class IdGeneratorUtils {
             slugged.add(Slugify.slugify(p, SLUG_REPLACE));
         }
 
-        return Joiner.on(HIERARCHY_SEPARATOR).join(slugged);
+        return hierarchyJoiner.join(slugged);
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -203,7 +203,7 @@ public final class Bundle {
 
     /**
      * Get the id of the bundle's graph vertex (or null if it does not yet
-     * exist.
+     * exist).
      *
      * @return The bundle's id
      */
@@ -232,9 +232,9 @@ public final class Bundle {
     }
 
     /**
-     * Get a data value.
+     * Get a data value by its key.
      *
-     * @return The data value
+     * @return The data value, or null if there is no data for this key
      */
     public <T> T getDataValue(String key) {
         checkNotNull(key);
@@ -242,11 +242,12 @@ public final class Bundle {
     }
 
     /**
-     * Set a value in the bundle's data.
+     * Set a value in the bundle's data. If value is null,
+     * this Bundle is returned.
      *
      * @param key   The data key
      * @param value The data value
-     * @return A new bundle
+     * @return A new bundle with value as key
      */
     public Bundle withDataValue(String key, Object value) {
         if (value == null) {

--- a/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
@@ -21,7 +21,9 @@ public class Slugify {
 
     /**
      * Slugify the input string using the given replacement string.
+     *
      * @param input the String to slugify
+     * @param replacement the replacement string
      * @return the slugified copy of the input string
      */
     public static String slugify(String input, String replacement) {

--- a/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
@@ -1,10 +1,5 @@
 package eu.ehri.project.utils;
 
-import com.ibm.icu.text.Transliterator;
-import org.apache.commons.lang.StringUtils;
-
-import java.text.Normalizer;
-
 /**
  * Class for handling slugification of strings, for use
  * in global identifiers.
@@ -13,8 +8,6 @@ import java.text.Normalizer;
  */
 public class Slugify {
 
-    private static final Transliterator transliterator
-            = Transliterator.getInstance("Hebrew-Latin; Cyrillic-Latin; Greek-Latin; Latin-Ascii; Any-Lower");
     private static final String DEFAULT_REPLACE = "-";
 
     /**
@@ -32,23 +25,12 @@ public class Slugify {
      * @return the slugified copy of the input string
      */
     public static String slugify(String input, String replacement) {
-        return normalize(input, replacement)
+        return input
+                .replaceAll("[\\p{P}=+<>~\\|]", replacement)
                 .replaceAll("\\s+", replacement)            // whitespace
                 .replaceAll(replacement + "+", replacement) // replacements
                 .replaceAll("^" + replacement + "|" + replacement + "$", "") // leading/trailing replacements
                 .toLowerCase();
-    }
-
-    private static String normalize(String input, String replacement) {
-        final String ret = StringUtils.trim(input);
-        if (StringUtils.isBlank(ret)) {
-            return "";
-        }
-
-        final String trans = transliterator.transform(ret);
-        return Normalizer.normalize(trans, Normalizer.Form.NFD)
-                .replaceAll("[^\\p{ASCII}]", "")
-                .replaceAll("[^a-zA-Z0-9]", replacement);
     }
 }
 

--- a/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/utils/Slugify.java
@@ -17,19 +17,29 @@ public class Slugify {
             = Transliterator.getInstance("Hebrew-Latin; Cyrillic-Latin; Greek-Latin; Latin-Ascii; Any-Lower");
     private static final String DEFAULT_REPLACE = "-";
 
+    /**
+     * Slugify the input string using the default replacement string.
+     * @param input the String to slugify
+     * @return the slugified copy of the input string
+     */
     public static String slugify(String input) {
         return slugify(input, DEFAULT_REPLACE);
     }
 
+    /**
+     * Slugify the input string using the given replacement string.
+     * @param input the String to slugify
+     * @return the slugified copy of the input string
+     */
     public static String slugify(String input, String replacement) {
-        return normalize(input)
+        return normalize(input, replacement)
                 .replaceAll("\\s+", replacement)            // whitespace
                 .replaceAll(replacement + "+", replacement) // replacements
-                .replaceAll("^\\W|\\W$", "")                // leading/trailing non alpha
+                .replaceAll("^" + replacement + "|" + replacement + "$", "") // leading/trailing replacements
                 .toLowerCase();
     }
 
-    private static String normalize(String input) {
+    private static String normalize(String input, String replacement) {
         final String ret = StringUtils.trim(input);
         if (StringUtils.isBlank(ret)) {
             return "";
@@ -38,7 +48,7 @@ public class Slugify {
         final String trans = transliterator.transform(ret);
         return Normalizer.normalize(trans, Normalizer.Form.NFD)
                 .replaceAll("[^\\p{ASCII}]", "")
-                .replaceAll("[^a-zA-Z0-9- ]", DEFAULT_REPLACE);
+                .replaceAll("[^a-zA-Z0-9]", replacement);
     }
 }
 

--- a/ehri-frames/src/test/java/eu/ehri/project/models/base/PermissionScopeTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/base/PermissionScopeTest.java
@@ -41,7 +41,7 @@ public class PermissionScopeTest extends AbstractFixtureTest {
     public void testContainedItems() throws Exception {
         PermissionScope c1 = manager.getFrame("c1", PermissionScope.class);
         PermissionScope c2 = manager.getFrame("c2", PermissionScope.class);
-        Iterable<Frame> containedItems = c1.getContainedItems();
+        Iterable<AccessibleEntity> containedItems = c1.getContainedItems();
         assertEquals(1L, Iterables.count(containedItems));
         assertEquals(c2, containedItems.iterator().next());
     }
@@ -53,18 +53,17 @@ public class PermissionScopeTest extends AbstractFixtureTest {
         PermissionScope c2 = manager.getFrame("c2", PermissionScope.class);
         PermissionScope c3 = manager.getFrame("c3", PermissionScope.class);
         PermissionScope c4 = manager.getFrame("c4", PermissionScope.class);
-        PermissionScope m19 = manager.getFrame("nl-r1-m19", PermissionScope.class);
-        List<Frame> r1contained = Lists.newArrayList(r1.getAllContainedItems());
+        List<AccessibleEntity> r1contained = Lists.newArrayList(r1.getAllContainedItems());
         assertEquals(5L, r1contained.size());
-        assertTrue(r1contained.contains(c1));
-        assertTrue(r1contained.contains(c2));
-        assertTrue(r1contained.contains(c3));
-        assertTrue(r1contained.contains(c4));
+        assertTrue(r1contained.contains(manager.cast(c1, AccessibleEntity.class)));
+        assertTrue(r1contained.contains(manager.cast(c2, AccessibleEntity.class)));
+        assertTrue(r1contained.contains(manager.cast(c3, AccessibleEntity.class)));
+        assertTrue(r1contained.contains(manager.cast(c4, AccessibleEntity.class)));
 
-        List<Frame> c1contained = Lists.newArrayList(c1.getAllContainedItems());
+        List<AccessibleEntity> c1contained = Lists.newArrayList(c1.getAllContainedItems());
         assertEquals(2L, c1contained.size());
-        assertTrue(c1contained.contains(c2));
-        assertTrue(c1contained.contains(c3));
+        assertTrue(c1contained.contains(manager.cast(c2, AccessibleEntity.class)));
+        assertTrue(c1contained.contains(manager.cast(c3, AccessibleEntity.class)));
     }
 
     @Test
@@ -79,7 +78,7 @@ public class PermissionScopeTest extends AbstractFixtureTest {
         Repository repo = manager.getFrame("r1", Repository.class);
         BundleDAO dao = new BundleDAO(graph, repo.idPath());
         DocumentaryUnit doc = dao.create(docBundle, DocumentaryUnit.class);
-        assertEquals("nl-r1-someid-01", doc.getId());
+        assertEquals("nl-r1-someid_01", doc.getId());
         doc.setPermissionScope(repo);
         assertEquals(Lists.newArrayList("nl", "r1", "someid-01"), doc.idPath());
     }

--- a/ehri-frames/src/test/java/eu/ehri/project/models/idgen/DescriptionIdGeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/idgen/DescriptionIdGeneratorTest.java
@@ -42,7 +42,7 @@ public class DescriptionIdGeneratorTest extends AbstractFixtureTest {
     @Test
     public void testGenerateIdWithStringScopes() throws Exception {
         String id = instance.generateId(scopes, bundle);
-        assertEquals("nl-r1-c1-eng-someid-01", id);
+        assertEquals("nl-r1-c1-eng_someid_01", id);
 
     }
 

--- a/ehri-frames/src/test/java/eu/ehri/project/models/idgen/DescriptionIdGeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/idgen/DescriptionIdGeneratorTest.java
@@ -42,13 +42,13 @@ public class DescriptionIdGeneratorTest extends AbstractFixtureTest {
     @Test
     public void testGenerateIdWithStringScopes() throws Exception {
         String id = instance.generateId(scopes, bundle);
-        assertEquals("nl-r1-c1-eng_someid_01", id);
+        assertEquals("nl-r1-c1.eng-someid_01", id);
 
     }
 
     @Test
     public void testGetIdBase() throws Exception {
         String id = instance.getIdBase(bundle);
-        assertEquals("eng-someid-01", id);
+        assertEquals("eng-someid_01", id);
     }
 }

--- a/ehri-frames/src/test/java/eu/ehri/project/models/idgen/IdentifiableEntityIdGeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/idgen/IdentifiableEntityIdGeneratorTest.java
@@ -26,7 +26,7 @@ public class IdentifiableEntityIdGeneratorTest extends AbstractFixtureTest {
 
     @Override
     @Before
-    public void setUp() throws Exception{
+    public void setUp() throws Exception {
         super.setUp();
         instance = IdentifiableEntityIdGenerator.INSTANCE;
         scopes = Lists.newArrayList("r1");
@@ -35,7 +35,7 @@ public class IdentifiableEntityIdGeneratorTest extends AbstractFixtureTest {
 
     @Test()
     public void testHandleIdCollision() throws Exception {
-        ListMultimap<String,String> errors = instance
+        ListMultimap<String, String> errors = instance
                 .handleIdCollision(scopes, bundle);
         assertTrue(errors.containsKey(Ontology.IDENTIFIER_KEY));
     }

--- a/ehri-frames/src/test/java/eu/ehri/project/models/idgen/IdentifiableEntityIdGeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/idgen/IdentifiableEntityIdGeneratorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -42,8 +43,62 @@ public class IdentifiableEntityIdGeneratorTest extends AbstractFixtureTest {
     @Test
     public void testGenerateIdWithStringScopes() throws Exception {
         String id = instance.generateId(scopes, bundle);
-        assertEquals("r1-someid-01", id);
+        assertEquals("r1-someid_01", id);
 
+    }
+
+    @Test
+    public void testGenerateIdWithPartialDupeStringScopes() throws Exception {
+        List<String> ids = Lists.newArrayList("r1", "Fonds 1",
+                "Fonds 1 / Subfonds 1", "Fonds 1 / Subfonds 1 / Item 3");
+        String id = IdGeneratorUtils.joinPath(ids);
+        assertEquals("r1-fonds_1-subfonds_1-item_3", id);
+
+        List<String> ids2 = Lists.newArrayList("il-002798", "M.40", "M.40.MAP");
+        String id2 = IdGeneratorUtils.joinPath(ids2);
+        assertEquals("il_002798-m_40-map", id2);
+
+        List<String> ids3 = Lists.newArrayList("de-002409", "DE ITS 1.1.0", "DE ITS 1.1.0.2", "2399000");
+        String id3 = IdGeneratorUtils.joinPath(ids3);
+        assertEquals("de_002409-de_its_1_1_0-2-2399000", id3);
+
+        List<String> ids4 = Lists.newArrayList("cz-002279", "COLLECTION.JMP.SHOAH/T",
+                "COLLECTION.JMP.SHOAH/T/2", "COLLECTION.JMP.SHOAH/T/2/A",
+                "COLLECTION.JMP.SHOAH/T/2/A/1", "COLLECTION.JMP.SHOAH/T/2/A/1a",
+                "COLLECTION.JMP.SHOAH/T/2/A/1a/028", "DOCUMENT.JMP.SHOAH/T/2/A/1a/028");
+        String id4 = IdGeneratorUtils.joinPath(ids4);
+        // special prefixes are not treated in 'smart' way
+        assertEquals("cz_002279-collection_jmp_shoah_t-2-a-1-a-028-document_jmp_shoah_t_2_a_1a_028", id4);
+
+        // The check is case sensitive, so prefix is repeated if case is different
+        List<String> ids5 = Lists.newArrayList("de-002409", "DE ITS 1.1.0", "de ITS 1.1.0.2", "2399000");
+        String id5 = IdGeneratorUtils.joinPath(ids5);
+        assertEquals("de_002409-de_its_1_1_0-de_its_1_1_0_2-2399000", id5);
+
+    }
+
+    @Test
+    public void testGenerateIdWithDupeStringScopes() throws Exception {
+        List<String> ids = Lists.newArrayList("r1", "Fonds 1",
+                "Thing 1", "Thing 1", "Thing 2");
+        String id = IdGeneratorUtils.joinPath(ids);
+        assertEquals("r1-fonds_1-thing_1-thing_1-thing_2", id);
+
+        List<String> ids2 = Lists.newArrayList("il-002798", "M.40", "MAP", "map");
+        String id2 = IdGeneratorUtils.joinPath(ids2);
+        assertEquals("il_002798-m_40-map-map", id2);
+
+        List<String> ids3 = Lists.newArrayList("de-002409", "DE ITS 1.1.0", "1.1.0", "1.1.0", "2399000");
+        String id3 = IdGeneratorUtils.joinPath(ids3);
+        assertEquals("de_002409-de_its_1_1_0-1_1_0-1_1_0-2399000", id3);
+    }
+
+    @Test
+    public void testHierarchyCollisions() throws Exception {
+        List<String> path1 = Lists.newArrayList("r1", "1-a", "b");
+        List<String> path2 = Lists.newArrayList("r1", "1", "a-b");
+        assertNotEquals(IdGeneratorUtils.joinPath(path1),
+                IdGeneratorUtils.joinPath(path2));
     }
 
     @Test

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleDAOTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleDAOTest.java
@@ -21,6 +21,7 @@ import eu.ehri.project.test.TestData;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.print.Doc;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -157,6 +158,7 @@ public class BundleDAOTest extends ModelTestBase {
             manager.getFrame(dpid, DatePeriod.class);
             fail("Date period '" + dpid + "' found in index AFTER delete test.");
         } catch (ItemNotFound e) {
+            // No problem
         }
 
         // It should also not exist as a node...
@@ -164,6 +166,7 @@ public class BundleDAOTest extends ModelTestBase {
             graph.getVertices(EntityType.ID_KEY, dpid).iterator().next();
             fail("Date period '" + dpid + "' found in index AFTER delete test.");
         } catch (NoSuchElementException e) {
+            // No problem
         }
     }
 
@@ -211,5 +214,13 @@ public class BundleDAOTest extends ModelTestBase {
         BundleDAO persister = new BundleDAO(graph);
         persister.update(b1, Repository.class);
         fail("Attempting to update a non-existent bundle did not throw an error");
+    }
+
+    @Test
+    public void testCreationWithUnicodeIdentifier() throws Exception {
+        Bundle b1 = Bundle.fromData(TestData.getTestDocBundle())
+                .withDataValue(Ontology.IDENTIFIER_KEY, "foo /?&% ארכיו bar");
+        DocumentaryUnit doc = new BundleDAO(graph).create(b1, DocumentaryUnit.class);
+        assertEquals("foo_ארכיו_bar", doc.getId());
     }
 }

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -286,11 +286,11 @@ public class BundleTest {
         assertNull(bundle.getId());
         assertNull(bundle.getRelations(
                 Ontology.DESCRIPTION_FOR_ENTITY).get(0).getId());
-        Bundle test = bundle.generateIds(Lists.<String>newArrayList("test"));
+        Bundle test = bundle.generateIds(Lists.newArrayList("test"));
         assertTrue(test.hasGeneratedId());
         assertEquals("test-foobar", test.getId());
         Bundle desc = test.getRelations(Ontology.DESCRIPTION_FOR_ENTITY).get(0);
         assertNotNull(desc.getId());
-        assertEquals("test-foobar-en", desc.getId());
+        assertEquals("test-foobar.en", desc.getId());
     }
 }

--- a/ehri-frames/src/test/java/eu/ehri/project/test/PermissionsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/test/PermissionsTest.java
@@ -100,7 +100,8 @@ public class PermissionsTest extends AbstractFixtureTest {
                 Bundle.fromData(TestData.getTestDocBundle()), user);
         // We should be able to create another item with c1 as the scope,
         // and inherit the perms from r1
-        Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
+        Bundle bundle = Bundle.fromData(TestData.getTestDocBundle())
+                .withDataValue(Ontology.IDENTIFIER_KEY, "some-other-id");
         DocumentaryUnit c2 = views.setScope(c1).create(bundle, user);
         assertNotNull(c2);
     }

--- a/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
@@ -2,13 +2,13 @@ package eu.ehri.project.tools;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
+import eu.ehri.project.models.idgen.DescriptionIdGenerator;
 import eu.ehri.project.models.idgen.IdGeneratorUtils;
 import eu.ehri.project.test.AbstractFixtureTest;
 import eu.ehri.project.utils.Slugify;
@@ -112,9 +112,9 @@ public class IdRegeneratorTest extends AbstractFixtureTest {
         assertNotNull(desc);
         String newDescId = String.format("%s%s%s%s%s",
                 doc.getId(),
-                IdGeneratorUtils.HIERARCHY_SEPARATOR,
+                DescriptionIdGenerator.DESCRIPTION_SEPARATOR,
                 desc.getLanguageOfDescription(),
-                IdGeneratorUtils.SLUG_REPLACE,
+                IdGeneratorUtils.HIERARCHY_SEPARATOR,
                 Slugify.slugify(desc.getDescriptionCode(), IdGeneratorUtils.SLUG_REPLACE));
         assertEquals(newDescId, desc.getId());
         // Doing it again should do nothing...

--- a/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/tools/IdRegeneratorTest.java
@@ -1,12 +1,17 @@
 package eu.ehri.project.tools;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
+import eu.ehri.project.models.idgen.IdGeneratorUtils;
 import eu.ehri.project.test.AbstractFixtureTest;
+import eu.ehri.project.utils.Slugify;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -102,6 +107,16 @@ public class IdRegeneratorTest extends AbstractFixtureTest {
         assertTrue(manager.exists("nl-r1-c1"));
         // It shouldn't actually do anything by default...
         assertEquals(remap.get().get(1), doc.getId());
+        // The descriptions should also be renamed...
+        DocumentDescription desc = Iterables.getFirst(doc.getDocumentDescriptions(), null);
+        assertNotNull(desc);
+        String newDescId = String.format("%s%s%s%s%s",
+                doc.getId(),
+                IdGeneratorUtils.HIERARCHY_SEPARATOR,
+                desc.getLanguageOfDescription(),
+                IdGeneratorUtils.SLUG_REPLACE,
+                Slugify.slugify(desc.getDescriptionCode(), IdGeneratorUtils.SLUG_REPLACE));
+        assertEquals(newDescId, desc.getId());
         // Doing it again should do nothing...
         assertFalse(idRegenerator.withActualRename(true)
                 .reGenerateId(doc).isPresent());

--- a/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
@@ -22,9 +22,15 @@ public class SlugifyTest {
     }
 
     @Test
-    public void removeLeadingTrailingDashes() {
+    public void removeLeadingTrailingReplacements() {
         String bad = "-foo-bad-";
         assertEquals("foo-bad", Slugify.slugify(bad));
+    }
+
+    @Test
+    public void removeMultipleLeadingTrailingReplacements() {
+        String bad = "__foo-bad__";
+        assertEquals("foo_bad", Slugify.slugify(bad, "_"));
     }
 
     @Test

--- a/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
@@ -59,7 +59,7 @@ public class SlugifyTest {
 
     @Test
     public void removeUnsafeOrReservedChars() {
-        String unsafe = "hello |:/?#[]@*+,;=%<>{}~-() world";
+        String unsafe = "hello \"\'|:/?#[]@*+,;=%<>{}~-() world";
         assertEquals("hello-world", Slugify.slugify(unsafe));
     }
 }

--- a/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/utils/SlugifyTest.java
@@ -42,18 +42,24 @@ public class SlugifyTest {
     @Test
     public void greekTransliteration() {
         String greek = "Καλημέρα κόσμε";
-        assertEquals("kalemera-kosme", Slugify.slugify(greek));
+        assertEquals("καλημέρα-κόσμε", Slugify.slugify(greek));
     }
 
     @Test
     public void hebrewTransliteration() {
         String hebrew = "ארכיון יד ושם";
-        assertEquals("rkywn-yd-wsm", Slugify.slugify(hebrew));
+        assertEquals("ארכיון-יד-ושם", Slugify.slugify(hebrew));
     }
 
     @Test
     public void cyrillicTransliteration() {
         String cyrillic = "Кіровоградська районна";
-        assertEquals("kirovogradska-rajonna", Slugify.slugify(cyrillic));
+        assertEquals("кіровоградська-районна", Slugify.slugify(cyrillic));
+    }
+
+    @Test
+    public void removeUnsafeOrReservedChars() {
+        String unsafe = "hello |:/?#[]@*+,;=%<>{}~-() world";
+        assertEquals("hello-world", Slugify.slugify(unsafe));
     }
 }

--- a/ehri-frames/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-frames/src/test/resources/fixtures/testdata.yaml
@@ -372,10 +372,9 @@
     identifier: m19
   relationships:
     describes:
-      - id: nl-r1-m19-eng
+      - id: nl-r1-m19.eng
         type: documentDescription
         data:
-          identifier: m19-desc
           name: Documentary Unit m19
           languageCode: eng
           scopeAndContent: Some description text for m19

--- a/ehri-importers/pom.xml
+++ b/ehri-importers/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.1-SNAPSHOT</version>
+        <version>0.9.2-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-importers</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
 
     <name>Import Tools</name>
     <description>Classes for importing data.</description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.9.2-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EadImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EadImporter.java
@@ -2,6 +2,7 @@ package eu.ehri.project.importers;
 
 import com.google.common.collect.Sets;
 import com.tinkerpop.frames.FramedGraph;
+
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.PermissionDenied;
@@ -69,7 +70,7 @@ public class EadImporter extends EaImporter {
     /**
      * Import a single archdesc or c01-12 item, keeping a reference to the hierarchical depth.
      *
-     * @param itemData The data map
+     * @param itemData The raw data map
      * @param idPath The identifiers of parent documents,
      *               not including those of the overall permission scope
      * @throws ValidationError when the itemData does not contain an identifier for the unit or...
@@ -90,7 +91,7 @@ public class EadImporter extends EaImporter {
             descBundle = descBundle.withRelation(Ontology.ENTITY_HAS_DATE, new Bundle(EntityClass.DATE_PERIOD, dpb));
         }
         for (Map<String, Object> rel : extractRelations(itemData)) {//, (String) unit.getErrors().get(IdentifiableEntity.IDENTIFIER_KEY)
-            logger.debug("relation found: " + rel.get(Ontology.NAME_KEY));
+            logger.debug("relation found: {}", rel.get(Ontology.NAME_KEY));
             for(String s : rel.keySet()){
                 logger.debug(s);
             }
@@ -102,12 +103,13 @@ public class EadImporter extends EaImporter {
             for(String u : unknowns.keySet()){
                 unknownProperties.append(u);
             }
-            logger.info("Unknown Properties found: " + unknownProperties.toString());
+            logger.debug("Unknown Properties found: {}", unknownProperties.toString());
             descBundle = descBundle.withRelation(Ontology.HAS_UNKNOWN_PROPERTY, new Bundle(EntityClass.UNKNOWN_PROPERTY, unknowns));
         }
+
         // extractDocumentaryUnit does not throw ValidationError on missing ID
         Bundle unit = new Bundle(unitEntity, extractDocumentaryUnit(itemData));
-        
+
         // Check for missing identifier, throw an exception when there is no ID.
         if (unit.getDataValue(Ontology.IDENTIFIER_KEY) == null) {
             throw new ValidationError(unit, Ontology.IDENTIFIER_KEY,
@@ -235,7 +237,7 @@ public class EadImporter extends EaImporter {
             } catch (ItemNotFound ex) {
                 throw new ValidationError(unit, "item not found exception", ex.getMessage());
             }
-        } else {
+        } else { // else we create a new bundle.
             return unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
         }
     }
@@ -243,13 +245,13 @@ public class EadImporter extends EaImporter {
     /**
      * subclasses can override this method to cater to their special needs for UndeterminedRelationships
      * by default, it expects something like this in the original EAD:
-     * 
+     *
      * <persname source="terezin-victims" authfilenumber="PERSON.ITI.1514982">Kien,
-                        Leonhard (* 11.5.1886)</persname>
+     *                   Leonhard (* 11.5.1886)</persname>
      *
      * it works in unison with the extractRelations() method. 
-     * 
-                        * 
+     *
+     *
      * @param unit
      * @param descBundle - not used
      * @throws ValidationError 

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EadImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EadImporter.java
@@ -19,11 +19,14 @@ import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.models.cvoc.Vocabulary;
+import eu.ehri.project.models.idgen.DescriptionIdGenerator;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.persistence.BundleDAO;
 import eu.ehri.project.persistence.Mutation;
 import eu.ehri.project.persistence.Serializer;
+import eu.ehri.project.utils.Slugify;
 import eu.ehri.project.views.impl.CrudViews;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,38 +143,47 @@ public class EadImporter extends EaImporter {
 
 
     }
-/**
-     * finds any bundle in the graph with the same ObjectIdentifier.
-     * if it exists it replaces the Description in the given language, else it just saves it
+
+    /**
+     * Finds any bundle in the graph with the same ObjectIdentifier.
+     * If there is no bundle with this identifier, it is created.
+     * If it exists and a Description in the given language exists from the same source file,
+     * the description is replaced. If the description is from another source, it is added to the
+     * bundle's descriptions.
      *
-     * @param unit       - the DocumentaryUnit to be saved
-     * @param descBundle - the documentsDescription to replace any previous ones with this language
+     * @param unit       the DocumentaryUnit to be saved
+     * @param descBundle the documentsDescription to replace any previous ones with this language
+     * @param idPath     the ID path of this bundle (will be relative to the ID path of the permission scope)
      * @return A bundle with description relationships merged.
      * @throws ValidationError
      */
-
     protected Bundle mergeWithPreviousAndSave(Bundle unit, Bundle descBundle, List<String> idPath) throws ValidationError {
         final String languageOfDesc = descBundle.getDataValue(Ontology.LANGUAGE_OF_DESCRIPTION);
         final String thisSourceFileId = descBundle.getDataValue(Ontology.SOURCEFILE_KEY);
+
+        logger.debug("merging: descBundle's language = {}, sourceFileId = {}",
+                languageOfDesc, thisSourceFileId);
         /*
          * for some reason, the idpath from the permissionscope does not contain the parent documentary unit.
          * TODO: so for now, it is added manually
          */
         List<String> lpath = new ArrayList<String>();
-        for(String p : getPermissionScope().idPath()){
+        for (String p : getPermissionScope().idPath()) {
             lpath.add(p);
         }
-        for(String p : idPath){
+        for (String p : idPath) {
             lpath.add(p);
         }
-        Bundle withIds = unit.generateIds(lpath);                
-        
-        if (manager.exists(withIds.getId())) {
+        Bundle unitWithIds = unit.generateIds(lpath);                
+        logger.debug("merging: docUnit's graph id = {}", unitWithIds.getId());
+        // If the bundle exists, we merge
+        if (manager.exists(unitWithIds.getId())) {
             try {
-                //read the current item’s bundle
+                // read the current item’s bundle
                 Bundle oldBundle = mergeSerializer
-                        .vertexFrameToBundle(manager.getVertex(withIds.getId()));
-                //filter out dependents that a) are descriptions, b) have the same language/code
+                        .vertexFrameToBundle(manager.getVertex(unitWithIds.getId()));
+
+                // filter out dependents that a) are descriptions, b) have the same language/code
                 Bundle.Filter filter = new Bundle.Filter() {
                     @Override
                     public boolean remove(String relationLabel, Bundle bundle) {
@@ -186,24 +198,36 @@ public class EadImporter extends EaImporter {
                 };
                 Bundle filtered = oldBundle.filterRelations(filter);
                 
-                //if this desc-id already exists, but with a different sourceFileId, 
-                //change the desc-id
-                String defaultDescIdentifier= withIds.getId()+"-"+languageOfDesc.toLowerCase();
-                String newDescIdentifier=withIds.getId()+"-"+thisSourceFileId.toLowerCase().replace("#", "-");
-                if(manager.exists(newDescIdentifier)){
-                        descBundle=descBundle.withDataValue(Ontology.IDENTIFIER_KEY, newDescIdentifier);
-                } else if(manager.exists(defaultDescIdentifier)){
+                // if this desc-id already exists, but with a different sourceFileId, 
+                // change the desc-id
+                String defaultDescIdentifier = unitWithIds.getId() + "-" + languageOfDesc.toLowerCase();
+                logger.debug("merging: defaultDescIdentifier = {}", defaultDescIdentifier);
+                String newDescIdentifier = defaultDescIdentifier + "-" + Slugify.slugify(thisSourceFileId);
+                logger.debug("merging: newDescIdentifier = {}", newDescIdentifier);
+                String generatedId = DescriptionIdGenerator.INSTANCE.generateId(lpath, filtered);
+                logger.debug("merging: generated ID = {}", generatedId);
+                // First see whether this has been done before and a desc with the new id exists
+                if (manager.exists(newDescIdentifier)) {
+                    descBundle = descBundle.withDataValue(Ontology.IDENTIFIER_KEY, newDescIdentifier);
+                    String anotherGeneratedId = DescriptionIdGenerator.INSTANCE.generateId(lpath, descBundle);
+                    logger.debug("merging: new desc ID exists, new generated ID = {}", anotherGeneratedId);
+                } else if (manager.exists(defaultDescIdentifier)) {
                     Bundle oldDescBundle = mergeSerializer
                         .vertexFrameToBundle(manager.getVertex(defaultDescIdentifier));
                     //if the previous had NO sourcefile_key OR it was different:
-                    if(oldDescBundle.getDataValue(Ontology.SOURCEFILE_KEY) == null
-                            || ! thisSourceFileId.equals(oldDescBundle.getDataValue(Ontology.SOURCEFILE_KEY).toString())){
-                        descBundle=descBundle.withDataValue(Ontology.IDENTIFIER_KEY, newDescIdentifier);
-                        logger.info("other description found ("+defaultDescIdentifier+"), creating new description id: " + descBundle.getDataValue(Ontology.IDENTIFIER_KEY).toString());
+                    if (oldDescBundle.getDataValue(Ontology.SOURCEFILE_KEY) == null
+                            || ! thisSourceFileId.equals(oldDescBundle.getDataValue(Ontology.SOURCEFILE_KEY).toString())) {
+                        descBundle = descBundle.withDataValue(Ontology.IDENTIFIER_KEY, thisSourceFileId);
+                        logger.info("other description found ({}), creating new description id: {}",
+                                defaultDescIdentifier,
+                                descBundle.getDataValue(Ontology.IDENTIFIER_KEY).toString()
+                                );
+                        String anotherGeneratedId = DescriptionIdGenerator.INSTANCE.generateId(lpath, descBundle);
+                        logger.debug("merging: def desc ID exists, source file differs, another generated ID = {}", anotherGeneratedId);
                     }
                 }
 
-                return withIds.withRelations(filtered.getRelations())
+                return unitWithIds.withRelations(filtered.getRelations())
                         .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
             } catch (SerializationError ex) {

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
@@ -30,8 +30,14 @@ public class AbstractImporterTest extends AbstractFixtureTest {
      * Shared import manager
      */
     protected AbstractImportManager importManager;
+
+    /**
+     * Test repository, initialised in test setup using TEST_REPO identifier.
+     */
     protected Repository repository;
-    // Depends on fixtures
+    /**
+     * Test repository identifier. Depends on fixtures
+     */
     protected final String TEST_REPO = "r1";
 
     /**
@@ -114,11 +120,27 @@ public class AbstractImporterTest extends AbstractFixtureTest {
         }
     }
 
+    /**
+     * Get a Vertex from the FramedGraph using its unit ID.
+     * @see {@link eu.ehri.project.definitions.Ontology#IDENTIFIER_KEY}
+     * @param graph the graph to search
+     * @param identifier the Vertex's 'human readable' identifier
+     * @return the first Vertex with the given identifier
+     * @throws NoSuchElementException when there are no vertices with this identifier
+     */
     protected Vertex getVertexByIdentifier(FramedGraph<?> graph, String identifier) {
         Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY, identifier);
         return docs.iterator().next();
     }
 
+    /**
+     * Get a Vertex from the FramedGraph using its graph ID.
+     * @see {@link eu.ehri.project.models.annotations.EntityType#ID_KEY}
+     * @param graph the graph to search
+     * @param id the Vertex's generated, slugified identifier
+     * @return the first Vertex with the given identifier
+     * @throws NoSuchElementException when there are no vertices with this identifier
+     */
     protected Vertex getVertexById(FramedGraph<?> graph, String id) {
         Iterable<Vertex> docs = graph.getVertices(EntityType.ID_KEY, id);
         return docs.iterator().next();

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
+import java.util.NoSuchElementException;
 
 /**
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Bbwo2HandlerTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Bbwo2HandlerTest.java
@@ -55,7 +55,7 @@ public class Bbwo2HandlerTest extends AbstractImporterTest {
         vocabulary.addItem(concept_716);
         
         
-        Vocabulary vocabularyTest = manager.getFrame("niod-trefwoorden", Vocabulary.class);
+        Vocabulary vocabularyTest = manager.getFrame("niod_trefwoorden", Vocabulary.class);
         assertNotNull(vocabularyTest);
 
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveSplitTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveSplitTest.java
@@ -63,8 +63,8 @@ public class BundesarchiveSplitTest extends AbstractImporterTest{
                 getVertexByIdentifier(graph,ARCHDESC),
                 DocumentaryUnit.class);
 
-        // Test ID generation and hierarchy
-        assertEquals("nl-r1-ns-1", archUnit.getId());
+        // Test ID generation andhierarchy
+        assertEquals("nl-r1-ns_1", archUnit.getId());
         assertTrue(archUnit.asVertex().getPropertyKeys().contains(Ontology.OTHER_IDENTIFIERS));
 
         assertNull(archUnit.getParent());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAATest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAATest.java
@@ -88,9 +88,9 @@ public class CegesomaAATest extends AbstractImporterTest{
                 DocumentaryUnit.class);
 
         // Test ID generation is correct
-        assertEquals("nl-r1-aa-1134-1234", c1.getId());
-        assertEquals(c1.getId() + "-aa-1134-32", c2_1.getId());
-        assertEquals(c1.getId() + "-aa-1134-34", c2_2.getId());
+        assertEquals("nl-r1-aa_1134-1234", c1.getId());
+        assertEquals(c1.getId() + "-aa_1134_32", c2_1.getId());
+        assertEquals(c1.getId() + "-aa_1134_34", c2_2.getId());
 
         /**
          * Test titles

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAraTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAraTest.java
@@ -84,9 +84,9 @@ public class CegesomaAraTest extends AbstractImporterTest {
                 DocumentaryUnit.class);
 
         // Test ID generation is correct
-        assertEquals("nl-r1-aa-1134-1234", c1.getId());
-        assertEquals(c1.getId() + "-aa-1134-32", c2_1.getId());
-        assertEquals(c1.getId() + "-aa-1134-34", c2_2.getId());
+        assertEquals("nl-r1-aa_1134-1234", c1.getId());
+        assertEquals(c1.getId() + "-aa_1134_32", c2_1.getId());
+        assertEquals(c1.getId() + "-aa_1134_34", c2_2.getId());
 
         for (String key : archdesc.asVertex().getPropertyKeys()) {
             logger.debug(key + " " + archdesc.asVertex().getProperty(key));

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaCATest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaCATest.java
@@ -58,7 +58,7 @@ public class CegesomaCATest extends AbstractImporterTest{
                 DocumentaryUnit.class);
 
         // Test ID generation is correct
-        assertEquals("nl-r1-ca-fe-1437", archdesc.getId());
+        assertEquals("nl-r1-ca_fe_1437", archdesc.getId());
 
         /**
          * Test titles

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomMultiLeveledTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomMultiLeveledTest.java
@@ -66,7 +66,7 @@ private final String UN_REL = "HR-HDA145corporateBodyAccessCroatianStateArchive"
         DocumentaryUnit unit = graph.frame(docs.iterator().next(), DocumentaryUnit.class);
 
         // Check unit ID
-        String targetUnitId = "nl-r1-hr-r000382hr-hr-hda-1551";
+        String targetUnitId = "nl-r1-hr_r000382hr_hr_hda_1551";
         assertEquals(targetUnitId, unit.getId());
 
         for(Description d : unit.getDocumentDescriptions())
@@ -83,8 +83,8 @@ private final String UN_REL = "HR-HDA145corporateBodyAccessCroatianStateArchive"
         assertEquals(unit, child2.getPermissionScope());
 
         // Check child IDs
-        assertEquals(targetUnitId + "-hr-hda-145", child1.getId());
-        assertEquals(targetUnitId + "-hr-hda-223", child2.getId());
+        assertEquals(targetUnitId + "-hr_hda_145", child1.getId());
+        assertEquals(targetUnitId + "-hr_hda_223", child2.getId());
 
         List<SystemEvent> actions = toList(unit.getHistory());
         // Check we've only got one action

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IfzTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IfzTest.java
@@ -84,9 +84,9 @@ public class IfzTest extends AbstractImporterTest{
                 DocumentaryUnit.class);
 
         // Test ID generation is correct
-        assertEquals("nl-r1-g-g-1", c1.getId());
-        assertEquals(c1.getId() + "-g-2", c2.getId());
-        assertEquals(c2.getId() + "-mb-35-10", c3_2.getId());
+        assertEquals("nl-r1-g-1", c1.getId());
+        assertEquals(c1.getId() + "-g_2", c2.getId());
+        assertEquals(c2.getId() + "-mb_35_10", c3_2.getId());
 
         /**
          * Test titles
@@ -98,7 +98,7 @@ public class IfzTest extends AbstractImporterTest{
             List<String> s = new ArrayList<String>();
             s.add("TO BE FILLED with selection");
             s.add("IfZ");
-            assertEquals(s, dd.asVertex().getProperty("processInfo"));
+            assertEquals(s, dd.asVertex().<List<String>>getProperty("processInfo"));
             assertEquals("recordgrp", dd.asVertex().getProperty("levelOfDescription"));
             
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
@@ -101,7 +101,7 @@ public class ItsTest extends AbstractImporterTest {
         assertTrue(docs.iterator().hasNext());
         DocumentaryUnit unit = graph.frame(docs.iterator().next(), DocumentaryUnit.class);
 
-        assertEquals("nl-r1-de-its-ous-1-1-7", unit.getId());
+        assertEquals("nl-r1-de_its_ous_1_1_7", unit.getId());
         // The arch has 1 c01 direct child (and 2 c02 "grandchildren", but these are not counted)
         for (DocumentaryUnit d : unit.getChildren()) {
             logger.debug("Child: " + d.getIdentifier());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesV2Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesV2Test.java
@@ -60,7 +60,7 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         */
         assertEquals(count+7, getNodeCount(graph));
         printGraph(graph);
-        HistoricalAgent person = manager.getFrame("ehri-pers-000051", HistoricalAgent.class);
+        HistoricalAgent person = manager.getFrame("ehri_pers_000051", HistoricalAgent.class);
         assertEquals(2, ((List)person.asVertex().getProperty(Ontology.OTHER_IDENTIFIERS)).size());
         
         for(Description d : person.getDescriptions()){
@@ -100,7 +100,7 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         */
         assertEquals(count+7, getNodeCount(graph));
         printGraph(graph);
-        HistoricalAgent person = manager.getFrame("ehri-pers-000051", HistoricalAgent.class);
+        HistoricalAgent person = manager.getFrame("ehri_pers_000051", HistoricalAgent.class);
         for(Description d : person.getDescriptions()){
             assertEquals("deu", d.getLanguageOfDescription());
             assertTrue(d.asVertex().getProperty("otherFormsOfName") instanceof List);
@@ -123,7 +123,7 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         vocabulary.addItem(concept_716);
         
         
-        Vocabulary vocabularyTest = manager.getFrame("fast-keywords", Vocabulary.class);
+        Vocabulary vocabularyTest = manager.getFrame("fast_keywords", Vocabulary.class);
         assertNotNull(vocabularyTest);
 
         
@@ -152,7 +152,7 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         */
         assertEquals(count+8, getNodeCount(graph));
 //        printGraph(graph);
-        HistoricalAgent person = manager.getFrame("ehri-pers-000051", HistoricalAgent.class);
+        HistoricalAgent person = manager.getFrame("ehri_pers_000051", HistoricalAgent.class);
         for (Description d : person.getDescriptions()) {
             for (UndeterminedRelationship rel : d.getUndeterminedRelationships()) {
                 if (rel.getRelationshipType().equals("subjectAccess")) {

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/StadsarchiefAdamTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/StadsarchiefAdamTest.java
@@ -84,12 +84,13 @@ public class StadsarchiefAdamTest extends AbstractImporterTest{
                 DocumentaryUnit.class);
 
         // Test correct ID generation
-        assertEquals("nl-r1-NL-SAA-22626598".toLowerCase(), archdesc.getId());
-        assertEquals("nl-r1-NL-SAA-22626598-NL-SAA-22730932".toLowerCase(), c1.getId());
-        assertEquals("nl-r1-NL-SAA-22626598-NL-SAA-22730932-NL-SAA-22730310".toLowerCase(), c2.getId());
-        assertEquals("nl-r1-NL-SAA-22626598-NL-SAA-22730932-NL-SAA-22730311-NL-SAA-22752512".toLowerCase(), c3.getId());
-        assertEquals("nl-r1-NL-SAA-22626598-NL-SAA-22730932-NL-SAA-22730311".toLowerCase(), c2_1.getId());
-        assertEquals("nl-r1-NL-SAA-22626598-NL-SAA-22730932-NL-SAA-22730311-NL-SAA-22752538".toLowerCase(), c3_2.getId());
+        assertEquals("nl-r1-NL_SAA_22626598".toLowerCase(), archdesc.getId());
+        assertEquals("nl-r1-NL_SAA_22626598-NL_SAA_22730932".toLowerCase(), c1.getId());
+        assertEquals("nl-r1-NL_SAA_22626598-NL_SAA_22730932-NL_SAA_22730310".toLowerCase(), c2.getId());
+        assertEquals("nl-r1-NL_SAA_22626598-NL_SAA_22730932-NL_SAA_22730311-NL_SAA_22752512".toLowerCase(), c3.getId());
+        assertEquals("nl-r1-NL_SAA_22626598-NL_SAA_22730932-NL_SAA_22730311".toLowerCase(), c2_1.getId());
+        assertEquals("nl-r1-NL_SAA_22626598-NL_SAA_22730932-NL_SAA_22730311-NL_SAA_22752538".toLowerCase(), c3_2
+                .getId());
 
         // Check permission scope and hierarchy
         assertNull(archdesc.getParent());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/VirtualEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/VirtualEadTest.java
@@ -18,6 +18,8 @@ import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.impl.CrudViews;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,13 +32,13 @@ public class VirtualEadTest extends AbstractImporterTest{
     private static final Logger logger = LoggerFactory.getLogger(VirtualEadTest.class);
     protected final String TEST_REPO = "mike";
     protected final String XMLFILE = "wp2_virtualcollection.xml";
-    private static final String REPO1= "il-002777";
-    private static final String REPO2= "cz-002302";
-    private static final String UNIT1 ="wp2-bt";
+    private static final String REPO1= "002777";
+    private static final String REPO2= "002302";
+    private static final String UNIT1 ="wp2_bt";
     private static final String UNIT2 ="vzpomínky pro EHRI";
     
     private static final String ARCHDESC = "ehri terezin research guide";
-    private static final String C01_VirtualLevel = "vc-tm";
+    private static final String C01_VirtualLevel = "vc_tm";
     private static final String C02 = REPO2+"-"+UNIT2;
     
     Repository repository1, repository2;
@@ -60,32 +62,32 @@ public void setStageTest() throws PermissionDenied, ValidationError {
         final String logMessage = "Importing an EAD as a Virtual collection";
 
         origCount = getNodeCount(graph);
-        
+
  // Before...
-//       List<VertexProxy> graphState1 = getGraphState(graph);
+       List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
 //	ImportLog log = 
                 new SaxImportManager(graph, agent, validUser, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc.properties")).importFile(ios, logMessage);
          // After...
-//       List<VertexProxy> graphState2 = getGraphState(graph);
-//       GraphDiff diff = diffGraph(graphState1, graphState2);
-//       diff.printDebug(System.out);
+       List<VertexProxy> graphState2 = getGraphState(graph);
+       GraphDiff diff = diffGraph(graphState1, graphState2);
+       diff.printDebug(System.out);
 
 //        printGraph(graph);
         // How many new nodes will have been created? We should have
         // - 2 more VirtualUnits (archdesc, 1 child (other 2 children are already existing DUs))
        	// - 2 more DocumentDescription
-        // - 3 more import Event links (4 for every Unit, 1 for the User)
+        // - 3 more import Event links (2 for every Unit, 1 for the User)
         // - 1 more import Event
         int newCount = origCount + 8; 
         assertEquals(newCount, getNodeCount(graph));
-        
+
         VirtualUnit toplevel = graph.frame(getVertexByIdentifier(graph, ARCHDESC), VirtualUnit.class);
         assertEquals(agent, toplevel.getAuthor());
         assertEquals("ehri terezin research guide", toplevel.getIdentifier());
         assertEquals(1, toList(toplevel.getIncludedUnits()).size());
 
-        DocumentaryUnit c1_vreferrer = graph.frame(getVertexById(graph, UNIT1), DocumentaryUnit.class);
+        DocumentaryUnit c1_vreferrer = manager.getFrame(UNIT1, DocumentaryUnit.class);
         for(AbstractUnit d : toplevel.getIncludedUnits()){
             assertEquals(c1_vreferrer, d);
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
@@ -56,7 +56,7 @@ public class Wp2BtEadTest extends AbstractImporterTest {
         vocabulary.addItem(concept_716);
         
         
-        Vocabulary vocabularyTest = manager.getFrame("wp2-keywords", Vocabulary.class);
+        Vocabulary vocabularyTest = manager.getFrame("wp2_keywords", Vocabulary.class);
         assertNotNull(vocabularyTest);
         
         final String logMessage = "Importing Beit Terezin EAD";
@@ -123,7 +123,7 @@ public class Wp2BtEadTest extends AbstractImporterTest {
         //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 6 items
         assertEquals(6, logVC.getCreated());
-        assertTrue(logVC.getAction() instanceof SystemEvent);
+        assertTrue(logVC.getAction() != null);
         assertEquals(logMessage, logVC.getAction().getLogMessage());
 
         //assert keywords are matched to cvocs

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2JmpEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2JmpEadTest.java
@@ -5,7 +5,6 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
-import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.events.SystemEvent;
 import java.io.InputStream;
@@ -22,25 +21,23 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
 
     private static final Logger logger = LoggerFactory.getLogger(Wp2JmpEadTest.class);
     protected final String SINGLE_EAD = "wp2_jmp_ead.xml";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
     // Depends on hierarchical-ead.xml
     protected final String C1 = "COLLECTION.JMP.SHOAH/T/2";
     protected final String C2 = "COLLECTION.JMP.SHOAH/T/2/A";
     protected final String C3 = "COLLECTION.JMP.SHOAH/T/2/A/1";
     protected final String C6 = "DOCUMENT.JMP.SHOAH/T/2/A/1a/028";
+    // <test-country>-<test-repo>-<__ID__>
+    protected final String C6_ID = "nl-r1-collection_jmp_shoah_t-2-a-1-a-028-document_jmp_shoah_t_2_a_1a_028";
     protected final String FONDS = "COLLECTION.JMP.SHOAH/T";
 
     @Test
     public void testImportItemsT() throws Exception {
 
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
-        
         final String logMessage = "Importing JMP EAD";
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
         
         importManager.setTolerant(Boolean.TRUE);
         
@@ -69,17 +66,21 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
         DocumentaryUnit c1 = graph.frame(getVertexByIdentifier(graph, C1), DocumentaryUnit.class);
         DocumentaryUnit c2 = graph.frame(getVertexByIdentifier(graph, C2), DocumentaryUnit.class);
         DocumentaryUnit c3 = graph.frame(getVertexByIdentifier(graph, C3), DocumentaryUnit.class);
-        DocumentaryUnit c6 = graph.frame(getVertexByIdentifier(graph, C6), DocumentaryUnit.class);
 
         assertEquals(fonds, c1.getParent());
         assertEquals(c1, c2.getParent());
         assertEquals(c2, c3.getParent());
-        
+
+        DocumentaryUnit c6ByIdentifier = graph.frame(getVertexByIdentifier(graph, C6), DocumentaryUnit.class);
+        logger.debug(c6ByIdentifier.getId());
+        DocumentaryUnit c6ById = graph.frame(getVertexById(graph, C6_ID), DocumentaryUnit.class);
+        assertEquals(c6ByIdentifier, c6ById);
+
         // Ensure the import action has the right number of subjects.
         //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 6 items
         assertEquals(7, log.getCreated());
-        assertTrue(log.getAction() instanceof SystemEvent);
+        assertTrue(log.getAction() != null);
         assertEquals(logMessage, log.getAction().getLogMessage());
 
 //        //assert keywords are matched to cvocs
@@ -105,7 +106,7 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
         assertEquals(log.getChanged(), subjects.size());
 
         // Check permission scopes
-        assertEquals(agent, fonds.getPermissionScope());
+        assertEquals(repository, fonds.getPermissionScope());
         assertEquals(fonds, c1.getPermissionScope());
         assertEquals(c1, c2.getPermissionScope());
         assertEquals(c2, c3.getPermissionScope());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
@@ -80,7 +80,7 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         // - 11 UndeterminedRelationship, 0 0 0 11
         // - 5 more import Event links (4 for every Unit, 1 for the User)
         // - 1 more import Event
-       
+
         // - 1 Link as resolved relationship 
 
 //printGraph(graph);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
@@ -35,12 +35,12 @@ public class Wp2YvEadTest extends AbstractImporterTest {
     protected final String C1 = "O.64.2-A.";
     protected final String C2 = "O.64.2-A.A.";
     protected final String C3 = "3685529";
+    protected final String C3_ID = "nl-r1-o_64_2-a-a-3685529";
     protected final String FONDS = "O.64.2";
 
     @Test
     public void testImportItemsT() throws Exception {
 
-        Repository agent = manager.getFrame(TEST_REPO, Repository.class);
         Bundle vocabularyBundle = new Bundle(EntityClass.CVOC_VOCABULARY)
                                 .withDataValue(Ontology.IDENTIFIER_KEY, "WP2_keywords")
                                 .withDataValue(Ontology.NAME_KEY, "WP2 Keywords");
@@ -51,22 +51,21 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         logger.debug(vocabulary.getId());
         Concept concept_288 = new CrudViews<Concept>(graph, Concept.class).create(conceptBundle, validUser);
         vocabulary.addItem(concept_288);
-        
-        
-        Vocabulary vocabularyTest = manager.getFrame("wp2-keywords", Vocabulary.class);
+
+        Vocabulary vocabularyTest = manager.getFrame("wp2_keywords", Vocabulary.class);
         assertNotNull(vocabularyTest);
-        
+
         final String logMessage = "Importing Yad Vashem EAD";
 
         int count = getNodeCount(graph);
 // Before...
-       List<VertexProxy> graphState1 = getGraphState(graph);
+        List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
-        
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
+
         importManager.setTolerant(Boolean.TRUE);
-        
+
         ImportLog log = importManager.importFile(ios, logMessage);
  // After...
        List<VertexProxy> graphState2 = getGraphState(graph);
@@ -100,7 +99,9 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         assertEquals(fonds, c1.getParent());
         assertEquals(c1, c2.getParent());
         assertEquals(c2, c3.getParent());
-        
+        // Expect no duplication of ID parts
+        assertEquals(C3_ID, c3.getId());
+
         // Ensure the import action has the right number of subjects.
         //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 6 items
@@ -133,7 +134,7 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         assertEquals(log.getChanged(), subjects.size());
 
         // Check permission scopes
-        assertEquals(agent, fonds.getPermissionScope());
+        assertEquals(repository, fonds.getPermissionScope());
         assertEquals(fonds, c1.getPermissionScope());
         assertEquals(c1, c2.getPermissionScope());
         assertEquals(c2, c3.getPermissionScope());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
@@ -34,9 +34,15 @@ public class YadVashemTest extends AbstractImporterTest{
     
     protected final String SOURCE_FILE_ID="10660245#ENG";
     
-
+    /**
+     * The test repository contains a unit (loaded from the fixtures) that matches 
+     * the unit described in the test file that is imported here.
+     * This test checks that the existing description (which has a different source)
+     * is untouched and the description from the test file is added.
+     * @throws Exception
+     */
     @Test
-    public void testWithExistingDescription() throws Exception{
+    public void testWithExistingDescription() throws Exception {
         final String logMessage = "Importing a single EAD";
         DocumentaryUnit m19 = manager.getFrame("nl-r1-m19", DocumentaryUnit.class);
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
@@ -76,7 +76,7 @@ public class YadVashemTest extends AbstractImporterTest{
         assertEquals(2, toList(m19.getDocumentDescriptions()).size());
         for (DocumentDescription desc : m19.getDocumentDescriptions()) {
             logger.debug("Document description graph ID: {}", desc.getId());
-            assertTrue(desc.getId().equals("nl-r1-m19-eng") || desc.getId().equals("nl-r1-m19-eng_c1_eng"));
+            assertTrue(desc.getId().equals("nl-r1-m19.eng") || desc.getId().equals("nl-r1-m19.eng-c1_eng"));
         }
     }
 

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
@@ -68,6 +68,10 @@ public class YadVashemTest extends AbstractImporterTest{
 
         assertEquals(count + 15, getNodeCount(graph));
         assertEquals(2, toList(m19.getDocumentDescriptions()).size());
+        for (DocumentDescription desc : m19.getDocumentDescriptions()) {
+            logger.debug("Document description graph ID: {}", desc.getId());
+            assertTrue(desc.getId().equals("nl-r1-m19-eng") || desc.getId().equals("nl-r1-m19-eng_c1_eng"));
+        }
     }
 
     @Test 

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/EventsSkosImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/EventsSkosImporterTest.java
@@ -150,7 +150,7 @@ public class EventsSkosImporterTest extends AbstractImporterTest {
         assertEquals(count + 13, getNodeCount(graph));
 //        printGraph(graph);   
         
-        Concept termJR = manager.getFrame("cvoc1-tema-866", Concept.class);
+        Concept termJR = manager.getFrame("cvoc1-tema_866", Concept.class);
         
         boolean found=false;
         for(Link desc : termJR.getLinks()){

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
@@ -135,7 +135,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
         }
         assertTrue(found);
 
-        Concept termJR = manager.getFrame("cvoc2-joodse-raad", Concept.class);
+        Concept termJR = manager.getFrame("cvoc2-joodse_raad", Concept.class);
         
         for(Link desc : termJR.getLinks()){
             assertTrue(desc.asVertex().getPropertyKeys().contains("type"));

--- a/ehri-importers/src/test/resources/PersonalitiesV2.xml
+++ b/ehri-importers/src/test/resources/PersonalitiesV2.xml
@@ -93,7 +93,7 @@
                 <placeEntry>Munich, Germany</placeEntry>
             </place>
             <localDescription localType="subject">
-                <term vocabularySource="fast-keywords" xml:id="fst894382"
+                <term vocabularySource="fast_keywords" xml:id="fst894382"
                     xmlns:xml="http://www.w3.org/XML/1998/namespace">Diplomatic documents
                 </term>
             </localDescription>

--- a/ehri-importers/src/test/resources/YV_c1.xml
+++ b/ehri-importers/src/test/resources/YV_c1.xml
@@ -78,7 +78,7 @@
                          era="ce"
                          calendar="gregorian"
                          normal="1942-09-18/1943-06-02">18/09/1942-02/06/1943</unitdate>
-               <unitid>M.19/7</unitid>
+               <unitid>m19/7</unitid>
                <unittitle>Correspondence of Rabbi A. S. Levisson with relatives of inmates in Westerbork, the Amsterdam Joodse Raad (Jewish Council) and Joodse Raad branches regarding the condition of inmates in the camp and other, exemptions from deportations and deportation lists of Jews in the Friesland district, 1942-1943</unittitle>
             </did>
             <custodhist>
@@ -101,7 +101,7 @@
                             era="ce"
                             calendar="gregorian"
                             normal="1943-05-18/1943-05-18">18/05/1943-18/05/1943</unitdate>
-                  <unitid>M.19/7.1</unitid>
+                  <unitid>m19/7.1</unitid>
                   <unittitle>List of Jews who perished in Westerbork, 12-18/05/1943</unittitle>
                </did>
                <scopecontent>

--- a/ehri-importers/src/test/resources/bbwo2.xml
+++ b/ehri-importers/src/test/resources/bbwo2.xml
@@ -4,7 +4,8 @@
   <dc:description xmlns="http://www.openarchives.org/OAI/2.0/">More refugee children arrive from Germany - in time for Christmas. Small refugees with their packs and bundles on arrival at Liverpool Street.</dc:description>
   <dc:date xmlns="http://www.openarchives.org/OAI/2.0/">23-12-1938 (Opname)</dc:date>
   <dc:subject xmlns="http://www.openarchives.org/OAI/2.0/">Joden - Zie ook: Gemengd gehuwden, Halfjoden, Kwartjoden</dc:subject>
-  <dc:subject xmlns="http://www.openarchives.org/OAI/2.0/" id="joodse-raad" source="niod-trefwoorden" type="subjectAccess" term="kinderen">Kinderen</dc:subject>
+  <dc:subject xmlns="http://www.openarchives.org/OAI/2.0/" id="joodse-raad" source="niod_trefwoorden"
+              type="subjectAccess" term="kinderen">Kinderen</dc:subject>
   <dc:subject xmlns="http://www.openarchives.org/OAI/2.0/">Vluchtelingen</dc:subject>
   <dc:coverage xmlns="http://www.openarchives.org/OAI/2.0/">Groot-Brittannië</dc:coverage>
   <dc:type xmlns="http://www.openarchives.org/OAI/2.0/">IMAGE</dc:type>

--- a/ehri-importers/src/test/resources/wp2_bt_ead_small.xml
+++ b/ehri-importers/src/test/resources/wp2_bt_ead_small.xml
@@ -57,7 +57,7 @@
                 <controlaccess>
                     <subject>personal document</subject>
                     <subject>correspondence</subject>
-                    <subject source="wp2-keywords" authfilenumber="KEYWORD.JMP.716"
+                    <subject source="wp2_keywords" authfilenumber="KEYWORD.JMP.716"
                         >Correspondence</subject>
                     <persname>Auerbach Sara</persname>
                     <persname> Auerbach Yossi</persname>

--- a/ehri-importers/src/test/resources/wp2_virtualcollection.xml
+++ b/ehri-importers/src/test/resources/wp2_virtualcollection.xml
@@ -82,13 +82,13 @@
 		<dsc>
 			<c01 level="collection">
 				<did>
-					<unitid label="ehri_main_identifier">wp2-bt</unitid>
-					<repository label="ehri_repository_vc">il-002777</repository>
+					<unitid label="ehri_main_identifier">wp2_bt</unitid>
+					<repository label="ehri_repository_vc">002777</repository>
 				</did>
 			</c01>
 			<c01 level="fonds">
 				<did>
-					<unitid label="ehri_main_identifier">vc-tm</unitid>
+					<unitid label="ehri_main_identifier">vc_tm</unitid>
 					<unittitle>Terezin Research Guide files from Terezin Memorial</unittitle>
 					<repository>Terezin Memorial</repository>
 				</did>
@@ -96,7 +96,7 @@
 				<c02 level="collection">
 					<did>
 						<unitid label="ehri_main_identifier">vzpomínky pro EHRI</unitid>
-						<repository label="ehri_repository_vc">cz-002302</repository>
+						<repository label="ehri_repository_vc">002302</repository>
 					</did>
 				</c02>
 			</c01>

--- a/ehri-importers/src/test/resources/wp2_yv_ead.xml
+++ b/ehri-importers/src/test/resources/wp2_yv_ead.xml
@@ -69,20 +69,20 @@
                             <subject>Judenrat of Ghetto Theresienstadt</subject>
                             <subject>Jewish leadership</subject>
                             <subject>Aeltestenrat --> Tagesbefehle</subject>
-                            <subject source="wp2-keywords" authfilenumber="KEYWORD.JMP.288">Daily
+                            <subject source="wp2_keywords" authfilenumber="KEYWORD.JMP.288">Daily
                                 orders</subject>
-                            <subject source="wp2-keywords" authfilenumber="KEYWORD.JMP.2"
+                            <subject source="wp2_keywords" authfilenumber="KEYWORD.JMP.2"
                                 >Judenrat</subject>
                             <geogname>Theresienstadt,Ghetto,Czechoslovakia</geogname>
-                            <geogname source="wp2-places" authfilenumber="PLACE.ČSÚ.565717"
+                            <geogname source="wp2_places" authfilenumber="PLACE.ČSÚ.565717"
                                 >Terezín</geogname>
-                            <geogname source="wp2-places" authfilenumber="PLACE.ČSÚ.586676"
+                            <geogname source="wp2_places" authfilenumber="PLACE.ČSÚ.586676"
                                 >Terezín</geogname>
-                            <geogname source="wp2-places" authfilenumber="PLACE.JMP.15">Magdeburger
+                            <geogname source="wp2_places" authfilenumber="PLACE.JMP.15">Magdeburger
                                 Kaserne/B V</geogname>
-                            <persname source="wp2-people" authfilenumber="PERSON.ITI.2009255"
+                            <persname source="wp2_people" authfilenumber="PERSON.ITI.2009255"
                                 >Zucker, Ota (* 3.10.1892)</persname>
-                            <persname source="wp2-people" authfilenumber="PERSON.ITI.1296855"
+                            <persname source="wp2_people" authfilenumber="PERSON.ITI.1296855"
                                 >Edelstein, Jacob (* 25.7.1903)</persname>
                         </controlaccess>
                     </c03>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
     <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>

--- a/src/site/markdown/identifiers.md
+++ b/src/site/markdown/identifiers.md
@@ -43,7 +43,7 @@ For example, if we import an EAD file from repository `001500` in country `us` w
 Prior to creating the hierarchical ID the local identifier is also transformed by removing all punctuation and certain
 other URI reserved characters and replacing them with at most one underscore per sequence. Leading and trailing underscores
 are then removed. Finally, the result is lower cased.
- 
+
 The final hierarchical ID is then formed by joining each transliterated local identifier with a __hyphen__ character.
 
 Relative identifiers are therefore preferred in EHRI since they provide the neatest global identifiers. However in

--- a/src/site/markdown/identifiers.md
+++ b/src/site/markdown/identifiers.md
@@ -76,17 +76,16 @@ transliteration, so if, for example, there was a hierarchy like so:
  
  - `us` => `005578` => `DOC-1` => `DOC-1 / 1` => `DOC-1 / 1 / 2` => "DOC-1 / 1 / 2 / 3"` (raw strings)
  - `us` => `005578` => `DOC-1` => ` / 1` => ` / 2` => ` / 3` (parent prefixes removed, note leading space-slash-space)
- - `us` => `005578` => `DOC_1` => `___1` => `___2` => `___3` (replace non-alphanumerics with underscores)
- - `us` => `005578` => `doc_1` => `1` => `2` => `3` (remove leading/training non-alphanumerics)
+ - `us` => `005578` => `DOC_1` => `___1` => `___2` => `___3` (replace non-characters with underscores)
+ - `us` => `005578` => `doc_1` => `1` => `2` => `3` (remove leading/training replacements)
  - `us-005578-doc_1-1-2-3` (joining sections with hyphens)
  
 ## Restrictions
 
 This scheme places some restrictions on what can be used as an identifier in an EHRI item:
 
- - it must contain some ASCII characters, or characters we can transliterate to ASCII via ICU
- - the sequence of transliterated ASCII characters, with non-alphanumerics replaced by underscores
-   and leading and trailing non-alphanumerics removed, *must be unique within the parent scope*
+ - it must contain some non-punctuation characters
+ - the sequence of characters with punctuation removed *must be unique within the parent scope*
 
 ## Trade-offs
 

--- a/src/site/markdown/identifiers.md
+++ b/src/site/markdown/identifiers.md
@@ -40,13 +40,9 @@ For example, if we import an EAD file from repository `001500` in country `us` w
 
 ### Transliteration
  
-Prior to creating the hierarchical ID the local identifier is also transliterated in the following ways:
- 
- - Hebrew, Cyrillic, and Greek characters are replaced by their ASCII "equivalents" (as provided by the [ICU project]
-  (http://site.icu-project.org/)
- - remaining sequences of one or more non-ASCII characters are replaced with __underscore__ characters
- - leading and trailing non-alphanumerics are removed
- - alphabetic characters are lower-cased
+Prior to creating the hierarchical ID the local identifier is also transformed by removing all punctuation and certain
+other URI reserved characters and replacing them with at most one underscore per sequence. Leading and trailing underscores
+are then removed. Finally, the result is lower cased.
  
 The final hierarchical ID is then formed by joining each transliterated local identifier with a __hyphen__ character.
 


### PR DESCRIPTION
This is a squashed form of PR #105 with additional changes to transliteration.

 - changes by @bencomp and @mikesname to enable shorter, de-duplicated hierarchical IDs for items with absolute (rather than relative) local identifiers
 - changed slugification strategy: explicit removal of IRI reserved chars and general punctuation, but no removal or transliteration of unicode
 - the underscore is now the replacement character for local identifiers, preserving hyphens for hierarchy separators
 - due to an issue where the ID of a child item could collide with that of one of the parent's descriptions, the delimiter separating the item-level part of a description's ID from it's language code (and possibly description code/file id) is now a period (`.`).
 - bumped version to 0.9.2-SNAPSHOT