### PR TITLE
Change the way event type/show/item-class params are deserialized.

### DIFF
--- a/ehri-extension/src/main/java/eu/ehri/extension/AbstractRestResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AbstractRestResource.java
@@ -31,6 +31,9 @@ import eu.ehri.extension.errors.BadRequester;
 import eu.ehri.project.acl.AnonymousAccessor;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.core.Tx;
+import eu.ehri.project.core.TxGraph;
+import eu.ehri.project.core.impl.TxNeo4jGraph;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.SerializationError;
@@ -39,9 +42,6 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Frame;
 import eu.ehri.project.persistence.Serializer;
-import eu.ehri.project.core.Tx;
-import eu.ehri.project.core.TxGraph;
-import eu.ehri.project.core.impl.TxNeo4jGraph;
 import eu.ehri.project.views.Query;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
@@ -65,7 +65,6 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 
 /**
@@ -191,34 +190,9 @@ public abstract class AbstractRestResource implements TxCheckedResource {
      * @param key the parameter name
      * @return a list of string values
      */
-    protected Optional<String> getStringQueryParam(String key) {
-        List<String> value = uriInfo.getQueryParameters().get(key);
-        return value.size() == 0
-                ? Optional.<String>absent()
-                : Optional.of(value.get(0));
-    }
-
-    /**
-     * Get a list of values for a given query parameter key.
-     *
-     * @param key the parameter name
-     * @return a list of string values
-     */
     protected List<String> getStringListQueryParam(String key) {
         List<String> value = uriInfo.getQueryParameters().get(key);
         return value == null ? Lists.<String>newArrayList() : value;
-    }
-
-    protected <T extends Enum<T>> List<T> getEnumListQueryParam(String key, Class<T> cls) {
-        List<T> out = Lists.newArrayList();
-        for (String t : getStringListQueryParam(key)) {
-            try {
-                out.add(Enum.valueOf(cls, t));
-            } catch (NoSuchElementException e) {
-                // ignore that value...
-            }
-        }
-        return out;
     }
 
     /**

--- a/ehri-extension/src/main/java/eu/ehri/extension/SystemEventResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/SystemEventResource.java
@@ -23,10 +23,8 @@ import eu.ehri.extension.base.GetResource;
 import eu.ehri.extension.errors.BadRequester;
 import eu.ehri.project.core.Tx;
 import eu.ehri.project.definitions.Entities;
-import eu.ehri.project.definitions.EventTypes;
 import eu.ehri.project.exceptions.AccessDenied;
 import eu.ehri.project.exceptions.ItemNotFound;
-import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Accessor;
@@ -374,22 +372,22 @@ public class SystemEventResource extends AbstractAccessibleEntityResource<System
     // Helpers
 
     private EventViews.Builder getEventViewsBuilder() {
-        List<EventTypes> eventTypes = getEnumListQueryParam(EVENT_TYPE_PARAM, EventTypes.class);
-        List<EntityClass> entityClasses = getEnumListQueryParam(ITEM_TYPE_PARAM, EntityClass.class);
-        List<EventViews.ShowType> showTypes = getEnumListQueryParam(SHOW_PARAM, EventViews.ShowType.class);
+        List<String> eventTypes = getStringListQueryParam(EVENT_TYPE_PARAM);
+        List<String> entityClasses = getStringListQueryParam(ITEM_TYPE_PARAM);
+        List<String> showTypes = getStringListQueryParam(SHOW_PARAM);
         List<String> fromStrings = getStringListQueryParam(FROM_PARAM);
         List<String> toStrings = getStringListQueryParam(TO_PARAM);
         List<String> users = getStringListQueryParam(USER_PARAM);
         List<String> ids = getStringListQueryParam(ITEM_ID_PARAM);
         return new EventViews.Builder(graph)
                 .withRange(getOffset(), getLimit())
-                .withEventTypes(eventTypes.toArray(new EventTypes[eventTypes.size()]))
-                .withEntityTypes(entityClasses.toArray(new EntityClass[entityClasses.size()]))
+                .withEventTypes(eventTypes.toArray(new String[eventTypes.size()]))
+                .withEntityTypes(entityClasses.toArray(new String[entityClasses.size()]))
                 .from(fromStrings.isEmpty() ? null : fromStrings.get(0))
                 .to(toStrings.isEmpty() ? null : toStrings.get(0))
                 .withUsers(users.toArray(new String[users.size()]))
                 .withIds(ids.toArray(new String[ids.size()]))
-                .withShowType(showTypes.toArray(new EventViews.ShowType[showTypes.size()]));
+                .withShowType(showTypes.toArray(new String[showTypes.size()]));
     }
 
     private int getOffset() {

--- a/ehri-frames/src/main/java/eu/ehri/project/views/EventViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/EventViews.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -138,13 +139,25 @@ public class EventViews {
             return this;
         }
 
-        public Builder withEntityTypes(EntityClass... entities) {
-            this.entityTypes.addAll(Lists.newArrayList(entities));
+        public Builder withEntityTypes(String... entities) {
+            for (String entity: entities) {
+                try {
+                    this.entityTypes.add(EntityClass.withName(entity));
+                } catch (NoSuchElementException e) {
+                    logger.warn("Invalid entity type: " + entity);
+                }
+            }
             return this;
         }
 
-        public Builder withEventTypes(EventTypes... eventTypes) {
-            this.eventTypes.addAll(Lists.newArrayList(eventTypes));
+        public Builder withEventTypes(String... eventTypes) {
+            for (String eventType: eventTypes) {
+                try {
+                    this.eventTypes.add(EventTypes.valueOf(eventType));
+                } catch (IllegalArgumentException e) {
+                    logger.warn("Invalid event type: " + eventType);
+                }
+            }
             return this;
         }
 
@@ -158,8 +171,14 @@ public class EventViews {
             return this;
         }
 
-        public Builder withShowType(ShowType... showType) {
-            this.showType.addAll(Lists.newArrayList(showType));
+        public Builder withShowType(String... showTypes) {
+            for (String showType: showTypes) {
+                try {
+                    this.showType.add(ShowType.valueOf(showType));
+                } catch (NoSuchElementException e) {
+                    logger.warn("Invalid show type type: " + showType);
+                }
+            }
             return this;
         }
 


### PR DESCRIPTION
At the cost of making these things more "stringly-typed" we now convert from strings in the builder. This is because trying to do it generically did not work (and nor did the previous Jersey params version).