### PR TITLE
Rename some web service headers. Fixes #172.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,27 +60,27 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-cmdline</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -90,7 +90,7 @@
                 <dependency>
                     <groupId>ehri-project</groupId>
                     <artifactId>ehri-extension-sparql</artifactId>
-                    <version>0.10.3-SNAPSHOT</version>
+                    <version>0.10.4-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/ehri-cmdline/pom.xml
+++ b/ehri-cmdline/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cmdline</artifactId>
     <name>Command Line Tools</name>
     <description>Command line tools for interacting with the backend graph DB.</description>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
 
         <!-- RDF export -->

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-extension-sparql/pom.xml
+++ b/ehri-extension-sparql/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ehri-extension-sparql</artifactId>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
 
     <name>Web Service SparQL Extension</name>
     <description>SparQL endpoint for web service.</description>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -109,14 +109,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/ehri-extension/pom.xml
+++ b/ehri-extension/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>
     <description>Web service layer exposed via a Neo4j extension.</description>
 
     <artifactId>ehri-extension</artifactId>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
 
     <!-- TODO add license info and more -->
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/AbstractRestResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AbstractRestResource.java
@@ -107,9 +107,9 @@ public abstract class AbstractRestResource implements TxCheckedResource {
      * Header names
      */
     public static final String RANGE_HEADER_NAME = "Content-Range";
-    public static final String AUTH_HEADER_NAME = "Authorization";
     public static final String PATCH_HEADER_NAME = "Patch";
-    public static final String LOG_MESSAGE_HEADER_NAME = "logMessage";
+    public static final String AUTH_HEADER_NAME = "X-User";
+    public static final String LOG_MESSAGE_HEADER_NAME = "X-LogMessage";
     public static final String STREAM_HEADER_NAME = "X-Stream";
 
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/ImportResource.java
@@ -92,7 +92,7 @@ public class ImportResource extends AbstractRestResource {
      * <p/>
      * <pre>
      * <code>curl -X POST \
-     *      -H "Authorization: mike" \
+     *      -H "X-User: mike" \
      *      --data-binary @skos-data.rdf \
      *      "http://localhost:7474/ehri/import/skos?scope=gb-my-vocabulary&log=testing&tolerant=true"
      * </code>
@@ -150,7 +150,7 @@ public class ImportResource extends AbstractRestResource {
      * <p/>
      * <pre>
      * <code>curl -X POST \
-     *      -H "Authorization: mike" \
+     *      -H "X-User: mike" \
      *      --data-binary @ead-list.txt \
      *      "http://localhost:7474/ehri/import/ead?scope=my-repo-id&log=testing&tolerant=true"
      *
@@ -229,7 +229,7 @@ public class ImportResource extends AbstractRestResource {
      * <p/>
      * <pre>
      * <code>curl -X POST \
-     *      -H "Authorization: mike" \
+     *      -H "X-User: mike" \
      *      --data-binary @ead-file.xml \
      *      "http://localhost:7474/ehri/import/single_ead?scope=my-repo-id&log=testing&tolerant=true"
      *
@@ -302,7 +302,7 @@ public class ImportResource extends AbstractRestResource {
      * <p/>
      * <pre>
      * <code>curl -X POST \
-     *      -H "Authorization: mike" \
+     *      -H "X-User: mike" \
      *      --data-binary @csv-list.txt \
      *      "http://localhost:7474/ehri/import/csv?scope=my-repo-id&log=testing"
      *

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-frames</artifactId>
     <packaging>jar</packaging>
 
 
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
 
     <name>EHRI Core API</name>
     <description>Java API for data access and permissions.</description>
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/ehri-importers/pom.xml
+++ b/ehri-importers/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.3-SNAPSHOT</version>
+        <version>0.10.4-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-importers</artifactId>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
 
     <name>Import Tools</name>
     <description>Classes for importing data.</description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.3-SNAPSHOT</version>
+            <version>0.10.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/fabfile.py
+++ b/fabfile.py
@@ -173,7 +173,7 @@ def import_ead(scope, log, properties, file_dir):
     log_file = "/opt/webapps/data/import-data/logs/%s" % log
     properties_file = "/opt/webapps/data/import-data/properties/%s" % properties
     file_list = "/opt/webapps/data/import-metadata/%s.txt" % scope
-    run("curl -m 7200 -X POST -H \"Authorization: $USER\" --data-binary @%s -H \"Content-Type: text/plain\" \"http://localhost:7474/ehri/import/ead?scope=%s&log=%s&tolerant=true&properties=%s\"" % (file_list, scope, log_file, properties_file) )
+    run("curl -m 7200 -X POST -H \"X-User: $USER\" --data-binary @%s -H \"Content-Type: text/plain\" \"http://localhost:7474/ehri/import/ead?scope=%s&log=%s&tolerant=true&properties=%s\"" % (file_list, scope, log_file, properties_file) )
 
 @task
 def import_ead_with_handler(scope, log, properties, file_dir, handler):
@@ -192,7 +192,7 @@ def import_ead_with_handler(scope, log, properties, file_dir, handler):
     log_file = "/opt/webapps/data/import-data/logs/%s" % log
     properties_file = "/opt/webapps/data/import-data/properties/%s" % properties
     file_list = "/opt/webapps/data/import-metadata/%s.txt" % scope
-    run("curl -m 7200 -X POST -H \"Authorization: $USER\" --data-binary @%s -H \"Content-Type: text/plain\" \"http://localhost:7474/ehri/import/ead?scope=%s&log=%s&tolerant=true&properties=%s&handler=%s\"" % (file_list, scope, log_file, properties_file, handler) )
+    run("curl -m 7200 -X POST -H \"X-User: $USER\" --data-binary @%s -H \"Content-Type: text/plain\" \"http://localhost:7474/ehri/import/ead?scope=%s&log=%s&tolerant=true&properties=%s&handler=%s\"" % (file_list, scope, log_file, properties_file, handler) )
 
 @task
 def import_large_ead_with_handler(scope, log, properties, file_dir, handler):
@@ -226,7 +226,7 @@ def import_skos(scope, log, file):
     fab stage import_skos:scope=ehri-camps,log=This+list+of+camps+has+been+compiled+by+EHRI+in+2014,file=authoritativeSet/camps-import.rdf"""
 
     full_file_path = "/opt/webapps/data/import-data/" + file
-    run("curl -X POST -H \"Authorization: $USER\" --data-binary @%s \"http://localhost:7474/ehri/import/skos?scope=%s&log=%s&tolerant=true\"" % (full_file_path, scope, log) )
+    run("curl -X POST -H \"X-User: $USER\" --data-binary @%s \"http://localhost:7474/ehri/import/skos?scope=%s&log=%s&tolerant=true\"" % (full_file_path, scope, log) )
 
 @task
 def import_csv(scope, log, importer, file):
@@ -243,7 +243,7 @@ def import_csv(scope, log, importer, file):
 
     full_file_path = "/opt/webapps/data/import-data/" + file
     full_log_path= "/opt/webapps/data/import-data/logs/" + log
-    run("curl -X POST -H \"Authorization: $USER\" --data-binary @%s \"http://localhost:7474/ehri/import/csv?scope=%s&log=%s&importer=%s\"" % (full_file_path, scope, full_log_path, importer) )
+    run("curl -X POST -H \"X-User: $USER\" --data-binary @%s \"http://localhost:7474/ehri/import/csv?scope=%s&log=%s&importer=%s\"" % (full_file_path, scope, full_log_path, importer) )
 
 @task
 def online_clone_db(local_dir):
@@ -393,7 +393,7 @@ def reindex_users():
     indexer_cmd = [
        "java", "-jar", env.index_helper,
         "--index",
-        "-H", "Authorization=admin",
+        "-H", "X-User=admin",
         "--stats",
         "--solr", "http://localhost:8080/ehri/portal",
         "--rest", "http://localhost:7474/ehri",
@@ -408,7 +408,7 @@ def reindex_concepts():
     indexer_cmd = [
        "java", "-jar", env.index_helper,
         "--index",
-        "-H", "Authorization=admin",
+        "-H", "X-User=admin",
         "--stats",
         "--solr", "http://localhost:8080/ehri/portal",
         "--rest", "http://localhost:7474/ehri",
@@ -422,7 +422,7 @@ def reindex_virtualcollections():
     indexer_cmd = [
        "java", "-jar", env.index_helper,
         "--index",
-        "-H", "Authorization=admin",
+        "-H", "X-User=admin",
         "--stats",
         "--solr", "http://localhost:8080/ehri/portal",
         "--rest", "http://localhost:7474/ehri",
@@ -437,7 +437,7 @@ def reindex_repository(repo_id):
         "java", "-jar", env.index_helper,
         "--clear-key-value", "holderId=" + repo_id,
         "--index",
-        "-H", "Authorization=admin",
+        "-H", "X-User=admin",
         "--stats",
         "--solr", "http://localhost:8080/ehri/portal",
         "--rest", "http://localhost:7474/ehri",
@@ -456,7 +456,7 @@ def reindex_all():
         "java", "-jar", env.index_helper,
         "--clear-all",
         "--index",
-        "-H", "Authorization=admin",
+        "-H", "X-User=admin",
         "--stats",
         "--solr", "http://localhost:8080/ehri/portal",
         "--rest", "http://localhost:7474/ehri",

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
    <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>

--- a/scripts/import-large-batch.sh
+++ b/scripts/import-large-batch.sh
@@ -21,7 +21,7 @@ split -l 100 /opt/webapps/data/import-metadata/$SCOPE.txt /opt/webapps/data/impo
 for TFILE in `ls /opt/webapps/data/import-metadata/$SCOPE-split*`; do
     echo "importing $TFILE..."
     head $TFILE
-    curl -X POST -m 7200 -H "Authorization: $USER" --data-binary @$TFILE -H "Content-Type: text/plain" "http://localhost:7474/ehri/import/ead?scope=$SCOPE&log=$LOGFILE&&properties=$PROPERTIES&handler=$HANDLER"    
+    curl -X POST -m 7200 -H "X-User: $USER" --data-binary @$TFILE -H "Content-Type: text/plain" "http://localhost:7474/ehri/import/ead?scope=$SCOPE&log=$LOGFILE&&properties=$PROPERTIES&handler=$HANDLER"
 done
 
 # Remove split files

--- a/src/site/markdown/install.md
+++ b/src/site/markdown/install.md
@@ -83,7 +83,7 @@ Now we can start the server again and check everything is working:
 
 	$NEO4J_HOME/bin/neo4j start
 
-	curl -H "Authorization:$USER" localhost:7474/ehri/userProfile/$USER
+	curl -H "X-User:$USER" localhost:7474/ehri/userProfile/$USER
 
 We should get the following output (with "mike" replaced by your $USER):
 


### PR DESCRIPTION
Calling the current user header "Authorization" conflicts with Neo4j's
basic auth DBMS server security, and is also a misnomer since it's just
a marker we always trust. It's now renamed `X-User`.

Additionally, rename the `logMessage` header to `X-LogMessage` for
consistency.

Since this breaks behaviour on the front end, bump version.