### PR TITLE
Renaming the child count property subtle broke event subject count cache...

### DIFF
--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/ActionManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/ActionManager.java
@@ -69,6 +69,7 @@ public final class ActionManager {
     public static final String DEBUG_TYPE = "_debugType";
     public static final String EVENT_LINK = "eventLink";
     public static final String LINK_TYPE = "_linkType";
+    public static final String SUBJECT_COUNT = "_childCount";
 
     private final FramedGraph<?> graph;
     private final GraphManager manager;
@@ -408,12 +409,12 @@ public final class ActionManager {
      * @param subjectLinkNode The subjectLinkNode node
      */
     private void addSubjectAndIncrementCount(Vertex event, Vertex subjectLinkNode) {
-        Long count = event.getProperty(ItemHolder.CHILD_COUNT);
+        Long count = event.getProperty(SUBJECT_COUNT);
         graph.addEdge(null, subjectLinkNode, event, Ontology.ENTITY_HAS_EVENT);
         if (count == null) {
-            event.setProperty(ItemHolder.CHILD_COUNT, 1L);
+            event.setProperty(SUBJECT_COUNT, 1L);
         } else {
-            event.setProperty(ItemHolder.CHILD_COUNT, count + 1L);
+            event.setProperty(SUBJECT_COUNT, count + 1L);
         }
     }
 

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/ActionManagerTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/ActionManagerTest.java
@@ -53,7 +53,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         // Check exactly one Event was created
         assertEquals(1, Iterables.count(second.getSubjects()));
         // Check item cache is correct...
-        assertEquals(1L, second.asVertex().getProperty(ItemHolder.CHILD_COUNT));
+        assertEquals(1L, second.asVertex().getProperty(ActionManager.SUBJECT_COUNT));
         assertNotNull(second.getActioner());
 
         // Check the user is correctly linked


### PR DESCRIPTION
Another subtle bug uncovered.

Renaming the child count property subtle broke event subject count cache.
    
It re-used this constant, this the property ended up named `childCount` and not `_childCount`, which did not serialize as a meta property value but as regular data. This caused some display issues with item history.
