### PR TITLE
Add ACL graph wrapper

### DIFF
--- a/ehri-extension/src/main/java/eu/ehri/extension/AdminResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AdminResource.java
@@ -22,11 +22,14 @@ package eu.ehri.extension;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.IndexableGraph;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.util.io.graphson.GraphSONMode;
 import com.tinkerpop.blueprints.util.io.graphson.GraphSONWriter;
+import eu.ehri.extension.errors.BadRequester;
 import eu.ehri.project.acl.AclManager;
 import eu.ehri.project.acl.PermissionType;
+import eu.ehri.project.acl.wrapper.AclGraph;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Group;
@@ -87,8 +90,12 @@ public class AdminResource extends AbstractRestResource {
             @Override
             public void write(OutputStream stream) throws IOException, WebApplicationException {
                 try (final Tx tx = graph.getBaseGraph().beginTx()) {
-                    GraphSONWriter.outputGraph(graph, stream, GraphSONMode.EXTENDED);
+                    Accessor accessor = getRequesterUserProfile();
+                    AclGraph<?> aclGraph = new AclGraph<IndexableGraph>(graph.getBaseGraph(), accessor);
+                    GraphSONWriter.outputGraph(aclGraph, stream, GraphSONMode.EXTENDED);
                     tx.success();
+                } catch (BadRequester e) {
+                    throw new RuntimeException(e);
                 }
             }
         }).build();

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/AdminRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/AdminRestClientTest.java
@@ -31,7 +31,10 @@ import javax.ws.rs.core.MediaType;
 import static com.sun.jersey.api.client.ClientResponse.Status.CREATED;
 import static com.sun.jersey.api.client.ClientResponse.Status.OK;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static eu.ehri.project.models.Group.ADMIN_GROUP_IDENTIFIER;
+import static eu.ehri.extension.AbstractRestResource.AUTH_HEADER_NAME;
 import static eu.ehri.extension.AdminResource.ENDPOINT;
 
 /**
@@ -40,6 +43,28 @@ import static eu.ehri.extension.AdminResource.ENDPOINT;
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public class AdminRestClientTest extends BaseRestClientTest {
+
+    @Test
+    public void testExportGraphSONAsAnon() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "_exportGraphSON"));
+        ClientResponse response = resource.get(ClientResponse.class);
+        String data = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertTrue("Anon export must contain publicly-visible item ann1", data.contains("ann1"));
+        assertFalse("Anon export must not contain restricted item ann3", data.contains("ann3"));
+        assertTrue("Anon export must contain promoted item ann4", data.contains("ann4"));
+    }
+
+    @Test
+    public void testExportGraphSONAsAdmin() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "_exportGraphSON"));
+        ClientResponse response = resource.header(AUTH_HEADER_NAME, ADMIN_GROUP_IDENTIFIER)
+                .get(ClientResponse.class);
+        String data = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertTrue("Admin export must contain publicly-visible item ann1", data.contains("ann1"));
+        assertTrue("Admin export must contain restricted item ann3", data.contains("ann3"));
+    }
 
     @Test
     public void testReindexInternal() throws Exception {

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/AclManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/AclManager.java
@@ -126,7 +126,7 @@ public final class AclManager {
      * @param accessor The user/group
      * @return User belongs to the admin group
      */
-    public boolean belongsToAdmin(Accessor accessor) {
+    public static boolean belongsToAdmin(Accessor accessor) {
         if (accessor.isAdmin()) {
             return true;
         }
@@ -144,7 +144,7 @@ public final class AclManager {
      * @param accessor The user/group
      * @return User is an anonymous accessor
      */
-    public boolean isAnonymous(Accessor accessor) {
+    public static boolean isAnonymous(Accessor accessor) {
         Preconditions.checkNotNull(accessor, "NULL accessor given.");
         return accessor instanceof AnonymousAccessor
                 || accessor.getId().equals(
@@ -370,7 +370,7 @@ public final class AclManager {
      * @param accessor The user/group
      * @return A PipeFunction for filtering a set of vertices as the given user
      */
-    public PipeFunction<Vertex, Boolean> getAclFilterFunction(Accessor accessor) {
+    public static PipeFunction<Vertex, Boolean> getAclFilterFunction(Accessor accessor) {
         Preconditions.checkNotNull(accessor, "Accessor is null");
         if (belongsToAdmin(accessor)) {
             return noopFilterFunction();
@@ -641,7 +641,7 @@ public final class AclManager {
      * @param accessor The user/group
      * @return A lookup of accessor vertices
      */
-    private HashSet<Vertex> getAllAccessors(Accessor accessor) {
+    private static HashSet<Vertex> getAllAccessors(Accessor accessor) {
 
         final HashSet<Vertex> all = Sets.newHashSet();
         if (!isAnonymous(accessor)) {
@@ -701,7 +701,7 @@ public final class AclManager {
      * @return A no-op PipeFunction for filtering a list of vertices as an admin
      *         user
      */
-    private PipeFunction<Vertex, Boolean> noopFilterFunction() {
+    private static PipeFunction<Vertex, Boolean> noopFilterFunction() {
         return new PipeFunction<Vertex, Boolean>() {
             public Boolean compute(Vertex v) {
                 return true;

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclEdge.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclEdge.java
@@ -1,0 +1,34 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.pipes.PipeFunction;
+import eu.ehri.project.acl.AclManager;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class AclEdge extends AclElement implements Edge {
+    private final PipeFunction<Vertex,Boolean> aclFilter;
+
+    protected AclEdge(final Edge baseEdge, final AclGraph<?> aclGraph) {
+        super(baseEdge, aclGraph);
+        aclFilter = AclManager.getAclFilterFunction(aclGraph.getAccessor());
+    }
+
+    @Override
+    public Vertex getVertex(Direction direction) throws IllegalArgumentException {
+        final Vertex vertex = ((Edge) baseElement).getVertex(direction);
+        return aclFilter.compute(vertex) ? new AclVertex(((Edge) baseElement).getVertex(direction), graph) : null;
+    }
+
+    @Override
+    public String getLabel() {
+        return ((Edge) this.baseElement).getLabel();
+    }
+
+    public Edge getBaseEdge() {
+        return (Edge) this.baseElement;
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclEdgeIterable.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclEdgeIterable.java
@@ -1,0 +1,68 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Edge;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class AclEdgeIterable implements CloseableIterable<Edge> {
+
+    private final Iterable<Edge> iterable;
+    private final AclGraph<?> graph;
+
+    public AclEdgeIterable(final Iterable<Edge> iterable, final AclGraph<?> graph) {
+        this.iterable = iterable;
+        this.graph = graph;
+    }
+
+
+    @Override
+    public void close() {
+        if (this.iterable instanceof CloseableIterable) {
+            ((CloseableIterable) iterable).close();
+        }
+    }
+
+    @Override
+    public Iterator<Edge> iterator() {
+        return new Iterator<Edge>() {
+            private Iterator<Edge> itty = iterable.iterator();
+            private AclEdge nextEdge;
+
+            public void remove() {
+                this.itty.remove();
+            }
+
+            public boolean hasNext() {
+                if (null != this.nextEdge) {
+                    return true;
+                }
+                while (this.itty.hasNext()) {
+                    final Edge edge = this.itty.next();
+                    nextEdge = new AclEdge(edge, graph);
+                    return true;
+                }
+                return false;
+
+            }
+
+            public Edge next() {
+                if (null != this.nextEdge) {
+                    final AclEdge temp = this.nextEdge;
+                    this.nextEdge = null;
+                    return temp;
+                } else {
+                    while (this.itty.hasNext()) {
+                        final Edge edge = this.itty.next();
+                        return new AclEdge(edge, graph);
+                    }
+                    throw new NoSuchElementException();
+                }
+            }
+        };
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclElement.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclElement.java
@@ -1,0 +1,76 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.util.ElementHelper;
+import eu.ehri.project.models.base.Accessor;
+
+import java.util.Set;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public abstract class AclElement implements Element {
+    protected Element baseElement;
+    protected AclGraph<?> graph;
+
+    protected AclElement(final Element baseElement, final AclGraph<?> graph) {
+        this.baseElement = baseElement;
+        this.graph = graph;
+    }
+
+    @Override
+    public <T> T getProperty(String s) {
+        return baseElement.getProperty(s);
+    }
+
+    @Override
+    public Set<String> getPropertyKeys() {
+        return baseElement.getPropertyKeys();
+    }
+
+    @Override
+    public void setProperty(String s, Object o) {
+        baseElement.setProperty(s, o);
+    }
+
+    @Override
+    public <T> T removeProperty(String s) {
+        return baseElement.removeProperty(s);
+    }
+
+    @Override
+    public void remove() {
+        baseElement.remove();
+    }
+
+    @Override
+    public Object getId() {
+        return baseElement.getId();
+    }
+
+    @Override
+    public String toString() {
+        return "[" + getId() + " (" + graph.getAccessor().getId() + ")]";
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        return ElementHelper.areEqual(this, object);
+    }
+
+    @Override
+    public int hashCode() {
+        // NB: Deliberate decision to ignore
+        // accessor when calculating hashCode
+        // or equality.
+        return baseElement.hashCode();
+    }
+
+    public Element getBaseElement() {
+        return baseElement;
+    }
+
+    public Accessor getAccessor() {
+        return graph.getAccessor();
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclGraph.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclGraph.java
@@ -11,7 +11,7 @@ import eu.ehri.project.models.base.Accessor;
 /**
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class AclGraph<T extends IndexableGraph> implements WrapperGraph<T>, IndexableGraph {
+public class AclGraph<T extends Graph> implements WrapperGraph<T>, Graph {
 
     protected final T baseGraph;
     private final Accessor accessor;
@@ -112,25 +112,5 @@ public class AclGraph<T extends IndexableGraph> implements WrapperGraph<T>, Inde
 
     public Accessor getAccessor() {
         return accessor;
-    }
-
-    @Override
-    public <E extends Element> Index<E> createIndex(String s, Class<E> tClass, Parameter... parameters) {
-        return baseGraph.createIndex(s, tClass, parameters);
-    }
-
-    @Override
-    public <E extends Element> Index<E> getIndex(String s, Class<E> tClass) {
-        return baseGraph.getIndex(s, tClass);
-    }
-
-    @Override
-    public Iterable<Index<? extends Element>> getIndices() {
-        return baseGraph.getIndices();
-    }
-
-    @Override
-    public void dropIndex(String s) {
-        baseGraph.dropIndex(s);
     }
 }

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclGraph.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclGraph.java
@@ -1,0 +1,136 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.*;
+import com.tinkerpop.blueprints.util.wrappers.WrappedGraphQuery;
+import com.tinkerpop.blueprints.util.wrappers.WrapperGraph;
+import com.tinkerpop.gremlin.java.GremlinPipeline;
+import com.tinkerpop.pipes.PipeFunction;
+import eu.ehri.project.acl.AclManager;
+import eu.ehri.project.models.base.Accessor;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class AclGraph<T extends IndexableGraph> implements WrapperGraph<T>, IndexableGraph {
+
+    protected final T baseGraph;
+    private final Accessor accessor;
+    private final PipeFunction<Vertex,Boolean> aclFilter;
+
+    public AclGraph(T graph, Accessor accessor) {
+        this.baseGraph = graph;
+        this.accessor = accessor;
+        this.aclFilter = AclManager.getAclFilterFunction(accessor);
+    }
+
+    @Override
+    public Features getFeatures() {
+        return baseGraph.getFeatures();
+    }
+
+    @Override
+    public Vertex addVertex(Object o) {
+        return baseGraph.addVertex(o);
+    }
+
+    @Override
+    public Vertex getVertex(Object o) {
+        Vertex vertex = baseGraph.getVertex(o);
+        return vertex != null
+                ? (aclFilter.compute(vertex) ? vertex : null)
+                : null;
+    }
+
+    @Override
+    public void removeVertex(Vertex vertex) {
+        baseGraph.removeVertex(vertex);
+    }
+
+    @Override
+    public Iterable<Vertex> getVertices() {
+        return new GremlinPipeline<Vertex, Vertex>(
+                baseGraph.getVertices()).filter(aclFilter);
+
+    }
+
+    @Override
+    public Iterable<Vertex> getVertices(String s, Object o) {
+        return new GremlinPipeline<Vertex, Vertex>(
+                baseGraph.getVertices(s, o)).filter(aclFilter);
+    }
+
+    @Override
+    public Edge addEdge(Object o, Vertex vertex, Vertex vertex2, String s) {
+        return baseGraph.addEdge(o, vertex, vertex2, s);
+    }
+
+    @Override
+    public Edge getEdge(Object o) {
+        return baseGraph.getEdge(o);
+    }
+
+    @Override
+    public void removeEdge(Edge edge) {
+        baseGraph.removeEdge(edge);
+    }
+
+    @Override
+    public Iterable<Edge> getEdges() {
+        return baseGraph.getEdges();
+    }
+
+    @Override
+    public Iterable<Edge> getEdges(String s, Object o) {
+        return baseGraph.getEdges(s, o);
+    }
+
+    @Override
+    public GraphQuery query() {
+        final AclGraph<?> partitionGraph = this;
+        return new WrappedGraphQuery(this.baseGraph.query()) {
+            @Override
+            public Iterable<Edge> edges() {
+                return new AclEdgeIterable(this.query.edges(), partitionGraph);
+            }
+
+            @Override
+            public Iterable<Vertex> vertices() {
+                return new AclVertexIterable(this.query.vertices(), partitionGraph);
+            }
+        };
+    }
+
+    @Override
+    public void shutdown() {
+        baseGraph.shutdown();
+    }
+
+    @Override
+    public T getBaseGraph() {
+        return baseGraph;
+    }
+
+    public Accessor getAccessor() {
+        return accessor;
+    }
+
+    @Override
+    public <E extends Element> Index<E> createIndex(String s, Class<E> tClass, Parameter... parameters) {
+        return baseGraph.createIndex(s, tClass, parameters);
+    }
+
+    @Override
+    public <E extends Element> Index<E> getIndex(String s, Class<E> tClass) {
+        return baseGraph.getIndex(s, tClass);
+    }
+
+    @Override
+    public Iterable<Index<? extends Element>> getIndices() {
+        return baseGraph.getIndices();
+    }
+
+    @Override
+    public void dropIndex(String s) {
+        baseGraph.dropIndex(s);
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclVertex.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclVertex.java
@@ -1,0 +1,51 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.VertexQuery;
+import com.tinkerpop.blueprints.util.wrappers.WrapperVertexQuery;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class AclVertex extends AclElement implements Vertex {
+
+    protected AclVertex(final Vertex baseVertex, final AclGraph<?> graph) {
+        super(baseVertex, graph);
+    }
+
+    @Override
+    public Iterable<Edge> getEdges(Direction direction, String... strings) {
+        return new AclEdgeIterable(((Vertex)this.baseElement).getEdges(direction, strings), this.graph);
+    }
+
+    @Override
+    public Iterable<Vertex> getVertices(Direction direction, String... strings) {
+        return new AclVertexIterable(((Vertex)this.baseElement).getVertices(direction, strings), this.graph);
+    }
+
+    @Override
+    public VertexQuery query() {
+        return new WrapperVertexQuery(((Vertex) this.baseElement).query()) {
+            @Override
+            public Iterable<Vertex> vertices() {
+                return new AclVertexIterable(this.query.vertices(), graph);
+            }
+
+            @Override
+            public Iterable<Edge> edges() {
+                return this.query.edges();
+            }
+        };
+    }
+
+    @Override
+    public Edge addEdge(String label, Vertex vertex) {
+        return this.graph.addEdge(null, this, vertex, label);
+    }
+
+    public Vertex getBaseVertex() {
+        return (Vertex) this.baseElement;
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclVertexIterable.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/wrapper/AclVertexIterable.java
@@ -1,0 +1,77 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.pipes.PipeFunction;
+import eu.ehri.project.acl.AclManager;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class AclVertexIterable implements CloseableIterable<Vertex> {
+    private final Iterable<Vertex> iterable;
+    private final AclGraph<?> graph;
+    private final PipeFunction<Vertex,Boolean> aclFilter;
+
+    public AclVertexIterable(final Iterable<Vertex> iterable, final AclGraph<?> graph) {
+        this.iterable = iterable;
+        this.graph = graph;
+        this.aclFilter = AclManager.getAclFilterFunction(graph.getAccessor());
+    }
+
+    @Override
+    public void close() {
+        if (this.iterable instanceof CloseableIterable) {
+            ((CloseableIterable) iterable).close();
+        }
+    }
+
+    @Override
+    public Iterator<Vertex> iterator() {
+        return new Iterator<Vertex>() {
+            private final Iterator<Vertex> itty = iterable.iterator();
+            private AclVertex nextVertex;
+
+            @Override
+            public boolean hasNext() {
+                if (null != this.nextVertex) {
+                    return true;
+                }
+                while (this.itty.hasNext()) {
+                    final Vertex vertex = this.itty.next();
+                    if (aclFilter.compute(vertex)) {
+                        this.nextVertex = new AclVertex(vertex, graph);
+                        return true;
+                    }
+                }
+                return false;
+
+            }
+
+            @Override
+            public Vertex next() {
+                if (null != this.nextVertex) {
+                    final AclVertex temp = this.nextVertex;
+                    this.nextVertex = null;
+                    return temp;
+                } else {
+                    while (this.itty.hasNext()) {
+                        final Vertex vertex = this.itty.next();
+                        if (aclFilter.compute(vertex)) {
+                            return new AclVertex(vertex, graph);
+                        }
+                    }
+                    throw new NoSuchElementException();
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2Graph.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2Graph.java
@@ -6,7 +6,6 @@ import com.tinkerpop.blueprints.Features;
 import com.tinkerpop.blueprints.GraphQuery;
 import com.tinkerpop.blueprints.Index;
 import com.tinkerpop.blueprints.IndexableGraph;
-import com.tinkerpop.blueprints.KeyIndexableGraph;
 import com.tinkerpop.blueprints.MetaGraph;
 import com.tinkerpop.blueprints.Parameter;
 import com.tinkerpop.blueprints.TransactionalGraph;

--- a/ehri-frames/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
@@ -1,0 +1,81 @@
+package eu.ehri.project.acl.wrapper;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.Repository;
+import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.neo4j.helpers.collection.Iterables;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for ACL graph that provides a 'view' of the available
+ * nodes that a given user is allowed to see. In these tests
+ * the vertex representing documentary unit 'c1' has visibility
+ * restrictions preventing it being seen by the invalid user.
+ *
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class AclGraphTest extends AbstractFixtureTest {
+
+    public AclGraph<?> validUserGraph;
+    public AclGraph<?> invalidUserGraph;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        validUserGraph = new AclGraph(graph.getBaseGraph(), validUser);
+        invalidUserGraph =  new AclGraph(graph.getBaseGraph(), invalidUser);
+    }
+
+    @Test
+    public void testGetVertexAsValidUser() throws Exception {
+        Vertex vertex = manager.getFrame("c1", DocumentaryUnit.class).asVertex();
+        Vertex validUserVertex = validUserGraph.getVertex(vertex.getId());
+        assertEquals(validUserVertex.getId(), vertex.getId());
+    }
+
+    @Test
+    public void testGetVertexAsInvalidUser() throws Exception {
+        Vertex vertex = manager.getFrame("c1", DocumentaryUnit.class).asVertex();
+        Vertex invalidUserVertex = invalidUserGraph.getVertex(vertex.getId());
+        assertNull(invalidUserVertex);
+    }
+
+    @Test
+    public void testGetVerticesAsValidUser() throws Exception {
+        Iterable<Vertex> vertices = validUserGraph.getVertices(Ontology.IDENTIFIER_KEY, "c1");
+        assertTrue(vertices.iterator().hasNext());
+        assertEquals(1L, Iterables.count(vertices));
+    }
+
+    @Test
+    public void testGetVerticesAsInvalidUser() throws Exception {
+        Iterable<Vertex> vertices = invalidUserGraph.getVertices(Ontology.IDENTIFIER_KEY, "c1");
+        assertFalse(vertices.iterator().hasNext());
+        assertEquals(0L, Iterables.count(vertices));
+    }
+
+    @Test
+    public void testTraversalAsInvalidUser() throws Exception {
+        Vertex vertex = manager.getFrame("r1", Repository.class).asVertex();
+        Vertex invalidUserVertex = invalidUserGraph.getVertex(vertex.getId());
+        // Invalid user can see repository r1
+        assertNotNull(invalidUserVertex);
+        // Because three of r1's doc unit nodes are restricted visibility, we
+        // should only get one node (c4) when we traverse 'heldBy'
+        Iterable<Vertex> docs = invalidUserVertex
+                .getVertices(Direction.IN, Ontology.DOC_HELD_BY_REPOSITORY);
+        for (Vertex doc: docs) {
+            System.out.println(doc.getProperty(EntityType.ID_KEY));
+        }
+        assertEquals(3L, Iterables.count(docs));
+    }
+}


### PR DESCRIPTION
The ACL graph is a wrapper that, given an accessor (user/group), hides vertices to which that accessor does not have access.

Currently it is only used in the GraphSON export, providing a means to export the full graph whilst excluding restricted-visibility nodes.