### PR TITLE
Changes to facilite more RDF-friendly data export.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,27 +60,27 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-cmdline</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -90,7 +90,7 @@
                 <dependency>
                     <groupId>ehri-project</groupId>
                     <artifactId>ehri-extension-sparql</artifactId>
-                    <version>0.10.1-SNAPSHOT</version>
+                    <version>0.10.2-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/ehri-cmdline/pom.xml
+++ b/ehri-cmdline/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cmdline</artifactId>
     <name>Command Line Tools</name>
     <description>Command line tools for interacting with the backend graph DB.</description>
-    <version>0.10.1-SNAPSHOT</version>
+    <version>0.10.2-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
 
         <!-- RDF export -->

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-definitions/src/main/java/eu/ehri/project/definitions/Entities.java
+++ b/ehri-definitions/src/main/java/eu/ehri/project/definitions/Entities.java
@@ -54,4 +54,5 @@ public class Entities {
     public static final String UNDETERMINED_RELATIONSHIP = "relationship";
     public static final String AUTHORITATIVE_SET = "authoritativeSet";
     public static final String VIRTUAL_UNIT = "virtualUnit";
+    public static final String EVENT_LINK = "eventLink";
 }

--- a/ehri-extension-sparql/pom.xml
+++ b/ehri-extension-sparql/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ehri-extension-sparql</artifactId>
-    <version>0.10.1-SNAPSHOT</version>
+    <version>0.10.2-SNAPSHOT</version>
 
     <name>Web Service SparQL Extension</name>
     <description>SparQL endpoint for web service.</description>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -109,14 +109,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/ehri-extension/pom.xml
+++ b/ehri-extension/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>
     <description>Web service layer exposed via a Neo4j extension.</description>
 
     <artifactId>ehri-extension</artifactId>
-    <version>0.10.1-SNAPSHOT</version>
+    <version>0.10.2-SNAPSHOT</version>
 
     <!-- TODO add license info and more -->
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/AbstractRestResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AbstractRestResource.java
@@ -400,13 +400,15 @@ public abstract class AbstractRestResource implements TxCheckedResource {
 
         return Response.ok(new StreamingOutput() {
             @Override
-            public void write(OutputStream os) throws IOException {
-                os.write(header.getBytes(utf8));
+            public void write(OutputStream stream) throws IOException {
                 try {
+                    stream.write(header.getBytes(utf8));
                     for (T item : page.getIterable()) {
-                        os.write(serializer.vertexFrameToXmlString(item)
+                        stream.write(serializer.vertexFrameToXmlString(item)
                                 .getBytes(utf8));
                     }
+                    stream.write(tail.getBytes(utf8));
+
                     tx.success();
                 } catch (SerializationError serializationError) {
                     tx.failure();
@@ -414,7 +416,6 @@ public abstract class AbstractRestResource implements TxCheckedResource {
                 } finally {
                     tx.close();
                 }
-                os.write(tail.getBytes(utf8));
             }
         }).header(RANGE_HEADER_NAME, getPaginationResponseHeader(page))
                 .build();
@@ -447,14 +448,15 @@ public abstract class AbstractRestResource implements TxCheckedResource {
         final Serializer cacheSerializer = serializer.withCache();
         StreamingOutput output = new StreamingOutput() {
             @Override
-            public void write(OutputStream os) throws IOException {
-                JsonGenerator g = jsonFactory.createJsonGenerator(os);
-                g.writeStartArray();
-                try {
+            public void write(OutputStream stream) throws IOException {
+                try (JsonGenerator g = jsonFactory.createJsonGenerator(stream)) {
+                    g.writeStartArray();
                     for (T item : page.getIterable()) {
-                        g.writeRaw('\n');
                         jsonMapper.writeValue(g, cacheSerializer.vertexFrameToData(item));
+                        g.writeRaw('\n');
                     }
+                    g.writeEndArray();
+
                     tx.success();
                 } catch (SerializationError e) {
                     tx.failure();
@@ -462,8 +464,6 @@ public abstract class AbstractRestResource implements TxCheckedResource {
                 } finally {
                     tx.close();
                 }
-                g.writeEndArray();
-                g.close();
             }
         };
         return Response.ok(output)
@@ -517,12 +517,14 @@ public abstract class AbstractRestResource implements TxCheckedResource {
         return Response.ok(new StreamingOutput() {
             @Override
             public void write(OutputStream os) throws IOException {
-                os.write(header.getBytes(utf8));
                 try {
+                    os.write(header.getBytes(utf8));
                     for (T item : list) {
                         os.write(serializer.vertexFrameToXmlString(item)
                                 .getBytes(utf8));
                     }
+                    os.write(tail.getBytes(utf8));
+
                     tx.success();
                 } catch (SerializationError e) {
                     tx.failure();
@@ -530,7 +532,6 @@ public abstract class AbstractRestResource implements TxCheckedResource {
                 } finally {
                     tx.close();
                 }
-                os.write(tail.getBytes(utf8));
             }
         }).build();
     }
@@ -541,13 +542,14 @@ public abstract class AbstractRestResource implements TxCheckedResource {
         return Response.ok(new StreamingOutput() {
             @Override
             public void write(OutputStream arg0) throws IOException {
-                JsonGenerator g = jsonFactory.createJsonGenerator(arg0);
-                g.writeStartArray();
-                try {
+                try (JsonGenerator g = jsonFactory.createJsonGenerator(arg0)) {
+                    g.writeStartArray();
                     for (T item : list) {
                         g.writeRaw('\n');
                         jsonMapper.writeValue(g, cacheSerializer.vertexFrameToData(item));
                     }
+                    g.writeEndArray();
+
                     tx.success();
                 } catch (SerializationError e) {
                     e.printStackTrace();
@@ -556,8 +558,6 @@ public abstract class AbstractRestResource implements TxCheckedResource {
                 } finally {
                     tx.close();
                 }
-                g.writeEndArray();
-                g.close();
             }
         }).build();
     }
@@ -567,18 +567,19 @@ public abstract class AbstractRestResource implements TxCheckedResource {
         final Serializer cacheSerializer = serializer.withCache();
         return Response.ok(new StreamingOutput() {
             @Override
-            public void write(OutputStream arg0) throws IOException {
-                JsonGenerator g = jsonFactory.createJsonGenerator(arg0);
-                g.writeStartArray();
-                try {
+            public void write(OutputStream stream) throws IOException {
+                try (JsonGenerator g = jsonFactory.createJsonGenerator(stream)) {
+                    g.writeStartArray();
                     for (Collection<T> collect : list) {
-                        g.writeRaw('\n');
                         g.writeStartArray();
-                        for (T item: collect) {
+                        for (T item : collect) {
                             jsonMapper.writeValue(g, cacheSerializer.vertexFrameToData(item));
                         }
                         g.writeEndArray();
+                        g.writeRaw('\n');
                     }
+                    g.writeEndArray();
+
                     tx.success();
                 } catch (SerializationError e) {
                     e.printStackTrace();
@@ -587,8 +588,6 @@ public abstract class AbstractRestResource implements TxCheckedResource {
                 } finally {
                     tx.close();
                 }
-                g.writeEndArray();
-                g.close();
             }
         }).build();
     }
@@ -606,14 +605,15 @@ public abstract class AbstractRestResource implements TxCheckedResource {
         final Serializer cacheSerializer = serializer.withCache();
         return Response.ok(new StreamingOutput() {
             @Override
-            public void write(OutputStream arg0) throws IOException {
-                JsonGenerator g = jsonFactory.createJsonGenerator(arg0);
-                g.writeStartArray();
-                try {
+            public void write(OutputStream stream) throws IOException {
+                try (JsonGenerator g = jsonFactory.createJsonGenerator(stream)) {
+                    g.writeStartArray();
                     for (Vertex item : list) {
-                        g.writeRaw('\n');
                         jsonMapper.writeValue(g, cacheSerializer.vertexToData(item));
+                        g.writeRaw('\n');
                     }
+                    g.writeEndArray();
+
                     tx.success();
                 } catch (SerializationError e) {
                     tx.failure();
@@ -621,8 +621,6 @@ public abstract class AbstractRestResource implements TxCheckedResource {
                 } finally {
                     tx.close();
                 }
-                g.writeEndArray();
-                g.close();
             }
         }).build();
     }

--- a/ehri-extension/src/main/java/eu/ehri/extension/AdminResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AdminResource.java
@@ -37,6 +37,7 @@ import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.core.Tx;
+import eu.ehri.project.tools.JsonDataExporter;
 import eu.ehri.project.views.Crud;
 import eu.ehri.project.views.ViewFactory;
 import org.codehaus.jackson.type.TypeReference;
@@ -93,6 +94,25 @@ public class AdminResource extends AbstractRestResource {
                     Accessor accessor = getRequesterUserProfile();
                     AclGraph<?> aclGraph = new AclGraph<IndexableGraph>(graph.getBaseGraph(), accessor);
                     GraphSONWriter.outputGraph(aclGraph, stream, GraphSONMode.EXTENDED);
+                    tx.success();
+                } catch (BadRequester e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/_exportJSON")
+    public Response exportNodes() throws Exception {
+        return Response.ok(new StreamingOutput() {
+            @Override
+            public void write(OutputStream stream) throws IOException, WebApplicationException {
+                try (final Tx tx = graph.getBaseGraph().beginTx()) {
+                    Accessor accessor = getRequesterUserProfile();
+                    AclGraph<?> aclGraph = new AclGraph<IndexableGraph>(graph.getBaseGraph(), accessor);
+                    JsonDataExporter.outputGraph(aclGraph, stream);
                     tx.success();
                 } catch (BadRequester e) {
                     throw new RuntimeException(e);

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/AdminRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/AdminRestClientTest.java
@@ -67,6 +67,15 @@ public class AdminRestClientTest extends BaseRestClientTest {
     }
 
     @Test
+    public void testExportJSON() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "_exportJSON"));
+        ClientResponse response = resource.header(AUTH_HEADER_NAME, ADMIN_GROUP_IDENTIFIER)
+                .get(ClientResponse.class);
+        String data = response.getEntity(String.class);
+        assertStatus(OK, response);
+    }
+
+    @Test
     public void testReindexInternal() throws Exception {
         WebResource resource = client.resource(ehriUri(ENDPOINT, "_reindexInternal"));
         ClientResponse response = resource.post(ClientResponse.class);

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-frames</artifactId>
     <packaging>jar</packaging>
 
 
-    <version>0.10.1-SNAPSHOT</version>
+    <version>0.10.2-SNAPSHOT</version>
 
     <name>EHRI Core API</name>
     <description>Java API for data access and permissions.</description>
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/ehri-frames/src/main/java/eu/ehri/project/core/GraphManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/core/GraphManager.java
@@ -69,6 +69,13 @@ public interface GraphManager {
     public String getType(Vertex vertex);
 
     /**
+     * Get a vertex's properties.
+     *
+     * @return a map of property objects
+     */
+    public Map<String,Object> getProperties(Vertex vertex);
+
+    /**
      * Get the type of an arbitrary vertex.
      *
      * @param vertex A vertex
@@ -233,7 +240,7 @@ public interface GraphManager {
      * Rename an existing vertex, changing its ID.
      *
      * @param vertex the vertex
-     * @param vertex the old ID
+     * @param oldId the old ID
      * @param newId  the new ID
      */
     public void renameVertex(Vertex vertex, String oldId, String newId);

--- a/ehri-frames/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
@@ -82,6 +82,17 @@ public class BlueprintsGraphManager<T extends IndexableGraph> implements GraphMa
     }
 
     @Override
+    public Map<String,Object> getProperties(Vertex vertex) {
+        Map<String,Object> props = Maps.newHashMap();
+        for (String key : vertex.getPropertyKeys()) {
+            if (!key.startsWith(METADATA_PREFIX)) {
+                props.put(key, vertex.getProperty(key));
+            }
+        }
+        return props;
+    }
+
+    @Override
     public EntityClass getEntityClass(Vertex vertex) {
         Preconditions.checkNotNull(vertex);
         return EntityClass.withName(getType(vertex));

--- a/ehri-frames/src/main/java/eu/ehri/project/models/EntityClass.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/EntityClass.java
@@ -25,6 +25,7 @@ import eu.ehri.project.models.cvoc.AuthoritativeSet;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.models.cvoc.ConceptDescription;
 import eu.ehri.project.models.cvoc.Vocabulary;
+import eu.ehri.project.models.events.EventLink;
 import eu.ehri.project.models.events.SystemEvent;
 import eu.ehri.project.models.events.SystemEventQueue;
 import eu.ehri.project.models.events.Version;
@@ -71,7 +72,8 @@ public enum EntityClass {
     MAINTENANCE_EVENT ( Entities.MAINTENANCE_EVENT, "me", MaintenanceEvent.class),
     UNDETERMINED_RELATIONSHIP (Entities.UNDETERMINED_RELATIONSHIP, "rs", UndeterminedRelationship.class),
     LINK (Entities.LINK, "lnk", Link.class),
-    VIRTUAL_UNIT(Entities.VIRTUAL_UNIT, "vu", VirtualUnit.class, IdentifiableEntityIdGenerator.INSTANCE);
+    VIRTUAL_UNIT(Entities.VIRTUAL_UNIT, "vu", VirtualUnit.class, IdentifiableEntityIdGenerator.INSTANCE),
+    EVENT_LINK(Entities.EVENT_LINK, "elnk", EventLink.class);
     // @formatter:on
 
     // Accessors.

--- a/ehri-frames/src/main/java/eu/ehri/project/models/events/EventLink.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/events/EventLink.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.models.events;
+
+import eu.ehri.project.definitions.Entities;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.models.base.Frame;
+
+@EntityType(EntityClass.EVENT_LINK)
+public interface EventLink extends Frame {
+}

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/ActionManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/ActionManager.java
@@ -37,6 +37,7 @@ import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.Frame;
+import eu.ehri.project.models.events.EventLink;
 import eu.ehri.project.models.events.SystemEvent;
 import eu.ehri.project.models.events.SystemEventQueue;
 import eu.ehri.project.models.events.Version;
@@ -516,10 +517,14 @@ public final class ActionManager {
      * type purely for debugging purposes.
      */
     private Vertex getLinkNode(String linkType) {
-        Vertex vertex = graph.addVertex(null);
-        vertex.setProperty(DEBUG_TYPE, EVENT_LINK);
-        vertex.setProperty(LINK_TYPE, linkType);
-        return vertex;
+        try {
+            return dao.create(Bundle.Builder.withClass(EntityClass.EVENT_LINK)
+                    .addDataValue(DEBUG_TYPE, EVENT_LINK)
+                    .addDataValue(LINK_TYPE, linkType).build(),
+                    EventLink.class).asVertex();
+        } catch (ValidationError e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/ehri-frames/src/main/java/eu/ehri/project/tools/JsonDataExporter.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/tools/JsonDataExporter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.tools;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.Vertex;
+import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.persistence.Bundle;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tool for exporting a graph in a manner conducive
+ * to converting it to other formats, e.g. RDF triples,
+ * in a streaming manner.
+ *
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class JsonDataExporter {
+
+    private static final JsonFactory jsonFactory = new JsonFactory();
+    private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+    /**
+     * Export the graph as JSON.
+     *
+     * @param graph  the graph database
+     * @param stream the output stream
+     * @throws IOException
+     */
+    public static void outputGraph(Graph graph, OutputStream stream)
+            throws IOException {
+
+        try (JsonGenerator g = jsonFactory.createJsonGenerator(stream)) {
+            g.writeStartArray();
+            for (Vertex vertex : graph.getVertices()) {
+
+                Map<String, Object> data = Maps.newHashMap();
+                data.put(Bundle.ID_KEY, vertex.getProperty(EntityType.ID_KEY));
+                data.put(Bundle.TYPE_KEY, vertex.getProperty(EntityType.TYPE_KEY));
+                data.put(Bundle.DATA_KEY, getProperties(vertex));
+                data.put(Bundle.REL_KEY, getRelations(vertex));
+
+                jsonMapper.writeValue(g, data);
+                g.writeRaw('\n');
+            }
+            g.writeEndArray();
+        }
+    }
+
+    private static Map<String, Object> getProperties(Vertex vertex) {
+        Map<String,Object> props = Maps.newHashMap();
+        for (String key : vertex.getPropertyKeys()) {
+            if (!key.startsWith("_")) {
+                props.put(key, vertex.getProperty(key));
+            }
+        }
+        return props;
+    }
+
+    private static Map<String,List<List<String>>> getRelations(Vertex vertex) {
+        Map<String,List<List<String>>> outRels = Maps.newHashMap();
+        for (Edge e : vertex.getEdges(Direction.OUT)) {
+            String label = e.getLabel();
+            Vertex other = e.getVertex(Direction.IN);
+            String oid = other.getProperty(EntityType.ID_KEY);
+            String otype = other.getProperty(EntityType.TYPE_KEY);
+            if (oid != null && otype != null) {
+                List<String> ref = Lists.newArrayList(oid, otype);
+                if (!outRels.containsKey(label)) {
+                    outRels.put(label, Lists.<List<String>>newArrayList());
+                }
+
+                outRels.get(label).add(ref);
+            }
+        }
+        return outRels;
+    }
+ }

--- a/ehri-importers/pom.xml
+++ b/ehri-importers/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.1-SNAPSHOT</version>
+        <version>0.10.2-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-importers</artifactId>
-    <version>0.10.1-SNAPSHOT</version>
+    <version>0.10.2-SNAPSHOT</version>
 
     <name>Import Tools</name>
     <description>Classes for importing data.</description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.2-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.10.1-SNAPSHOT</version>
+    <version>0.10.2-SNAPSHOT</version>
    <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>


### PR DESCRIPTION
We don't actually export RDF directly (yet) but the added JSON data export format is easier to transform/stream an entire graph into RDF than GraphSON or bundles, since it is vertex-based and includes both id and type of outgoing relationship target vertices.

The only vertices in the graph which _didn't_ have __ID__ and __ISA__ properties before were event links. This has now been changed so these can be exported with the same transformations as other nodes. A helper has been added to create ID and ISA on event links which don't currently have them.

 - add new `eventLink` type
 - set an entity type and ID on event link nodes in the ActionManager
 - add a WS helper to set these were they don't exist
 - add a data exporter better suited to RDF translation
 - increase version to 0.10.2-SNAPSHOT, since we're adding an entity type
 - clean up and refactor WS streaming methods to reduce chance of TX leaks