### PR TITLE
In the test server, check iterated elements for deletions in the current TX

### DIFF
--- a/ehri-extension/src/test/java/eu/ehri/extension/test/helpers/ServerRunner.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/helpers/ServerRunner.java
@@ -85,8 +85,10 @@ public class ServerRunner {
                 .build();
         neoServer.start();
 
+        Neo4jGraph graph = new Neo4jGraph(neoServer.getDatabase().getGraph());
+        graph.setCheckElementsInTransaction(true);
         FramedGraph<? extends TransactionalGraph> framedGraph
-                = graphFactory.create(new Neo4jGraph(neoServer.getDatabase().getGraph()));
+                = graphFactory.create(graph);
         fixtureLoader = FixtureLoaderFactory.getInstance(framedGraph);
         graphCleaner = new GraphCleaner(framedGraph);
     }

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/helpers/ServerRunner.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/helpers/ServerRunner.java
@@ -25,6 +25,7 @@ import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.frames.FramedGraphFactory;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerModule;
 import eu.ehri.project.test.utils.GraphCleaner;
+import eu.ehri.project.utils.TxCheckedNeo4jGraph;
 import eu.ehri.project.utils.fixtures.FixtureLoader;
 import eu.ehri.project.utils.fixtures.FixtureLoaderFactory;
 import org.neo4j.server.CommunityNeoServer;
@@ -85,7 +86,7 @@ public class ServerRunner {
                 .build();
         neoServer.start();
 
-        Neo4jGraph graph = new Neo4jGraph(neoServer.getDatabase().getGraph());
+        Neo4jGraph graph = new TxCheckedNeo4jGraph(neoServer.getDatabase().getGraph());
         graph.setCheckElementsInTransaction(true);
         FramedGraph<? extends TransactionalGraph> framedGraph
                 = graphFactory.create(graph);


### PR DESCRIPTION
This won't affect runtime behaviour, but should make testing the rest client a bit more repeatable, especially when we fire lots of requests at the server, some of which occasionally fail at the moment.

In any case, this problem should go away with Neo4j 2, which due to read transactions doesn't have index/store inconsistencies nearly as much.