### PR TITLE
Remove prefix from child count name, now it's not used for cache purposes

### DIFF
--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/ItemHolder.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/ItemHolder.java
@@ -4,7 +4,7 @@ package eu.ehri.project.models.base;
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public interface ItemHolder {
-    public static final String CHILD_COUNT = "_childCount";
+    public static final String CHILD_COUNT = "childCount";
 
     public long getChildCount();
 }


### PR DESCRIPTION
This prevented the frontend being able to discern the number of child items.