### PR TITLE
Clean up of command line utility classes:

### DIFF
--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/BaseCommand.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/BaseCommand.java
@@ -28,35 +28,87 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 
+/**
+ * Abstract base class for commands. Provides the main
+ * entry points for interaction:
+ * </p>
+ * <ul>
+ *     <li>Set options</li>
+ *     <li>Get help</li>
+ *     <li>Get usage</li>
+ *     <li>Execute with options</li>
+ * </ul>
+ */
 public abstract class BaseCommand implements Command {
-    
-    Options options = new Options();
-    CommandLineParser parser = new PosixParser();
-        
-    protected void setCustomOptions() {}
 
+    private Options options = new Options();
+    private CommandLineParser parser = new PosixParser();
+
+    protected void setCustomOptions(Options options) {
+    }
+
+    /**
+     * Get help for this command.
+     *
+     * @return a contextual help string
+     */
     public abstract String getHelp();
+
+    /**
+     * Get usage info.
+     *
+     * @return a brief usage output
+     */
     public abstract String getUsage();
 
+    /**
+     * Execute this command with the given database and un-parsed
+     * command line arguments
+     *
+     * @param graph the graph database
+     * @param args  the raw command line arguments
+     * @return a command return code
+     * @throws Exception
+     */
     public final int exec(final FramedGraph<? extends TransactionalGraph> graph, String[] args) throws Exception {
-        setCustomOptions();
+        setCustomOptions(options);
         return execWithOptions(graph, parser.parse(options, args));
     }
+
+    /**
+     * Execute this command with the given database and parsed command
+     * line arguments.
+     *
+     * @param graph   the graph database
+     * @param cmdLine the parsed command line object
+     * @return a command return code
+     * @throws Exception
+     */
     public abstract int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws Exception;
 
     /**
      * Utility to get a parsed command line from some args. This is
      * mainly helpful for testing.
+     *
      * @param args A list of arg strings
      * @return The parsed command line
      */
     public CommandLine getCmdLine(String[] args) throws ParseException {
-        setCustomOptions();
+        setCustomOptions(options);
         return parser.parse(options, args);
     }
 
+    /**
+     * Get an optional log message given a string that may or may not
+     * be empty.
+     *
+     * @param msg a possibly null or empty string
+     * @return an optional message string
+     */
     protected Optional<String> getLogMessage(String msg) {
-        return msg.trim().isEmpty() ? Optional.<String>absent() : Optional.of(msg);
+        return (msg == null || msg.trim().isEmpty())
+                ? Optional.<String>absent()
+                : Optional.of(msg);
     }
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/Check.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/Check.java
@@ -38,6 +38,7 @@ import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.models.idgen.IdGeneratorUtils;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.util.List;
 
@@ -55,9 +56,6 @@ public class Check extends BaseCommand implements Command {
 
     final static String NAME = "check";
 
-    /**
-     * Constructor.
-     */
     public Check() {
     }
     
@@ -73,15 +71,10 @@ public class Check extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("q", "quick", false, "Quick checks only"));
     }
     
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     @SuppressWarnings("unchecked")
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/Command.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/Command.java
@@ -34,17 +34,28 @@ public interface Command {
     /**
      * Get information about the usage of the command, including
      * required and/or optional parameters.
+     *
      * @return a usage text
      */
     public String getUsage();
 
     /**
      * Execute this command with the given command line options.
-     * @param graph
-     * @param cmdLine
+     *
+     * @param graph   the graph database
+     * @param cmdLine the command line options
      * @return a status code (0 = success)
      * @throws Exception
      */
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph, CommandLine cmdLine) throws Exception;
+
+    /**
+     * Execute this command with the given arguments.
+     *
+     * @param graph the graph database
+     * @param args  the raw argument strings
+     * @return a status code (0 = success)
+     * @throws Exception
+     */
     public int exec(FramedGraph<? extends TransactionalGraph> graph, String[] args) throws Exception;
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/CountryAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/CountryAdd.java
@@ -38,24 +38,20 @@ import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.impl.LoggingCrudViews;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
  * Add a country.
- * 
  */
 public class CountryAdd extends BaseCommand implements Command {
 
     final static String NAME = "countryadd";
 
-    /**
-     * Constructor.
-     * 
-     */
     public CountryAdd() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("n", "name", true, "Country's full name"));
         options.addOption(new Option("c", "comment", false,
                 "Log message for create action action."));
@@ -71,14 +67,6 @@ public class CountryAdd extends BaseCommand implements Command {
         return "Create a new country";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     * 
-     * @throws ItemNotFound
-     * @throws DeserializationError 
-     * @throws PermissionDenied 
-     * @throws ValidationError 
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws ItemNotFound, ValidationError, PermissionDenied, DeserializationError {
@@ -96,13 +84,9 @@ public class CountryAdd extends BaseCommand implements Command {
 
         String countryId = (String) cmdLine.getArgList().get(0);
         String countryName = cmdLine.getOptionValue("n", countryId);
-//        String[] groups = {};
-//        if (cmdLine.hasOption("group")) {
-//            groups = cmdLine.getOptionValues("group");
-//        }
 
         Bundle bundle = new Bundle(EntityClass.COUNTRY,
-                Maps.<String, Object> newHashMap())
+                Maps.<String, Object>newHashMap())
                 .withDataValue(Ontology.IDENTIFIER_KEY, countryId)
                 .withDataValue(Ontology.NAME_KEY, countryName);
 

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/CsvConceptImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/CsvConceptImport.java
@@ -28,9 +28,6 @@ public class CsvConceptImport extends ImportCsvCommand implements Command {
 
     final static String NAME = "csv-concept-import";
 
-    /**
-     * Constructor.
-     */
     public CsvConceptImport() {
         super(CsvConceptImporter.class);
     }
@@ -47,7 +44,4 @@ public class CsvConceptImport extends ImportCsvCommand implements Command {
         return "Import a CSV file as concepts into the graph database, using the specified"
                 + sep + "scope and user.";
     }
-
-   
-   
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/CsvDocDescImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/CsvDocDescImport.java
@@ -20,7 +20,6 @@
 package eu.ehri.project.commands;
 
 import eu.ehri.project.importers.EadImporter;
-import eu.ehri.project.importers.PersonalitiesImporter;
 
 /**
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
@@ -29,9 +28,6 @@ public class CsvDocDescImport extends ImportCsvCommand implements Command {
 
     final static String NAME = "csv-doc-import";
 
-    /**
-     * Constructor.
-     */
     public CsvDocDescImport() {
         super(EadImporter.class);
     }
@@ -48,7 +44,4 @@ public class CsvDocDescImport extends ImportCsvCommand implements Command {
         return "Import a CSV file as Personalities into the graph database, using the specified"
                 + sep + "scope and user.";
     }
-
-   
-   
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/DcImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/DcImport.java
@@ -27,29 +27,26 @@ import eu.ehri.project.importers.SaxXmlHandler;
 
 /**
  * Import EAD from the command line...
- * 
  */
 public class DcImport extends ImportCommand implements Command {
 
     final static String NAME = "dc-import";
 
-    /**
-     * Constructor.
-     */
     public DcImport() {
         this(DcEuropeanaHandler.class, EadImporter.class);
     }
-    
+
     /**
      * Generic EAD import command, designed for extending classes that use specific Handlers.
-     * @param handler The Handler class to be used for import
+     *
+     * @param handler  The Handler class to be used for import
      * @param importer The Importer class to be used. If null, IcaAtomEadImporter is used.
      */
     public DcImport(Class<? extends SaxXmlHandler> handler, Class<? extends AbstractImporter> importer) {
-    	super(handler, importer);
+        super(handler, importer);
     }
 
-        @Override
+    @Override
     public String getHelp() {
         return "Usage: " + NAME + " [OPTIONS] -user <user-id> -scope <repository-id> <ead1.xml> <ead2.xml> ... <eadN.xml>";
     }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/DeleteEntities.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/DeleteEntities.java
@@ -36,6 +36,7 @@ import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.views.impl.CrudViews;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
  * Delete an entire class of stuff via the command line.
@@ -44,16 +45,13 @@ public class DeleteEntities extends BaseCommand implements Command {
 
     final static String NAME = "delete-all";
 
-    /**
-     * Constructor.
-     */
     public DeleteEntities() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("user", true,
-                "Identifier of user to import as"));
+           "Identifier of user to import as"));
         options.addOption(new Option("log", true,
                 "Log message for import action."));
     }
@@ -68,11 +66,6 @@ public class DeleteEntities extends BaseCommand implements Command {
         return "Delete ALL entities of a given type.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws Exception {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EacImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EacImport.java
@@ -29,9 +29,6 @@ public class EacImport extends ImportCommand implements Command {
 
     final static String NAME = "eac-import";
 
-    /**
-     * Constructor.
-     */
     public EacImport() {
         super(EacHandler.class, EacImporter.class);
     }
@@ -47,7 +44,4 @@ public class EacImport extends ImportCommand implements Command {
         return "Import an EAC file into the graph database, using the specified"
                 + sep + "Repository and User.";
     }
-
-   
-   
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EadAsVirtualCollectionImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EadAsVirtualCollectionImport.java
@@ -25,30 +25,27 @@ import eu.ehri.project.importers.VirtualEadHandler;
 import eu.ehri.project.importers.VirtualEadImporter;
 
 /**
- * Import EAD from the command line...
- * 
+ * Import EAD from the command line as a virtual collection.
  */
 public class EadAsVirtualCollectionImport extends ImportCommand implements Command {
 
     final static String NAME = "virtual-ead-import";
 
-    /**
-     * Constructor.
-     */
     public EadAsVirtualCollectionImport() {
         this(VirtualEadHandler.class, VirtualEadImporter.class);
     }
-    
+
     /**
      * Generic EAD import command, designed for extending classes that use specific Handlers.
-     * @param handler The Handler class to be used for import
+     *
+     * @param handler  The Handler class to be used for import
      * @param importer The Importer class to be used. If null, IcaAtomEadImporter is used.
      */
     public EadAsVirtualCollectionImport(Class<? extends SaxXmlHandler> handler, Class<? extends AbstractImporter> importer) {
-    	super(handler, importer);
+        super(handler, importer);
     }
 
-        @Override
+    @Override
     public String getHelp() {
         return "Usage: " + NAME + " [OPTIONS] -user <importing-user-id> -scope <responsible-user-id> <ead1.xml> <ead2.xml> ... <eadN.xml>";
     }
@@ -56,8 +53,7 @@ public class EadAsVirtualCollectionImport extends ImportCommand implements Comma
     @Override
     public String getUsage() {
         String sep = System.getProperty("line.separator");
-        String help = "Import an EAD file into the graph database as a tree of VirtualUnits, using the specified"
+        return "Import an EAD file into the graph database as a tree of VirtualUnits, using the specified"
                 + sep + "responsible User and importing User.";
-        return help;
     }
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EadImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EadImport.java
@@ -26,29 +26,26 @@ import eu.ehri.project.importers.SaxXmlHandler;
 
 /**
  * Import EAD from the command line...
- * 
  */
 public class EadImport extends ImportCommand implements Command {
 
     final static String NAME = "ead-import";
 
-    /**
-     * Constructor.
-     */
     public EadImport() {
         this(EadHandler.class, EadImporter.class);
     }
-    
+
     /**
      * Generic EAD import command, designed for extending classes that use specific Handlers.
-     * @param handler The Handler class to be used for import
+     *
+     * @param handler  The Handler class to be used for import
      * @param importer The Importer class to be used. If null, IcaAtomEadImporter is used.
      */
     public EadImport(Class<? extends SaxXmlHandler> handler, Class<? extends AbstractImporter> importer) {
-    	super(handler, importer);
+        super(handler, importer);
     }
 
-        @Override
+    @Override
     public String getHelp() {
         return String.format("Usage: %s [OPTIONS] -user <user-id> " +
                 "-scope <repository-id> <ead1.xml> <ead2.xml> ... <eadN.xml>", NAME);
@@ -57,7 +54,7 @@ public class EadImport extends ImportCommand implements Command {
     @Override
     public String getUsage() {
         String sep = System.getProperty("line.separator");
-        return  "Import an EAD file into the graph database, using the specified"
+        return "Import an EAD file into the graph database, using the specified"
                 + sep + "Repository and User.";
     }
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EagImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EagImport.java
@@ -29,9 +29,6 @@ public class EagImport  extends ImportCommand implements Command {
 
     final static String NAME = "eag-import";
 
-    /**
-     * Constructor.
-     */
     public EagImport() {
         super(EagHandler.class, EagImporter.class);
     }
@@ -44,11 +41,7 @@ public class EagImport  extends ImportCommand implements Command {
     @Override
     public String getUsage() {
         String sep = System.getProperty("line.separator");
-        String help = "Import an EAG file into the graph database, using the specified"
+        return "Import an EAG file into the graph database, using the specified"
                 + sep + "Repository and User.";
-        return help;
     }
-
-   
-   
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EntityAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EntityAdd.java
@@ -37,6 +37,7 @@ import eu.ehri.project.views.impl.LoggingCrudViews;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
 
 import java.util.Properties;
 
@@ -47,26 +48,23 @@ public class EntityAdd extends BaseCommand implements Command {
 
     final static String NAME = "add";
 
-    /**
-     * Constructor.
-     */
     public EntityAdd() {
     }
 
     @Override
     @SuppressWarnings("static-access")
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(OptionBuilder.withArgName("property=value")
-                .hasArgs(2)
-                .withValueSeparator()
-                .withDescription("Add a property with the given value")
-                .create("P"));
+           .hasArgs(2)
+           .withValueSeparator()
+           .withDescription("Add a property with the given value")
+           .create("P"));
         options.addOption(new Option("scope", true,
-                "Identifier of scope to create item in, i.e. a repository"));
+           "Identifier of scope to create item in, i.e. a repository"));
         options.addOption(new Option("u", "update", false,
-                "Update item if it already exists"));
+           "Update item if it already exists"));
         options.addOption(new Option("user", true,
-                "Identifier of user to import as"));
+           "Identifier of user to import as"));
         options.addOption(new Option("log", true,
                 "Log message for create action."));
     }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EntityDelete.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EntityDelete.java
@@ -29,6 +29,7 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.views.impl.LoggingCrudViews;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
  * Delete an entire class of stuff via the command line.
@@ -37,16 +38,13 @@ public class EntityDelete extends BaseCommand implements Command {
 
     final static String NAME = "delete";
 
-    /**
-     * Constructor.
-     */
     public EntityDelete() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("user", true,
-                "Identifier of user to import as"));
+           "Identifier of user to import as"));
         options.addOption(new Option("log", true,
                 "Log message for import action."));
     }
@@ -61,11 +59,6 @@ public class EntityDelete extends BaseCommand implements Command {
         return "Delete an item by ID.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws Exception {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/GetEntity.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/GetEntity.java
@@ -29,16 +29,12 @@ import eu.ehri.project.persistence.Serializer;
 import org.apache.commons.cli.CommandLine;
 
 /**
- * Import EAD from the command line...
- * 
+ * Fetch an item's serialized representation via the command line.
  */
 public class GetEntity extends BaseCommand implements Command {
 
     final static String NAME = "get";
 
-    /**
-     * Constructor.
-     */
     public GetEntity() {
     }
 
@@ -52,11 +48,6 @@ public class GetEntity extends BaseCommand implements Command {
         return "Get an entity by its identifier.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     * 
-     * @throws Exception
-     */
     @Override
     @SuppressWarnings("unchecked")
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/GraphML.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/GraphML.java
@@ -27,6 +27,7 @@ import eu.ehri.project.core.GraphReindexer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.cli.UnrecognizedOptionException;
 
 import java.io.FileInputStream;
@@ -65,9 +66,6 @@ public class GraphML extends BaseCommand implements Command {
 
     final static String NAME = "graphml";
 
-    /**
-     * Constructor.
-     */
     public GraphML() {
     }
     
@@ -83,16 +81,11 @@ public class GraphML extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("d", true,
                 "Output or input a dump"));
     }
     
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     @SuppressWarnings("unchecked")
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/GraphSON.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/GraphSON.java
@@ -28,6 +28,7 @@ import eu.ehri.project.core.GraphReindexer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.cli.UnrecognizedOptionException;
 
 import java.io.FileInputStream;
@@ -59,9 +60,6 @@ public class GraphSON extends BaseCommand implements Command {
 
     final static String NAME = "graphson";
 
-    /**
-     * Constructor.
-     */
     public GraphSON() {
     }
 
@@ -76,15 +74,10 @@ public class GraphSON extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("d", true, "Output or input a dump"));
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     @SuppressWarnings("unchecked")
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/GraphViz.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/GraphViz.java
@@ -27,6 +27,7 @@ import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -44,9 +45,6 @@ public class GraphViz extends BaseCommand implements Command {
 
     final static String NAME = "graphviz";
 
-    /**
-     * Constructor.
-     */
     public GraphViz() {
     }
 
@@ -56,7 +54,7 @@ public class GraphViz extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("r", "relationship", true,
                 "A relationship to include in the graph"));
     }
@@ -66,11 +64,6 @@ public class GraphViz extends BaseCommand implements Command {
         return "Dump a dot file.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     @SuppressWarnings("unchecked")
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/IcaAtomEadImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/IcaAtomEadImport.java
@@ -32,9 +32,6 @@ public class IcaAtomEadImport extends ImportCommand implements Command {
 
     final static String NAME = "ica-atom-ead-import";
 
-    /**
-     * Constructor.
-     */
     public IcaAtomEadImport() {
         this(EadHandler.class, IcaAtomEadImporter.class);
     }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -37,6 +37,7 @@ import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.PermissionScope;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -59,17 +60,17 @@ public abstract class ImportCommand extends BaseCommand implements Command{
     }
     
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("scope", true,
-                "Identifier of scope to import into, i.e. repository"));
+           "Identifier of scope to import into, i.e. repository"));
         options.addOption(new Option("F", "files-from", true,
-                "Read list of input files from another file (or standard input, if given '-')"));
+           "Read list of input files from another file (or standard input, if given '-')"));
         options.addOption(new Option("user", true,
-                "Identifier of user to import as"));
+           "Identifier of user to import as"));
         options.addOption(new Option("tolerant", false,
-                "Don't error if a file is not valid."));
+           "Don't error if a file is not valid."));
         options.addOption(new Option("log", true,
-                "Log message for action."));
+           "Log message for action."));
         options.addOption(new Option("properties", true,
                 "Provide another property file (default depends on HandlerClass)"));
     }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
@@ -31,6 +31,7 @@ import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.PermissionScope;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -39,16 +40,15 @@ import java.util.Map;
 /**
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
-public abstract class ImportCsvCommand extends BaseCommand implements Command{
+public abstract class ImportCsvCommand extends BaseCommand implements Command {
     Class<? extends MapImporter> importer;
-//    Class<? extends AbstractImporter> importer;
-    
-    public ImportCsvCommand(Class<? extends MapImporter> importer){
+
+    public ImportCsvCommand(Class<? extends MapImporter> importer) {
         this.importer = importer;
     }
-    
+
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("scope", true,
                 "Identifier of scope to import into, i.e. AuthoritativeSet"));
         options.addOption(new Option("user", true,
@@ -58,8 +58,8 @@ public abstract class ImportCsvCommand extends BaseCommand implements Command{
         options.addOption(new Option("log", true,
                 "Log message for import action."));
     }
-    
-     @Override
+
+    @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws Exception {
 
@@ -92,7 +92,7 @@ public abstract class ImportCsvCommand extends BaseCommand implements Command{
 
             ImportLog log = new CsvImportManager(graph, scope, user, importer)
                     .setTolerant(tolerant).importFiles(filePaths, logMessage);
-            
+
             System.out.println("Import completed. Created: " + log.getCreated()
                     + ", Updated: " + log.getUpdated());
             if (log.getErrored() > 0) {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/Initialize.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/Initialize.java
@@ -23,6 +23,7 @@ import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.utils.GraphInitializer;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
 
 /**
  * Import EAD from the command line...
@@ -37,7 +38,7 @@ public class Initialize extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
     }
 
     @Override

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/ListEntities.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/ListEntities.java
@@ -30,6 +30,7 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.persistence.Serializer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -44,26 +45,21 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 
 /**
- * Import EAD from the command line...
+ * List database items.
  */
 public class ListEntities extends BaseCommand implements Command {
 
     final static String NAME = "list";
 
-    /**
-     * Constructor.
-     */
-    public ListEntities() {
-    }
-
     @Override
-    protected void setCustomOptions() {
+    @SuppressWarnings("static-access")
+    protected void setCustomOptions(Options options) {
         options.addOption(OptionBuilder
-                .withType(String.class)
-                .withLongOpt("format").isRequired(false)
-                .hasArg(true).withArgName("f")
-                .withDescription("Format for output data, which defaults to just the id. " +
-                        "If provided can be one of: xml, json").create("f"));
+           .withType(String.class)
+           .withLongOpt("format").isRequired(false)
+           .hasArg(true).withArgName("f")
+           .withDescription("Format for output data, which defaults to just the id. " +
+                   "If provided can be one of: xml, json").create("f"));
         options.addOption(OptionBuilder
                 .withType(String.class)
                 .withLongOpt("root-node").isRequired(false)
@@ -81,11 +77,6 @@ public class ListEntities extends BaseCommand implements Command {
         return "List entities of a given type.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph, CommandLine cmdLine) throws Exception {
 

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/LoadFixtures.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/LoadFixtures.java
@@ -25,6 +25,7 @@ import eu.ehri.project.utils.fixtures.FixtureLoader;
 import eu.ehri.project.utils.fixtures.FixtureLoaderFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,15 +39,11 @@ public class LoadFixtures extends BaseCommand implements Command {
 
     final static String NAME = "load-fixtures";
 
-    /**
-     * Constructor.
-     * 
-     */
     public LoadFixtures() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("init",
                 "Initialize graph before loading fixtures"));
     }
@@ -61,11 +58,6 @@ public class LoadFixtures extends BaseCommand implements Command {
         return "Load the fixtures into the database.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     * 
-     * @throws Exception
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws Exception {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/PersonalitiesImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/PersonalitiesImport.java
@@ -28,9 +28,6 @@ public class PersonalitiesImport extends ImportCsvCommand implements Command {
 
     final static String NAME = "csv-pers-import";
 
-    /**
-     * Constructor.
-     */
     public PersonalitiesImport() {
         super(PersonalitiesImporter.class);
     }
@@ -47,7 +44,4 @@ public class PersonalitiesImport extends ImportCsvCommand implements Command {
         return "Import a CSV file as Personalities into the graph database, using the specified"
                 + sep + "scope and user.";
     }
-
-   
-   
 }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/RdfExport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/RdfExport.java
@@ -26,6 +26,7 @@ import com.tinkerpop.frames.FramedGraph;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -67,7 +68,7 @@ public class RdfExport extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("format", "f", true, "RDF format"));
     }
 

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/Reindex.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/Reindex.java
@@ -23,6 +23,7 @@ import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.core.GraphReindexer;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
 
 /**
  * Import EAD from the command line...
@@ -37,7 +38,7 @@ public class Reindex extends BaseCommand implements Command {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
     }
 
     @Override

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/RelationAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/RelationAdd.java
@@ -28,6 +28,7 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.models.utils.JavaHandlerUtils;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
  * Add an arbitrary edge between two nodes.
@@ -37,17 +38,13 @@ public class RelationAdd extends BaseCommand implements Command {
 
     final static String NAME = "add-rel";
 
-    /**
-     * Constructor.
-     *
-     */
     public RelationAdd() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("s", "single", false,
-                "Ensure the out entity only has one relationship of this type by removing any others"));
+           "Ensure the out entity only has one relationship of this type by removing any others"));
         options.addOption(new Option("d", "allow-duplicates", false,
                 "Allow creating multiple edges with the same label between the same two nodes"));
     }
@@ -62,11 +59,6 @@ public class RelationAdd extends BaseCommand implements Command {
         return "Create a relationship between a source and a target";
     }
 
-    /**
-     * Add a relationship between two nodes.
-     *
-     * @throws eu.ehri.project.exceptions.ItemNotFound
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws ItemNotFound {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/SkosVocabularyImport.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/SkosVocabularyImport.java
@@ -30,6 +30,7 @@ import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.cvoc.Vocabulary;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.util.Map.Entry;
 
@@ -40,20 +41,14 @@ public class SkosVocabularyImport extends BaseCommand implements Command {
 
     final static String NAME = "skos-import";
 
-    /**
-     * Constructor.
-     */
     public SkosVocabularyImport() {
     }
 
     @Override
-    protected void setCustomOptions() {
-        options.addOption(new Option("scope", true,
-                "Identifier of scope to import into, i.e. the Vocabulary"));
-        options.addOption(new Option("user", true,
-                "Identifier of user to import as"));
-        options.addOption(new Option("tolerant", false,
-                "Don't error if a file is not valid."));
+    protected void setCustomOptions(Options options) {
+        options.addOption(new Option("scope", true, "Identifier of scope to import into, i.e. the Vocabulary"));
+        options.addOption(new Option("user", true, "Identifier of user to import as"));
+        options.addOption(new Option("tolerant", false, "Don't error if a file is not valid."));
         options.addOption(new Option("log", true,
                 "Log message for import action."));
     }
@@ -70,11 +65,6 @@ public class SkosVocabularyImport extends BaseCommand implements Command {
                 + sep + "Vocabulary and User.";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     *
-     * @throws Exception
-     */
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
                                CommandLine cmdLine) throws Exception {
 

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserAdd.java
@@ -38,6 +38,7 @@ import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.impl.LoggingCrudViews;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
  * Add a user.
@@ -47,17 +48,13 @@ public class UserAdd extends BaseCommand implements Command {
 
     final static String NAME = "useradd";
 
-    /**
-     * Constructor.
-     * 
-     */
     public UserAdd() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("group", true,
-                "A group to add the new user to"));
+           "A group to add the new user to"));
         options.addOption(new Option("n", "name", true, "User's full name"));
         options.addOption(new Option("c", "comment", false,
                 "Log message for create action action."));
@@ -73,14 +70,6 @@ public class UserAdd extends BaseCommand implements Command {
         return "Create a new user, and optionally add them to a group";
     }
 
-    /**
-     * Command-line entry-point (for testing.)
-     * 
-     * @throws ItemNotFound
-     * @throws DeserializationError 
-     * @throws PermissionDenied 
-     * @throws ValidationError 
-     */
     @Override
     public int execWithOptions(final FramedGraph<? extends TransactionalGraph> graph,
             CommandLine cmdLine) throws ItemNotFound, ValidationError, PermissionDenied, DeserializationError {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserListEntities.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserListEntities.java
@@ -29,19 +29,16 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.views.Query;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
- * Import EAD from the command line...
+ * List items as a given user, respecting access controls.
  * 
  */
 public class UserListEntities extends BaseCommand implements Command {
 
     final static String NAME = "user-list";
 
-    /**
-     * Constructor.
-     * 
-     */
     public UserListEntities() {
     }
 
@@ -56,7 +53,7 @@ public class UserListEntities extends BaseCommand implements Command {
     }
     
     @Override
-    public void setCustomOptions() {
+    public void setCustomOptions(Options options) {
         options.addOption(new Option("user", true,
                 "Identifier of user to list items as"));
     }

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserMod.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserMod.java
@@ -36,26 +36,22 @@ import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.persistence.ActionManager.EventContext;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 /**
- * Add a user.
- * 
+ * Modify an existing user.
  */
 public class UserMod extends BaseCommand implements Command {
 
     final static String NAME = "usermod";
 
-    /**
-     * Constructor.
-     * 
-     */
     public UserMod() {
     }
 
     @Override
-    protected void setCustomOptions() {
+    protected void setCustomOptions(Options options) {
         options.addOption(new Option("group", true,
-                "A group to add the new user to"));
+           "A group to add the new user to"));
         options.addOption(new Option("c", "comment", false,
                 "Log message for create action action."));
     }


### PR DESCRIPTION
 - remove copy/paste Javadoc that's not at all helpful
 - add some Javadoc where it hopefully will be more helpful
 - mildly refactor option setting for better encapsulation and
   one-fewer protected fields
 - code reformatting