### PR TITLE
Rework the way events are written to the graph.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,27 +60,27 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-cmdline</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -90,7 +90,7 @@
                 <dependency>
                     <groupId>ehri-project</groupId>
                     <artifactId>ehri-extension-sparql</artifactId>
-                    <version>0.9.2-SNAPSHOT</version>
+                    <version>0.9.3-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/ehri-cmdline/pom.xml
+++ b/ehri-cmdline/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cmdline</artifactId>
     <name>Command Line Tools</name>
     <description>Command line tools for interacting with the backend graph DB.</description>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -90,14 +90,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
 
         <!-- RDF export -->
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-graph-sail</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-sail-graph</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/DeleteEntities.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/DeleteEntities.java
@@ -95,9 +95,9 @@ public class DeleteEntities extends BaseCommand implements Command {
                 UserProfile.class);
 
         try {
-            new ActionManager(graph).logEvent(user,
-                    EventTypes.deletion,
-                    getLogMessage(logMessage));
+            new ActionManager(graph)
+                    .newEventContext(user, EventTypes.deletion, getLogMessage(logMessage))
+                    .commit();
             deleteIds(graph, manager, type, user);
             graph.getBaseGraph().commit();
         } catch (Exception e) {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserMod.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserMod.java
@@ -96,7 +96,7 @@ public class UserMod extends BaseCommand implements Command {
             UserProfile user = manager.getFrame(userId,
                     EntityClass.USER_PROFILE, UserProfile.class);
 
-            EventContext actionCtx = new ActionManager(graph).logEvent(
+            EventContext actionCtx = new ActionManager(graph).newEventContext(
                     user, admin, EventTypes.modification,
                     getLogMessage(logMessage));
 
@@ -106,6 +106,7 @@ public class UserMod extends BaseCommand implements Command {
                 group.addMember(user);
                 actionCtx.addSubjects(group);
             }
+            actionCtx.commit();
             graph.getBaseGraph().commit();
         } catch (Exception e) {
             graph.getBaseGraph().rollback();

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-extension-sparql/pom.xml
+++ b/ehri-extension-sparql/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ehri-extension-sparql</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
 
     <name>Web Service SparQL Extension</name>
     <description>SparQL endpoint for web service.</description>
 
     <properties>
-        <sesame.version>2.6.10</sesame.version>
+        <sesame.version>2.7.10</sesame.version>
     </properties>
 
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-sail-graph</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-graph-sail</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -109,14 +109,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/ehri-extension/pom.xml
+++ b/ehri-extension/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>
     <description>Web service layer exposed via a Neo4j extension.</description>
 
     <artifactId>ehri-extension</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
 
     <!-- TODO add license info and more -->
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -155,13 +155,13 @@
         <dependency>
             <groupId>com.tinkerpop</groupId>
             <artifactId>frames</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-neo4j-graph</artifactId>
-            <version>2.4.0</version><!-- was 1.2 -->
+            <version>2.6.0</version><!-- was 1.2 -->
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/LinkResource.java
@@ -224,7 +224,7 @@ public class LinkResource extends AbstractAccessibleEntityResource<Link>
                     getRequesterUserProfile(), PermissionType.ANNOTATE);
             Actioner actioner = manager.cast(getRequesterUserProfile(), Actioner.class);
             Link link = manager.getFrame(linkId, EntityClass.LINK, Link.class);
-            actionManager.logEvent(link, actioner, EventTypes.deletion);
+            actionManager.newEventContext(link, actioner, EventTypes.deletion).commit();
             manager.deleteVertex(link.asVertex());
             graph.getBaseGraph().commit();
             return Response.ok().build();

--- a/ehri-extension/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -180,7 +180,7 @@ public class VocabularyResource extends AbstractAccessibleEntityResource<Vocabul
             Iterable<Concept> concepts = vocabulary.getConcepts();
             if (concepts.iterator().hasNext()) {
                 ActionManager.EventContext context = actionManager
-                        .logEvent(user, EventTypes.deletion, getLogMessage());
+                        .newEventContext(user, EventTypes.deletion, getLogMessage());
                 for (Concept concept : concepts) {
                     context.addSubjects(concept);
                     conceptViews.delete(concept.getId(), user);

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/AccessRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/AccessRestClientTest.java
@@ -40,7 +40,7 @@ public class AccessRestClientTest extends BaseRestClientTest {
     static final String PRIVILEGED_USER_NAME = "mike";
     static final String LIMITED_USER_NAME = "reto";
 
-    @Test @Ignore
+    @Test
     public void testUserCannotRead() throws Exception {
         // Create
         ClientResponse response = jsonCallAs(LIMITED_USER_NAME,

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/PermissionRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/PermissionRestClientTest.java
@@ -108,7 +108,6 @@ public class PermissionRestClientTest extends BaseRestClientTest {
     }
 
     @Test
-    @Ignore
     public void testPermissionSetPermissionDenied() throws Exception {
 
         // Test a user setting his own permissions over REST - this should

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/UserProfileRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/UserProfileRestClientTest.java
@@ -210,7 +210,6 @@ public class UserProfileRestClientTest extends BaseRestClientTest {
     }
 
     @Test
-    @Ignore
     public void testFollowAndUnfollow() throws Exception {
         String user1 = "reto";
         String user2 = "mike";

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-frames</artifactId>
     <packaging>jar</packaging>
 
 
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
 
     <name>EHRI Core API</name>
     <description>Java API for data access and permissions.</description>
@@ -102,13 +102,13 @@
         <dependency>
             <groupId>com.tinkerpop</groupId>
             <artifactId>frames</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-neo4j-graph</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>com.tinkerpop.gremlin</groupId>
             <artifactId>gremlin-java</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/ehri-frames/src/main/java/eu/ehri/project/tools/Linker.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/tools/Linker.java
@@ -158,7 +158,7 @@ public class Linker {
         ActionManager actionManager = new ActionManager(graph);
         ActionManager.EventContext conceptEvent = actionManager
                 .setScope(vocabulary)
-                .logEvent(user, EventTypes.creation, logMessage);
+                .newEventContext(user, EventTypes.creation, logMessage);
         CrudViews<Concept> conceptMaker = new CrudViews<Concept>(graph, Concept.class, vocabulary);
 
         for (Map.Entry<String, String> idName : conceptIdentifierNames.entrySet()) {
@@ -200,10 +200,12 @@ public class Linker {
             }
         }
 
+        conceptEvent.commit();
+
         // Now link the concepts with elements having the access point from
         // which the concept originally derived.
         ActionManager.EventContext linkEvent = actionManager
-                .logEvent(user, EventTypes.creation, logMessage);
+                .newEventContext(user, EventTypes.creation, logMessage);
         CrudViews<Link> linkMaker = new CrudViews<Link>(graph, Link.class);
 
         long linkCount = 0L;
@@ -236,6 +238,8 @@ public class Linker {
                 }
             }
         }
+
+        linkEvent.commit();
 
         return linkCount;
     }

--- a/ehri-frames/src/main/java/eu/ehri/project/views/AclViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/AclViews.java
@@ -100,13 +100,14 @@ public final class AclViews implements Scoped<AclViews> {
         acl.setPermissionMatrix(accessor, permissionSet);
         boolean scoped = !scope.equals(SystemScope.INSTANCE);
         // Log the action...
-        ActionManager.EventContext context = actionManager.logEvent(
+        ActionManager.EventContext context = actionManager.newEventContext(
                 manager.cast(accessor, AccessibleEntity.class),
                 manager.cast(grantee, Actioner.class),
                 EventTypes.setGlobalPermissions);
         if (scoped) {
             context.addSubjects(manager.cast(scope, AccessibleEntity.class));
         }
+        context.commit();
         return acl.getInheritedGlobalPermissions(accessor);
     }
 
@@ -123,8 +124,9 @@ public final class AclViews implements Scoped<AclViews> {
         helper.checkEntityPermission(entity, user, PermissionType.UPDATE);
         acl.setAccessors(entity, accessors);
         // Log the action...
-        actionManager.logEvent(
-                entity, manager.cast(user, Actioner.class), EventTypes.setVisibility);
+        actionManager.newEventContext(
+                entity, manager.cast(user, Actioner.class), EventTypes.setVisibility)
+                .commit();
     }
 
     /**
@@ -176,9 +178,10 @@ public final class AclViews implements Scoped<AclViews> {
         helper.checkEntityPermission(item, grantee, PermissionType.GRANT);
         acl.setItemPermissions(item, accessor, permissionList);
         // Log the action...
-        actionManager.logEvent(item,
+        actionManager.newEventContext(item,
                 manager.cast(grantee, Actioner.class), EventTypes.setItemPermissions)
-                .addSubjects(manager.cast(accessor, AccessibleEntity.class));
+                .addSubjects(manager.cast(accessor, AccessibleEntity.class))
+                .commit();
     }
 
     public void revokePermissionGrant(PermissionGrant grant, Accessor user)
@@ -214,9 +217,10 @@ public final class AclViews implements Scoped<AclViews> {
         ensureCanModifyGroupMembership(group, user, grantee);
         group.addMember(user);
         // Log the action...
-        actionManager.logEvent(group,
+        actionManager.newEventContext(group,
                 manager.cast(grantee, Actioner.class), EventTypes.addGroup)
-                .addSubjects(manager.cast(user, AccessibleEntity.class));
+                .addSubjects(manager.cast(user, AccessibleEntity.class))
+                .commit();
     }
 
     /**
@@ -233,9 +237,10 @@ public final class AclViews implements Scoped<AclViews> {
         ensureCanModifyGroupMembership(group, user, grantee);
         group.removeMember(user);
         // Log the action...
-        actionManager.logEvent(group,
-                    manager.cast(grantee, Actioner.class), EventTypes.removeGroup)
-                .addSubjects(manager.cast(user, AccessibleEntity.class));
+        actionManager.newEventContext(group,
+                manager.cast(grantee, Actioner.class), EventTypes.removeGroup)
+                .addSubjects(manager.cast(user, AccessibleEntity.class))
+                .commit();
     }
 
     private void ensureCanModifyGroupMembership(Group group, Accessor user, Accessor grantee)

--- a/ehri-frames/src/main/java/eu/ehri/project/views/AnnotationViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/AnnotationViews.java
@@ -119,9 +119,11 @@ public final class AnnotationViews implements Scoped<AnnotationViews> {
         acl.withScope(SystemScope.INSTANCE)
                 .grantPermission(annotation, PermissionType.OWNER, user);
 
-        new ActionManager(graph, entity).logEvent(annotation,
-                graph.frame(user.asVertex(), Actioner.class),
-                EventTypes.annotation, Optional.<String>absent());
+        new ActionManager(graph, entity)
+                .newEventContext(annotation,
+                        graph.frame(user.asVertex(), Actioner.class),
+                        EventTypes.annotation, Optional.<String>absent())
+                .commit();
         return annotation;
     }
 

--- a/ehri-frames/src/main/java/eu/ehri/project/views/DescriptionViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/DescriptionViews.java
@@ -74,9 +74,10 @@ public class DescriptionViews <E extends DescribedEntity> {
             throw new PermissionDenied("Given description does not belong to its parent item");
         }
         helper.checkEntityPermission(parent, user, PermissionType.UPDATE);
-        actionManager.logEvent(parent, manager.cast(user, Actioner.class),
-                        EventTypes.deleteDependent, logMessage)
-                .createVersion(dependentItem);
+        actionManager.newEventContext(parent, manager.cast(user, Actioner.class),
+                EventTypes.deleteDependent, logMessage)
+                .createVersion(dependentItem)
+                .commit();
         return getPersister(parent)
                 .delete(serializer.vertexFrameToBundle(dependentItem));
     }
@@ -87,8 +88,9 @@ public class DescriptionViews <E extends DescribedEntity> {
         E parent = crud.detail(parentId, user);
         helper.checkEntityPermission(parent, user, PermissionType.UPDATE);
         T out = getPersister(parent).create(data, descriptionClass);
-        actionManager.logEvent(parent, manager.cast(user, Actioner.class),
-                    EventTypes.createDependent, logMessage);
+        actionManager.newEventContext(parent, manager.cast(user, Actioner.class),
+                EventTypes.createDependent, logMessage)
+                .commit();
         return out;
     }
 
@@ -100,9 +102,10 @@ public class DescriptionViews <E extends DescribedEntity> {
         Mutation<T> out = getPersister(parent).update(data, descriptionClass);
         if (!out.unchanged()) {
             actionManager
-                    .logEvent(parent, manager.cast(user, Actioner.class),
+                    .newEventContext(parent, manager.cast(user, Actioner.class),
                             EventTypes.modifyDependent, logMessage)
-                    .createVersion(out.getNode(), out.getPrior().get());
+                    .createVersion(out.getNode(), out.getPrior().get())
+                    .commit();
         }
         return out;
     }

--- a/ehri-frames/src/main/java/eu/ehri/project/views/LinkViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/LinkViews.java
@@ -104,15 +104,17 @@ public final class LinkViews implements Scoped<LinkViews> {
         link.addLinkTarget(t1);
         link.addLinkTarget(t2);
         link.setLinker(user);
-        ActionManager.EventContext eventContext = new ActionManager(graph, t1).logEvent(
+        ActionManager.EventContext eventContext = new ActionManager(graph, t1).newEventContext(
                 graph.frame(user.asVertex(), Actioner.class),
-                EventTypes.link, Optional.<String>absent());
-        eventContext.addSubjects(link).addSubjects(t2);
+                EventTypes.link, Optional.<String>absent())
+                .addSubjects(link)
+                .addSubjects(t2);
         for (String body : bodies) {
             AccessibleEntity item = manager.getFrame(body, AccessibleEntity.class);
             link.addLinkBody(item);
             eventContext.addSubjects(item);
         }
+        eventContext.commit();
         return link;
     }
 
@@ -148,9 +150,10 @@ public final class LinkViews implements Scoped<LinkViews> {
         link.addLinkTarget(t2);
         link.setLinker(user);
         link.addLinkBody(rel);
-        ActionManager.EventContext eventContext = new ActionManager(graph).logEvent(
+        ActionManager.EventContext eventContext = new ActionManager(graph).newEventContext(
                 t1, graph.frame(user.asVertex(), Actioner.class), EventTypes.link);
         eventContext.addSubjects(link).addSubjects(t2).addSubjects(rel);
+        eventContext.commit();
         return link;
     }
 

--- a/ehri-frames/src/main/java/eu/ehri/project/views/PromotionViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/PromotionViews.java
@@ -81,7 +81,9 @@ public class PromotionViews implements Scoped<PromotionViews> {
             throw new NotPromotableError(item.getId());
         }
         item.addPromotion(user);
-        actionManager.logEvent(item, user, EventTypes.promotion);
+        actionManager
+                .newEventContext(item, user, EventTypes.promotion)
+                .commit();
     }
 
     /**
@@ -109,7 +111,7 @@ public class PromotionViews implements Scoped<PromotionViews> {
             throw new NotPromotableError(item.getId());
         }
         item.addDemotion(user);
-        actionManager.logEvent(item, user, EventTypes.demotion);
+        actionManager.newEventContext(item, user, EventTypes.demotion).commit();
     }
 
     /**

--- a/ehri-frames/src/test/java/eu/ehri/project/models/events/SystemEventTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/events/SystemEventTest.java
@@ -60,15 +60,17 @@ public class SystemEventTest extends AbstractFixtureTest {
         Bundle userBundle = Bundle.fromData(TestData.getTestUserBundle());
         UserProfile user = bundleDAO.create(userBundle, UserProfile.class);
 
-        SystemEvent first = actionManager.logEvent(user,
+        ActionManager.EventContext ctx = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.creation).getSystemEvent();
+                EventTypes.creation);
+        SystemEvent first = ctx.commit();
         assertEquals(1, Iterables.count(first.getSubjects()));
 
         // Delete the user and log it
-        actionManager.logEvent(user,
+        ActionManager.EventContext ctx2 = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.deletion).getSystemEvent();
+                EventTypes.deletion);
+        ctx2.commit();
         bundleDAO.delete(serializer.vertexFrameToBundle(user));
 
         // First event should now have 0 subjects, since it's
@@ -83,25 +85,26 @@ public class SystemEventTest extends AbstractFixtureTest {
         Bundle userBundle3 = userBundle.withDataValue("foo", "bar2");
         UserProfile user = bundleDAO.create(userBundle, UserProfile.class);
 
-        SystemEvent first = actionManager.logEvent(user,
+        ActionManager.EventContext ctx = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.creation).getSystemEvent();
+                EventTypes.creation);
+        SystemEvent first = ctx.commit();
         assertEquals(1, Iterables.count(first.getSubjects()));
 
         // Delete the user and log it
-        SystemEvent second = actionManager.logEvent(user,
+        ActionManager.EventContext ctx2 = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.modification).getSystemEvent();
+                EventTypes.modification);
+        SystemEvent second = ctx2.commit();
         bundleDAO.update(userBundle2, UserProfile.class);
 
-        SystemEvent third = actionManager.logEvent(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.modification).getSystemEvent();
+        SystemEvent third = ctx2.commit();
         bundleDAO.update(userBundle3, UserProfile.class);
 
-        SystemEvent forth = actionManager.logEvent(user,
+        ActionManager.EventContext ctx3 = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.deletion).getSystemEvent();
+                EventTypes.deletion);
+        SystemEvent forth = ctx3.commit();
 
         // creation and modification are different
         assertFalse(sameAs(first, second));
@@ -116,9 +119,10 @@ public class SystemEventTest extends AbstractFixtureTest {
         Repository repository = bundleDAO.create(repoBundle, Repository.class);
 
         // Delete the user and log it
-        SystemEvent repoEvent = actionManager.logEvent(repository,
+        ActionManager.EventContext ctx4 = actionManager.newEventContext(repository,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.modification).getSystemEvent();
+                EventTypes.modification);
+        SystemEvent repoEvent = ctx4.commit();
 
         assertFalse(sameAs(second, repoEvent));
     }

--- a/ehri-frames/src/test/java/eu/ehri/project/models/events/VersionTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/events/VersionTest.java
@@ -52,24 +52,23 @@ public class VersionTest extends AbstractFixtureTest {
         Bundle userBundle3 = userBundle.withDataValue("foo", "bar2");
         UserProfile user = bundleDAO.create(userBundle, UserProfile.class);
 
-        SystemEvent first = actionManager.logEvent(user,
+        ActionManager.EventContext ctx1 = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.creation).getSystemEvent();
+                EventTypes.creation);
+        SystemEvent first = ctx1.commit();
         assertEquals(1, Iterables.count(first.getSubjects()));
 
         // Change the user twice...
-        SystemEvent second = actionManager.logEvent(user,
+        ActionManager.EventContext ctx2 = actionManager.newEventContext(user,
                 graph.frame(validUser.asVertex(), Actioner.class),
                 EventTypes.modification)
-                    .createVersion(user).getSystemEvent();
+                .createVersion(user);
+        SystemEvent second = ctx2.commit();
         Mutation<UserProfile> update1 = bundleDAO
                 .update(userBundle2, UserProfile.class);
         assertEquals(MutationState.UPDATED, update1.getState());
 
-        SystemEvent third = actionManager.logEvent(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
-                EventTypes.modification)
-                    .createVersion(user).getSystemEvent();
+        SystemEvent third = ctx2.createVersion(user).commit();
         bundleDAO.update(userBundle3, UserProfile.class);
         assertEquals(MutationState.UPDATED, update1.getState());
 

--- a/ehri-frames/src/test/java/eu/ehri/project/views/LinkViewsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/views/LinkViewsTest.java
@@ -31,6 +31,7 @@ import eu.ehri.project.models.Link;
 import eu.ehri.project.models.UndeterminedRelationship;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.LinkableEntity;
+import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Before;
@@ -47,11 +48,13 @@ import static org.junit.Assert.assertTrue;
 public class LinkViewsTest extends AbstractFixtureTest {
 
     private LinkViews linkViews;
+    private ActionManager actionManager;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
         linkViews = new LinkViews(graph);
+        actionManager = new ActionManager(graph);
     }
 
     @Test
@@ -78,6 +81,8 @@ public class LinkViewsTest extends AbstractFixtureTest {
         assertTrue(Iterables.contains(link.getLinkTargets(), dst));
         assertEquals(1L, Iterables.size(link.getLinkBodies()));
         assertTrue(Iterables.contains(link.getLinkBodies(), rel));
+        assertTrue(Lists.newArrayList(actionManager
+                .getLatestGlobalEvent().getSubjects()).contains(link));
     }
 
 
@@ -108,6 +113,8 @@ public class LinkViewsTest extends AbstractFixtureTest {
         assertEquals(rel.getRelationshipType(), linkType);
         Description d = rel.getDescription();
         assertEquals(desc, d);
+        assertTrue(Lists.newArrayList(actionManager
+                .getLatestGlobalEvent().getSubjects()).contains(link));
     }
 
     private Bundle getLinkBundle(String linkDesc, String linkType) {

--- a/ehri-importers/pom.xml
+++ b/ehri-importers/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>0.9.3-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-importers</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
 
     <name>Import Tools</name>
     <description>Classes for importing data.</description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.3-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -69,13 +69,13 @@
         <dependency>
             <groupId>com.tinkerpop</groupId>
             <artifactId>frames</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-neo4j-graph</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvImportManager.java
@@ -21,7 +21,6 @@ package eu.ehri.project.importers;
 
 import au.com.bytecode.opencsv.CSVReader;
 import com.google.common.collect.Maps;
-import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InvalidInputFormatError;
@@ -51,7 +50,7 @@ public class CsvImportManager extends AbstractImportManager {
 
     private static final Logger logger = LoggerFactory.getLogger(CsvImportManager.class);
 
-    public CsvImportManager(FramedGraph<? extends TransactionalGraph> framedGraph,
+    public CsvImportManager(FramedGraph<?> framedGraph,
             final PermissionScope permissionScope, final Actioner actioner, Class<? extends AbstractImporter> importerClass) {
         super(framedGraph, permissionScope, actioner, importerClass);
     }
@@ -124,24 +123,15 @@ public class CsvImportManager extends AbstractImportManager {
                     }
                 }
             }
-            framedGraph.getBaseGraph().commit();
-        } catch (ValidationError e) {
-            framedGraph.getBaseGraph().rollback();
-            throw e;
-        } catch (InstantiationException e) {
-            framedGraph.getBaseGraph().rollback();
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            framedGraph.getBaseGraph().rollback();
+        } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         } catch (NoSuchMethodException e) {
-            framedGraph.getBaseGraph().rollback();
             throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            framedGraph.getBaseGraph().rollback();
+        } catch (InstantiationException e) {
             throw new RuntimeException(e);
-        }
-        finally {
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } finally {
             if (reader != null) {
                 reader.close();
             }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/ImportLog.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/ImportLog.java
@@ -21,7 +21,6 @@ package eu.ehri.project.importers;
 
 import com.google.common.collect.Maps;
 import eu.ehri.project.models.base.Actioner;
-import eu.ehri.project.models.events.SystemEvent;
 import eu.ehri.project.persistence.ActionManager.EventContext;
 import org.codehaus.jackson.annotate.JsonValue;
 
@@ -119,13 +118,6 @@ public class ImportLog {
     public void setErrored(String item, String error) {
         errors.put(item, error);
         errored++;
-    }
-
-    /**
-     * @return returns the SystemEvent associated with this import
-     */
-    public SystemEvent getAction() {
-        return eventContext.getSystemEvent();
     }
 
     /**

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/SaxImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/SaxImportManager.java
@@ -21,7 +21,6 @@ package eu.ehri.project.importers;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
@@ -67,7 +66,7 @@ public class SaxImportManager extends AbstractImportManager {
      * @param scope     the permission scope
      * @param actioner  the actioner
      */
-    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+    public SaxImportManager(FramedGraph<?> graph,
             final PermissionScope scope, final Actioner actioner,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             Optional<XmlImportProperties> properties,
@@ -87,7 +86,7 @@ public class SaxImportManager extends AbstractImportManager {
      * @param scope     a permission scope
      * @param actioner  the actioner
      */
-    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+    public SaxImportManager(FramedGraph<?> graph,
             final PermissionScope scope, final Actioner actioner,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             List<ImportCallback> callbacks) {
@@ -101,7 +100,7 @@ public class SaxImportManager extends AbstractImportManager {
      * @param scope     a permission scope
      * @param actioner  the actioner
      */
-    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+    public SaxImportManager(FramedGraph<?> graph,
             final PermissionScope scope, final Actioner actioner,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             XmlImportProperties properties) {
@@ -116,7 +115,7 @@ public class SaxImportManager extends AbstractImportManager {
      * @param scope     a permission scope
      * @param actioner  the actioner
      */
-    public SaxImportManager(FramedGraph<? extends TransactionalGraph> graph,
+    public SaxImportManager(FramedGraph<?> graph,
             final PermissionScope scope, final Actioner actioner,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
         this(graph, scope, actioner, importerClass, handlerClass, Lists.<ImportCallback>newArrayList());

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/Wp2PersonalitiesImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/Wp2PersonalitiesImporter.java
@@ -21,7 +21,6 @@ package eu.ehri.project.importers;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
@@ -55,7 +54,7 @@ public abstract class Wp2PersonalitiesImporter extends MapImporter {
 
     private static final Logger logger = LoggerFactory.getLogger(Wp2PersonalitiesImporter.class);
 
-    public Wp2PersonalitiesImporter(FramedGraph<? extends TransactionalGraph> framedGraph, PermissionScope permissionScope,
+    public Wp2PersonalitiesImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope,
             ImportLog log) {
         super(framedGraph, permissionScope, log);
     }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/SkosImporterFactory.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/SkosImporterFactory.java
@@ -20,7 +20,6 @@
 
 package eu.ehri.project.importers.cvoc;
 
-import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.cvoc.Vocabulary;
@@ -29,7 +28,7 @@ import eu.ehri.project.models.cvoc.Vocabulary;
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public class SkosImporterFactory {
-    public static SkosImporter newSkosImporter(FramedGraph<? extends TransactionalGraph> graph,
+    public static SkosImporter newSkosImporter(FramedGraph<?> graph,
             Actioner actioner, Vocabulary vocabulary) {
         //String property = System.getProperty("eu.ehri.project.importers.SkosImporter");
         // TODO: Load dynamically via system prop

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
@@ -29,6 +29,7 @@ import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.cvoc.Concept;
+import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.test.AbstractFixtureTest;
 
 import org.junit.After;
@@ -51,6 +52,11 @@ public class AbstractImporterTest extends AbstractFixtureTest {
     protected AbstractImportManager importManager;
 
     /**
+     * Action Manager
+     */
+    protected ActionManager actionManager;
+
+    /**
      * Test repository, initialised in test setup using TEST_REPO identifier.
      */
     protected Repository repository;
@@ -66,6 +72,7 @@ public class AbstractImporterTest extends AbstractFixtureTest {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        actionManager = new ActionManager(graph);
         repository = manager.getFrame(TEST_REPO, Repository.class);
     }
 

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CsvAuthItemImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CsvAuthItemImporterTest.java
@@ -75,7 +75,7 @@ public class CsvAuthItemImporterTest extends AbstractImporterTest{
         assertEquals(voccount + 9, toList(authoritativeSet.getAuthoritativeItems()).size());
 
         // Check permission scopes are correct.
-        for (AccessibleEntity subject : log.getAction().getSubjects()) {
+        for (AccessibleEntity subject : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(authoritativeSet, subject.getPermissionScope());
         }
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CsvConceptImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CsvConceptImporterTest.java
@@ -74,7 +74,7 @@ public class CsvConceptImporterTest extends AbstractImporterTest{
         assertEquals(voccount + 18, toList(authoritativeSet.getAuthoritativeItems()).size());
 
         // Check permission scopes are correct.
-        for (AccessibleEntity subject : log.getAction().getSubjects()) {
+        for (AccessibleEntity subject : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(authoritativeSet, subject.getPermissionScope());
         }
         Concept antisemitism = manager.getFrame("auths-fst810769", Concept.class);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/EacImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/EacImporterTest.java
@@ -188,11 +188,11 @@ public class EacImporterTest extends AbstractImporterTest {
 //            assertEquals(1, toList(actions).size());
         // Check we've only got one action
         assertEquals(1, log.getCreated());
-        assertTrue(log.getAction() instanceof SystemEvent);
-        assertEquals(logMessage, log.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
         // Ensure the import action has the right number of subjects.
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         assertEquals(1, subjects.size());
         assertEquals(log.getChanged(), subjects.size());
 

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Eag2896Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Eag2896Test.java
@@ -109,11 +109,11 @@ public class Eag2896Test extends AbstractImporterTest {
 
         // Check we've only got one action
         assertEquals(1, log.getCreated());
-        assertTrue(log.getAction() instanceof SystemEvent);
-        assertEquals(logMessage, log.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
         // Ensure the import action has the right number of subjects.
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         assertEquals(1, subjects.size());
         assertEquals(log.getChanged(), subjects.size());
 

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadImporterTest.java
@@ -30,6 +30,7 @@ import eu.ehri.project.models.events.SystemEvent;
 import java.io.InputStream;
 import java.util.List;
 import static org.junit.Assert.*;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,11 +110,11 @@ public class IcaAtomEadImporterTest extends AbstractImporterTest{
 //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 4 items
         assertEquals(5, log.getCreated());
-        assertTrue(log.getAction() instanceof SystemEvent);
-        assertEquals(logMessage, log.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
 
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         for(AccessibleEntity subject  : subjects)
             logger.info("identifier: " + subject.getId());
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadSingleEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadSingleEadTest.java
@@ -110,7 +110,7 @@ public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
         assertEquals(0, log2.getUpdated());
 
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(agent, e.getPermissionScope());
         }
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Jmp130Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Jmp130Test.java
@@ -96,7 +96,7 @@ public class Jmp130Test extends AbstractImporterTest {
             assertTrue(d.asVertex().getProperty("languageOfMaterial").toString().startsWith("[ces"));
         }
 
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(actionManager.getLatestGlobalEvent().getSubjects());
         for (AccessibleEntity subject : subjects) {
             logger.info("identifier: " + subject.getId());
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/JmpEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/JmpEadTest.java
@@ -89,7 +89,7 @@ public class JmpEadTest extends AbstractImporterTest {
             assertTrue(d.asVertex().getProperty("languageOfMaterial").toString().startsWith("[deu"));
         }
 
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(actionManager.getLatestGlobalEvent().getSubjects());
         for (AccessibleEntity subject : subjects) {
             logger.info("identifier: " + subject.getId());
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/JustASimpleTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/JustASimpleTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.google.common.base.Optional;
 import eu.ehri.project.definitions.EventTypes;
+import eu.ehri.project.models.events.SystemEvent;
 import eu.ehri.project.persistence.ActionManager;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -40,14 +41,15 @@ private static final Logger logger = LoggerFactory.getLogger(JustASimpleTest.cla
         int nodeCount = getNodeCount(graph);
         ActionManager am = new ActionManager(graph);
         logger.info("size : " + toList(validUser.getActions()).size());
-        ActionManager.EventContext ctx = am.logEvent(validUser,
+        ActionManager.EventContext ctx = am.newEventContext(validUser,
                 EventTypes.creation,
                 Optional.of("Doing something to lots of nodes"));
+        SystemEvent ev = ctx.commit();
         assertEquals(nodeCount + 2, getNodeCount(graph));
 
         assertEquals(validUser, ctx.getActioner());
         assertEquals(userActions + 1, toList(validUser.getActions()).size());
-        logger.info("number of events on event: " + toList(ctx.getSystemEvent().getHistory()).size());
+        logger.info("number of events on event: " + toList(ev.getHistory()).size());
         logger.info("size : " + toList(validUser.getActions()).size());
 
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesImporterTest.java
@@ -24,6 +24,7 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.AuthoritativeSet;
 import java.io.InputStream;
 
+import eu.ehri.project.models.events.SystemEvent;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -56,6 +57,7 @@ public class PersonalitiesImporterTest extends AbstractImporterTest{
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
         ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser, PersonalitiesImporter.class).importFile(ios, logMessage);
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
         System.out.println(Iterables.toList(authoritativeSet.getAuthoritativeItems()));
         /*
          * 8 HistAgent
@@ -68,7 +70,7 @@ public class PersonalitiesImporterTest extends AbstractImporterTest{
         assertEquals(voccount + 8, toList(authoritativeSet.getAuthoritativeItems()).size());
 
         // Check permission scopes are correct.
-        for (AccessibleEntity subject : log.getAction().getSubjects()) {
+        for (AccessibleEntity subject : ev.getSubjects()) {
             assertEquals(authoritativeSet, subject.getPermissionScope());
         }
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/UkrainianUnitImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/UkrainianUnitImporterTest.java
@@ -62,7 +62,9 @@ public class UkrainianUnitImporterTest extends AbstractImporterTest{
         assertTrue(p.containsProperty("project_judaica"));
         
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new CsvImportManager(graph, repo, validUser, UkrainianUnitImporter.class).importFile(ios, logMessage);
+        ImportLog log = new CsvImportManager(graph, repo, validUser, UkrainianUnitImporter.class)
+                .importFile(ios, logMessage);
+        assertTrue(log.hasDoneWork());
 
         /*
          * 17 DocumentaryUnits
@@ -71,7 +73,7 @@ public class UkrainianUnitImporterTest extends AbstractImporterTest{
          * 18 more import Event links (1 for every Unit, 1 for the User)
          * 1 more import Event
          */
-        assertEquals(count+76, getNodeCount(graph));
+        assertEquals(count + 76, getNodeCount(graph));
         printGraph(graph);
 //        assertEquals(voccount + 8, toList(authoritativeSet.getAuthoritativeItems()).size());
        

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/WienerLibraryTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/WienerLibraryTest.java
@@ -70,7 +70,7 @@ public class WienerLibraryTest extends AbstractImporterTest {
 //        int nodeCount = getNodeCount(graph);
 //        ActionManager am = new ActionManager(graph);
 //        logger.info("size : " + toList(validUser.getActions()).size());
-//        ActionManager.EventContext ctx = am.logEvent(validUser,
+//        ActionManager.EventContext ctx = am.newEventContext(validUser,
 //                EventTypes.creation,
 //                Optional.of("Doing something to lots of nodes"));
 //        assertEquals(nodeCount + 2, getNodeCount(graph));
@@ -138,11 +138,11 @@ public class WienerLibraryTest extends AbstractImporterTest {
 //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 4 items
         assertEquals(5, log.getCreated());
-        assertTrue(log.getAction() instanceof SystemEvent);
-        assertEquals(logMessage, log.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
 
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         for(AccessibleEntity subject  : subjects)
             logger.info("identifier: " + subject.getId());
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
@@ -30,6 +30,7 @@ import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.models.cvoc.Vocabulary;
+import eu.ehri.project.models.events.SystemEvent;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.impl.CrudViews;
 import java.io.InputStream;
@@ -140,8 +141,8 @@ public class Wp2BtEadTest extends AbstractImporterTest {
         //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 6 items
         assertEquals(6, logVC.getCreated());
-        assertTrue(logVC.getAction() != null);
-        assertEquals(logMessage, logVC.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
         //assert keywords are matched to cvocs
         assertTrue(toList(c1_b.getLinks()).size() > 0);
@@ -149,7 +150,7 @@ public class Wp2BtEadTest extends AbstractImporterTest {
             logger.debug(a.getLinkType());
         }
 
-        List<AccessibleEntity> subjects = toList(logVC.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         for (AccessibleEntity subject : subjects) {
             logger.info("identifier: " + subject.getId());
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2JmpEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2JmpEadTest.java
@@ -27,6 +27,8 @@ import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.base.AccessibleEntity;
 import java.io.InputStream;
 import java.util.List;
+
+import eu.ehri.project.models.events.SystemEvent;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,8 +100,8 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
         //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 6 items
         assertEquals(7, log.getCreated());
-        assertTrue(log.getAction() != null);
-        assertEquals(logMessage, log.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
 //        //assert keywords are matched to cvocs
 //        assertTrue(toList(c6.getLinks()).size() > 0);
@@ -115,7 +117,7 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
             assertEquals("deu", d.asVertex().getProperty("languageOfMaterial").toString());
         }
 
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         for (AccessibleEntity subject : subjects) {
             logger.info("identifier: " + subject.getId());
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2PersonalitiesImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2PersonalitiesImporterTest.java
@@ -69,7 +69,7 @@ public class Wp2PersonalitiesImporterTest extends AbstractImporterTest{
         assertEquals(voccount + 16, toList(authoritativeSet.getAuthoritativeItems()).size());
 
         // Check permission scopes are correct.
-        for (AccessibleEntity subject : log.getAction().getSubjects()) {
+        for (AccessibleEntity subject : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(authoritativeSet, subject.getPermissionScope());
         }
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
@@ -124,8 +124,8 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         //        Iterable<Action> actions = unit.getHistory();
         // Check we've created 6 items
         assertEquals(4, log.getCreated());
-        assertTrue(log.getAction() instanceof SystemEvent);
-        assertEquals(logMessage, log.getAction().getLogMessage());
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
+        assertEquals(logMessage, ev.getLogMessage());
 
         //assert keywords are matched to cvocs
         assertTrue(toList(c3.getLinks()).size() > 0);
@@ -140,7 +140,7 @@ public class Wp2YvEadTest extends AbstractImporterTest {
             assertEquals(1, hasBody);
         }
 
-        List<AccessibleEntity> subjects = toList(log.getAction().getSubjects());
+        List<AccessibleEntity> subjects = toList(ev.getSubjects());
         int countSubject=0;
         for (AccessibleEntity subject : subjects) {
             logger.info("identifier: " + subject.getId());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosImporterTest.java
@@ -25,6 +25,7 @@ import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.cvoc.Vocabulary;
+import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ public abstract class AbstractSkosImporterTest extends AbstractFixtureTest {
     public static String FILE5 = "cvoc/ghettos.rdf";
 
     protected Actioner actioner;
+    protected ActionManager actionManager;
     protected Vocabulary vocabulary;
 
     @Before
@@ -49,6 +51,7 @@ public abstract class AbstractSkosImporterTest extends AbstractFixtureTest {
         super.setUp();
         actioner = manager.cast(validUser, Actioner.class);
         vocabulary = manager.getFrame("cvoc2", Vocabulary.class);
+        actionManager = new ActionManager(graph);
     }
     
      protected void printGraph(FramedGraph<?> graph) {

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/CampsImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/CampsImporterTest.java
@@ -82,7 +82,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         assertEquals(1, toList(list.get(0).getBroaderConcepts()).size());
 
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
     }
@@ -121,7 +121,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         assertEquals(1, toList(list.get(0).getBroaderConcepts()).size());
 
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/CampsV2_1Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/CampsV2_1Test.java
@@ -82,7 +82,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
         assertEquals(1, toList(list.get(0).getBroaderConcepts()).size());
 
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
     }
@@ -121,7 +121,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
         assertEquals(1, toList(list.get(0).getBroaderConcepts()).size());
 
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
@@ -94,6 +94,7 @@ public class GhettosImporterV20140831Test extends AbstractImporterTest {
        List<VertexProxy> graphState1 = getGraphState(graph);
         ImportLog logv2 = importer.importFile(iosV2, logMessage);
         // After...
+
        List<VertexProxy> graphState2 = getGraphState(graph);
        GraphDiff diff = diffGraph(graphState1, graphState2);
        diff.printDebug(System.out);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
@@ -45,7 +45,7 @@ public class JenaSkosImporterTest extends AbstractSkosImporterTest {
         ImportLog importLog = importer.setDefaultLang("de")
                 .importFile(ClassLoader.getSystemResourceAsStream("cvoc/ehri-skos.rdf"), "ehri-skos");
         assertEquals(877, importLog.getCreated());
-        AccessibleEntity concept = importLog.getAction().getFirstSubject();
+        AccessibleEntity concept = actionManager.getLatestGlobalEvent().getFirstSubject();
         assertEquals("deu", manager.cast(concept, Concept.class)
                 .getDescriptions().iterator().next().getLanguageOfDescription());
     }
@@ -58,7 +58,7 @@ public class JenaSkosImporterTest extends AbstractSkosImporterTest {
         ImportLog importLog = importer.setDefaultLang("de")
                 .importFile(ClassLoader.getSystemResourceAsStream(FILE1), "simple 1");
         assertEquals(1, importLog.getCreated());
-        AccessibleEntity concept = importLog.getAction().getFirstSubject();
+        AccessibleEntity concept = actionManager.getLatestGlobalEvent().getFirstSubject();
         assertEquals("deu", manager.cast(concept, Concept.class)
                 .getDescriptions().iterator().next().getLanguageOfDescription());
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
@@ -93,7 +93,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
         assertEquals(1, toList(list.get(0).getBroaderConcepts()).size());
 
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
         Concept term698 = manager.getFrame("cvoc1-698", Concept.class);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/OwlApiSkosImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/OwlApiSkosImporterTest.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers.cvoc;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.Concept;
+import eu.ehri.project.models.events.SystemEvent;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -45,8 +46,9 @@ public class OwlApiSkosImporterTest extends AbstractSkosImporterTest {
         // being created with the corresponding 3-letter code.
         ImportLog importLog = importer.setDefaultLang("de")
                 .importFile(ClassLoader.getSystemResourceAsStream(FILE1), "simple 1");
+        SystemEvent ev = actionManager.getLatestGlobalEvent();
         assertEquals(1, importLog.getCreated());
-        AccessibleEntity concept = importLog.getAction().getFirstSubject();
+        AccessibleEntity concept = ev.getFirstSubject();
         assertEquals("deu", manager.cast(concept, Concept.class)
                 .getDescriptions().iterator().next().getLanguageOfDescription());
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
@@ -84,7 +84,7 @@ public class Wp2KeywordsTest extends AbstractImporterTest {
         assertTrue(found847);
         
         // Check permission scopes
-        for (AccessibleEntity e : log.getAction().getSubjects()) {
+        for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
     <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>


### PR DESCRIPTION
Creating an event context now does not actually change the graph. Only when it is committed will changes take affect.

This removes the need to roll back the transaction when an idempotent import/ingest does not end up doing any work, and potentially removes the need to hold a lock on the event root node for the duration of an ingest task (although this is handled separately.)

The importers now do no transaction-handling of their own, leaving that aspect to higher levels of the stack, e.g. the command line and web service tools.

Additional changes:
 - bumped Blueprints version to 2.6.0 (since we now have Java 7)
 - bumped version to 0.9.3