### PR TITLE
Fix some iteration order sensitive tests

### DIFF
--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleDAOTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/BundleDAOTest.java
@@ -137,14 +137,16 @@ public class BundleDAOTest extends ModelTestBase {
     public void testDeletingDependents() throws SerializationError,
             ValidationError, IntegrityError, ItemNotFound {
         DocumentaryUnit c1 = manager.getFrame(ID, DocumentaryUnit.class);
-        Bundle bundle = new Serializer(graph).vertexFrameToBundle(c1);
+        DocumentDescription cd1 = manager.getFrame("cd1", DocumentDescription.class);
+        Bundle bundle = new Serializer(graph).vertexFrameToBundle(cd1);
         assertEquals(2, Iterables.size(c1.getDocumentDescriptions()));
-        assertEquals(2, Iterables.size(c1.getDocumentDescriptions()
-                .iterator().next().getDatePeriods()));
+        assertEquals(2, Iterables.size(cd1.getDatePeriods()));
 
         System.out.println("Orig bundle: " + bundle);
 
-        String dpid = "c1-dp2";
+        String deletePath = "hasDate[0]";
+        String dpid = BundleUtils
+                .getBundle(bundle, deletePath).getId();
         try {
             manager.getFrame(dpid, DatePeriod.class);
         } catch (ItemNotFound e) {
@@ -154,7 +156,7 @@ public class BundleDAOTest extends ModelTestBase {
 
         // Delete the *second* date period from the first description...
         Bundle newBundle = BundleUtils.deleteBundle(
-                bundle, "describes[0]/hasDate[1]");
+                bundle, deletePath);
         System.out.println("Delete bundle: " + newBundle);
         BundleDAO persister = new BundleDAO(graph);
         Mutation<DocumentaryUnit> mutation
@@ -192,9 +194,9 @@ public class BundleDAOTest extends ModelTestBase {
     public void testDeletingWholeBundle() throws SerializationError,
             ValidationError, ItemNotFound {
         DocumentaryUnit c1 = manager.getFrame(ID, DocumentaryUnit.class);
+        DocumentDescription cd1 = manager.getFrame("cd1", DocumentDescription.class);
         Bundle bundle = serializer.vertexFrameToBundle(c1);
-        assertEquals(2, toList(c1.getDocumentDescriptions()
-                .iterator().next().getDatePeriods()).size());
+        assertEquals(2, toList(cd1.getDatePeriods()).size());
         List<DatePeriod> dates = toList(manager.getFrames(
                 EntityClass.DATE_PERIOD, DatePeriod.class));
 

--- a/ehri-frames/src/test/java/eu/ehri/project/persistence/SerializerTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/persistence/SerializerTest.java
@@ -27,10 +27,7 @@ import eu.ehri.project.persistence.utils.BundleUtils;
 import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Mike Bryant (http://github.com/mikesname)
@@ -111,8 +108,11 @@ public class SerializerTest extends AbstractFixtureTest {
         Bundle serialized = serializer.vertexFrameToBundle(link1);
         Bundle target0 = BundleUtils.getBundle(serialized, "hasLinkTarget[0]");
         assertEquals(1, target0.depth());
-        assertEquals("c3",
-                BundleUtils.get(serialized, "hasLinkTarget[0]/identifier"));
+        String t1 = BundleUtils.get(serialized, "hasLinkTarget[0]/identifier");
+        String t2 = BundleUtils.get(serialized, "hasLinkTarget[1]/identifier");
+        assertNotEquals(t1, t2);
+        assertTrue(Lists.newArrayList("c3", "a1").contains(t1));
+        assertTrue(Lists.newArrayList("c3", "a1").contains(t2));
         try {
             BundleUtils.getBundle(serialized, "hasLinkTarget[0]/childOf[0]/describes[0]");
             fail("Max ifBelowLevel serialization should ignore childOf relation for item c3");


### PR DESCRIPTION
These tests will break if/when we update for Neo4j 2.2.x, but they're fragile now since iteration order is not guaranteed.