### PR TITLE
Web service API refactoring (part 1)

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,27 +60,27 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-cmdline</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -90,7 +90,7 @@
                 <dependency>
                     <groupId>ehri-project</groupId>
                     <artifactId>ehri-extension-sparql</artifactId>
-                    <version>0.10.4-SNAPSHOT</version>
+                    <version>0.11.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/ehri-cmdline/pom.xml
+++ b/ehri-cmdline/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cmdline</artifactId>
     <name>Command Line Tools</name>
     <description>Command line tools for interacting with the backend graph DB.</description>
-    <version>0.10.4-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-graphviz</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
         </dependency>
 
         <!-- Command line parsing -->
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -75,14 +75,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-io</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
 
         <!-- RDF export -->

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-extension-sparql/pom.xml
+++ b/ehri-extension-sparql/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ehri-extension-sparql</artifactId>
-    <version>0.10.4-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
 
     <name>Web Service SparQL Extension</name>
     <description>SparQL endpoint for web service.</description>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -109,14 +109,14 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-extension</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>compile</scope>
             <exclusions>
@@ -133,21 +133,21 @@
         <dependency>
             <groupId>org.neo4j.app</groupId>
             <artifactId>neo4j-server</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-io</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/ehri-extension/pom.xml
+++ b/ehri-extension/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>
     <description>Web service layer exposed via a Neo4j extension.</description>
 
     <artifactId>ehri-extension</artifactId>
-    <version>0.10.4-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
 
     <!-- TODO add license info and more -->
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-importers</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -125,36 +125,36 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j.app</groupId>
             <artifactId>neo4j-server</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j.app</groupId>
             <artifactId>neo4j-server</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-io</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>
@@ -192,14 +192,20 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.18.1</version>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>1.19</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/AbstractAccessibleEntityResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AbstractAccessibleEntityResource.java
@@ -124,20 +124,6 @@ public class AbstractAccessibleEntityResource<E extends AccessibleEntity>
     }
 
     /**
-     * Count items accessible to a given user.
-     *
-     * @return Number of items.
-     * @throws BadRequester
-     */
-    public long countItems() throws BadRequester {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            long count = getQuery(cls).count();
-            tx.success();
-            return count;
-        }
-    }
-
-    /**
      * Create an instance of the 'entity' in the database
      *
      * @param entityBundle A bundle of item data

--- a/ehri-extension/src/main/java/eu/ehri/extension/AnnotationResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AnnotationResource.java
@@ -83,20 +83,10 @@ public class AnnotationResource
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
     }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
-    }
-
 
     /**
      * Create an annotation for a particular item.

--- a/ehri-extension/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
@@ -85,22 +85,9 @@ public class AuthoritativeSetResource extends
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        try (Tx tx = graph.getBaseGraph().beginTx()) {
-            long items = countItems();
-            tx.success();
-            return items;
-        }
     }
 
     @GET
@@ -120,23 +107,6 @@ public class AuthoritativeSetResource extends
         } catch (Exception e) {
             tx.close();
             throw e;
-        }
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    @Override
-    public long countChildren(
-            @PathParam("id") String id,
-            @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester {
-        try (Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            AuthoritativeSet set = views.detail(id, user);
-            long count = getQuery(AuthoritativeItem.class).count(set.getAuthoritativeItems());
-            tx.success();
-            return count;
         }
     }
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/ContentTypeResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/ContentTypeResource.java
@@ -62,17 +62,8 @@ public class ContentTypeResource extends AbstractAccessibleEntityResource<Conten
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 }

--- a/ehri-extension/src/main/java/eu/ehri/extension/CountryResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/CountryResource.java
@@ -81,18 +81,9 @@ public class CountryResource
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @GET
@@ -111,24 +102,6 @@ public class CountryResource
         } catch (Exception e) {
             tx.close();
             throw e;
-        }
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    @Override
-    public long countChildren(
-            @PathParam("id") String id,
-            @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester {
-        try (Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Country country = views.detail(id, user);
-            long count = getQuery(Repository.class)
-                    .count(country.getRepositories());
-            tx.success();
-            return count;
         }
     }
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/CvocConceptResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/CvocConceptResource.java
@@ -83,18 +83,9 @@ public class CvocConceptResource
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @PUT
@@ -155,22 +146,6 @@ public class CvocConceptResource
         } catch (Exception e) {
             tx.close();
             throw e;
-        }
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    @Override
-    public long countChildren(@PathParam("id") String id,
-                              @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Concept concept = views.detail(id, user);
-            long count = getQuery(Concept.class).count(concept.getNarrowerConcepts());
-            tx.success();
-            return count;
         }
     }
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
@@ -77,18 +77,9 @@ public class DocumentaryUnitResource
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @GET
@@ -109,25 +100,6 @@ public class DocumentaryUnitResource
         } catch (Exception e) {
             tx.close();
             throw e;
-        }
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    @Override
-    public long countChildren(
-            @PathParam("id") String id,
-            @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester, PermissionDenied {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            DocumentaryUnit parent = manager.getFrame(id, DocumentaryUnit.class);
-            Iterable<DocumentaryUnit> units = all
-                    ? parent.getAllChildren()
-                    : parent.getChildren();
-            long count = getQuery(cls).count(units);
-            tx.success();
-            return count;
         }
     }
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/GroupResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/GroupResource.java
@@ -85,18 +85,9 @@ public class GroupResource
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @POST

--- a/ehri-extension/src/main/java/eu/ehri/extension/HistoricalAgentResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/HistoricalAgentResource.java
@@ -75,18 +75,9 @@ public class HistoricalAgentResource extends AbstractAccessibleEntityResource<Hi
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @POST

--- a/ehri-extension/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/LinkResource.java
@@ -21,6 +21,7 @@ package eu.ehri.extension;
 
 import eu.ehri.extension.base.DeleteResource;
 import eu.ehri.extension.base.GetResource;
+import eu.ehri.extension.base.ListResource;
 import eu.ehri.extension.base.UpdateResource;
 import eu.ehri.extension.errors.BadRequester;
 import eu.ehri.project.acl.PermissionType;
@@ -70,7 +71,7 @@ import java.util.List;
  */
 @Path(Entities.LINK)
 public class LinkResource extends AbstractAccessibleEntityResource<Link>
-        implements GetResource, DeleteResource, UpdateResource {
+        implements GetResource, ListResource, DeleteResource, UpdateResource {
 
     public static final String BODY_PARAM = "body";
 
@@ -94,16 +95,8 @@ public class LinkResource extends AbstractAccessibleEntityResource<Link>
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    public long countResources() throws BadRequester {
-        return countItems();
     }
 
     @PUT

--- a/ehri-extension/src/main/java/eu/ehri/extension/RepositoryResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/RepositoryResource.java
@@ -77,18 +77,9 @@ public class RepositoryResource extends AbstractAccessibleEntityResource<Reposit
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @GET
@@ -110,26 +101,6 @@ public class RepositoryResource extends AbstractAccessibleEntityResource<Reposit
         } catch (Exception e) {
             tx.close();
             throw e;
-        }
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    @Override
-    public long countChildren(
-            @PathParam("id") String id,
-            @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Repository repository = views.detail(id, user);
-            Iterable<DocumentaryUnit> units = all
-                    ? repository.getAllCollections()
-                    : repository.getCollections();
-            long count = getQuery(DocumentaryUnit.class).count(units);
-            tx.success();
-            return count;
         }
     }
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/SystemEventResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/SystemEventResource.java
@@ -20,6 +20,7 @@
 package eu.ehri.extension;
 
 import eu.ehri.extension.base.GetResource;
+import eu.ehri.extension.base.ListResource;
 import eu.ehri.extension.errors.BadRequester;
 import eu.ehri.project.core.Tx;
 import eu.ehri.project.definitions.Entities;
@@ -120,36 +121,16 @@ public class SystemEventResource extends AbstractAccessibleEntityResource<System
     }
 
     /**
-     * List global events. Standard list parameters for paging and filtering apply.
+     * List aggregated global events. Standard list parameters for paging apply.
      *
-     * @throws BadRequester
-     */
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
-    public Response listEvents() throws BadRequester {
-
-        Tx tx = graph.getBaseGraph().beginTx();
-        try {
-            Accessor user = getRequesterUserProfile();
-            EventViews eventViews = getEventViewsBuilder().build();
-            return streamingList(eventViews.list(user), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
-        }
-    }
-
-    /**
-     * Aggregate of global events.
-     *
-     * @param aggregation Aggregate events by strict, or user
+     * @param aggregation The manner in which to aggregate the results, accepting
+     *                    "user", "strict" or "off" (no aggregation). Default is
+     *                    "user".
      * @throws BadRequester
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/aggregate")
-    public Response aggregateEvents(
+    public Response list(
             @QueryParam(AGGREGATION_PARAM) @DefaultValue("user") EventViews.Aggregation aggregation)
             throws BadRequester {
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/UserProfileResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/UserProfileResource.java
@@ -92,15 +92,6 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
@@ -182,7 +173,7 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + FOLLOWERS)
     public Response listFollowers(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
@@ -199,7 +190,7 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + FOLLOWING)
     public Response listFollowing(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
@@ -251,14 +242,12 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws BadRequester, PermissionDenied, ItemNotFound {
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            if (!otherIds.isEmpty()) {
-                Accessor accessor = getRequesterUserProfile();
-                UserProfile user = views.detail(userId, accessor);
-                for (String id : otherIds) {
-                    user.addFollowing(manager.getFrame(id, UserProfile.class));
-                }
-                tx.success();
+            Accessor accessor = getRequesterUserProfile();
+            UserProfile user = views.detail(userId, accessor);
+            for (String id : otherIds) {
+                user.addFollowing(manager.getFrame(id, UserProfile.class));
             }
+            tx.success();
             return Response.status(Status.OK).build();
         }
     }
@@ -285,11 +274,12 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + BLOCKED)
     public Response listBlocked(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
-            return streamingPage(getQuery(UserProfile.class).page(user.getBlocked(), accessor), tx);
+            return streamingPage(getQuery(UserProfile.class)
+                    .page(user.getBlocked(), accessor), tx);
         } catch (Exception e) {
             tx.close();
             throw e;
@@ -351,9 +341,8 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + WATCHING)
     public Response listWatching(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
-
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
             return streamingPage(getQuery(Watchable.class)
@@ -419,9 +408,8 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + Entities.ANNOTATION)
     public Response listAnnotations(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
-
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
             return streamingPage(getQuery(Annotation.class)
@@ -437,12 +425,12 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + Entities.LINK)
     public Response pageLinks(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
-
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
-            return streamingPage(getQuery(Link.class).page(user.getLinks(), accessor), tx);
+            return streamingPage(getQuery(Link.class)
+                    .page(user.getLinks(), accessor), tx);
         } catch (Exception e) {
             tx.close();
             throw e;
@@ -454,9 +442,8 @@ public class UserProfileResource extends AbstractAccessibleEntityResource<UserPr
     @Path("{userId:.+}/" + Entities.VIRTUAL_UNIT)
     public Response pageVirtualUnits(@PathParam("userId") String userId)
             throws ItemNotFound, BadRequester {
-        Tx tx = graph.getBaseGraph().beginTx();
+        final Tx tx = graph.getBaseGraph().beginTx();
         try {
-
             Accessor accessor = getRequesterUserProfile();
             UserProfile user = views.detail(userId, accessor);
             return streamingPage(getQuery(VirtualUnit.class)

--- a/ehri-extension/src/main/java/eu/ehri/extension/VirtualUnitResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/VirtualUnitResource.java
@@ -92,18 +92,9 @@ public final class VirtualUnitResource extends
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
     }
 
     @GET
@@ -187,24 +178,6 @@ public final class VirtualUnitResource extends
             vuViews.moveIncludedUnits(fromVu, toVu, units, currentUser);
             tx.success();
             return Response.status(Response.Status.OK).build();
-        }
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    public long countChildVirtualUnits(
-            @PathParam("id") String id,
-            @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester, PermissionDenied {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            VirtualUnit parent = manager.getFrame(id, VirtualUnit.class);
-            Iterable<VirtualUnit> units = all
-                    ? parent.getAllChildren()
-                    : parent.getChildren();
-            long count = getQuery(cls).count(units);
-            tx.success();
-            return count;
         }
     }
 

--- a/ehri-extension/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -86,35 +86,9 @@ public class VocabularyResource extends AbstractAccessibleEntityResource<Vocabul
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/count")
-    @Override
-    public long count() throws BadRequester {
-        return countItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/list")
     @Override
     public Response list() throws BadRequester {
         return listItems();
-    }
-
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/count")
-    @Override
-    public long countChildren(
-            @PathParam("id") String id,
-            @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
-            throws ItemNotFound, BadRequester {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Vocabulary vocabulary = views.detail(id, user);
-            long count = getQuery(cls).count(vocabulary.getConcepts());
-            tx.success();
-            return count;
-        }
     }
 
     @GET

--- a/ehri-extension/src/main/java/eu/ehri/extension/base/ListResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/base/ListResource.java
@@ -57,12 +57,4 @@ public interface ListResource {
      * @throws BadRequester
      */
     Response list() throws BadRequester;
-
-    /**
-     * Count the number of available resources.
-     *
-     * @return The total number of applicable items
-     * @throws BadRequester
-     */
-    long count() throws BadRequester;
 }

--- a/ehri-extension/src/main/java/eu/ehri/extension/base/ParentResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/base/ParentResource.java
@@ -56,20 +56,6 @@ public interface ParentResource {
             throws ItemNotFound, BadRequester, PermissionDenied;
 
     /**
-     * Count the number of available resources subordinate to this item.
-     *
-     * @param id  The requested item id
-     * @param all Whether to count all child items, or just those at the
-     *            immediate sub-level.
-     * @return The total number of applicable items
-     * @throws ItemNotFound
-     * @throws BadRequester
-     * @throws PermissionDenied
-     */
-    long countChildren(String id, boolean all)
-            throws ItemNotFound, BadRequester, PermissionDenied;
-
-    /**
      * Create a subordinate resource.
      *
      * @param id The parent resource ID.

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/BaseRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/BaseRestClientTest.java
@@ -135,7 +135,7 @@ public class BaseRestClientTest extends RunningServerTest {
      */
     protected List<Map<String, Object>> getEntityList(String entityType,
             String userId, MultivaluedMap<String, String> params) throws Exception {
-        return getItemList("/" + entityType + "/list", userId, params);
+        return getItemList("/" + entityType, userId, params);
     }
 
     protected Integer getPaginationPage(ClientResponse response) {
@@ -161,15 +161,12 @@ public class BaseRestClientTest extends RunningServerTest {
     protected Long getEntityCount(String entityType,
             String userId) throws Exception {
         WebResource resource = client.resource(getExtensionEntryPointUri()
-                + "/" + entityType + "/count");
+                + "/" + entityType);
         ClientResponse response = resource.accept(MediaType.APPLICATION_JSON)
                 .type(MediaType.APPLICATION_JSON)
                 .header(AbstractRestResource.AUTH_HEADER_NAME, userId)
-                .get(ClientResponse.class);
-        String json = response.getEntity(String.class);
-        TypeReference<Long> typeRef = new TypeReference<Long>() {
-        };
-        return jsonMapper.readValue(json, typeRef);
+                .head();
+        return Long.valueOf(getPaginationTotal(response));
     }
 
     protected UriBuilder ehriUriBuilder(String... segments) {

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/SystemEventRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/SystemEventRestClientTest.java
@@ -51,7 +51,7 @@ public class SystemEventRestClientTest extends BaseRestClientTest {
     public void testListActions() throws Exception {
         // Create a new agent. We're going to test that this creates
         // a corresponding action.
-        String url = "/" + Entities.SYSTEM_EVENT + "/aggregate";
+        String url = "/" + Entities.SYSTEM_EVENT;
         List<List<Map<String, Object>>> actionsBefore = getItemListOfLists(
                 url, getAdminUserProfileId());
 
@@ -88,7 +88,7 @@ public class SystemEventRestClientTest extends BaseRestClientTest {
         MultivaluedMap<String, String> badFilters = new MultivaluedMapImpl();
         badFilters.add(SystemEventResource.USER_PARAM, "nobody");
 
-        String url = "/" + Entities.SYSTEM_EVENT + "/aggregate";
+        String url = "/" + Entities.SYSTEM_EVENT;
         List<List<Map<String, Object>>> goodFiltered = getItemListOfLists(
                 url, getAdminUserProfileId(), goodFilters);
 

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -85,18 +85,18 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.7</version>
+            <version>2.8.1</version>
         </dependency>
         <!-- logging -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.2</version>
+            <version>1.7.7</version>
         </dependency>
 
         <dependency>
@@ -162,7 +162,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.11</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>

--- a/ehri-frames/pom.xml
+++ b/ehri-frames/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-frames</artifactId>
     <packaging>jar</packaging>
 
 
-    <version>0.10.4-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
 
     <name>EHRI Core API</name>
     <description>Java API for data access and permissions.</description>
@@ -108,12 +108,12 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-io</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/ehri-importers/pom.xml
+++ b/ehri-importers/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.10.4-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-importers</artifactId>
-    <version>0.10.4-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
 
     <name>Import Tools</name>
     <description>Classes for importing data.</description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-frames</artifactId>
-            <version>0.10.4-SNAPSHOT</version>
+            <version>0.11.0-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-io</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.5</version>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.10.4-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
    <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>


### PR DESCRIPTION
 - remove `/list` from list endpoints (now just using the resource name)
 - remove all `/count` endpoints (can be done using `HEAD` requests on list endpoints)
 - upgrade Neo4j version
 - bump version to 0.11.0

Fix an existing (unnoticed) issue where `HEAD` requests would like a transaction on streaming endpoints.