### PR TITLE
Remove iterables as argument types when not expecting lazy data.

### DIFF
--- a/ehri-frames/src/main/java/eu/ehri/project/acl/AclManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/AclManager.java
@@ -181,7 +181,7 @@ public final class AclManager {
      * @param accessors A set of users/groups who can access the item
      */
     public void setAccessors(AccessibleEntity entity,
-            Iterable<Accessor> accessors) {
+            Collection<Accessor> accessors) {
         Set<Accessor> accessorVertices = Sets.newHashSet(accessors);
         Set<Accessor> remove = Sets.newHashSet();
         for (Accessor accessor : entity.getAccessors()) {

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/BundleDAO.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/BundleDAO.java
@@ -36,6 +36,7 @@ import eu.ehri.project.models.utils.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -61,7 +62,7 @@ public final class BundleDAO {
      * @param graph The graph
      * @param scopeIds The ID set for the current scope.
      */
-    public BundleDAO(FramedGraph<?> graph, Iterable<String> scopeIds) {
+    public BundleDAO(FramedGraph<?> graph, Collection<String> scopeIds) {
         this.graph = graph;
         manager = GraphManagerFactory.getInstance(graph);
         serializer = new Serializer.Builder(graph).dependentOnly().build();

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/BundleValidator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/BundleValidator.java
@@ -30,6 +30,7 @@ import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.utils.ClassUtils;
 
 import java.text.MessageFormat;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -43,9 +44,10 @@ public final class BundleValidator {
     private final GraphManager manager;
     private final List<String> scopes;
 
-    public BundleValidator(GraphManager manager, Iterable<String> scopes) {
+    public BundleValidator(GraphManager manager, Collection<String> scopes) {
         this.manager = manager;
-        this.scopes = Lists.newArrayList(Optional.fromNullable(scopes).or(Lists.<String>newArrayList()));
+        this.scopes = Lists.newArrayList(Optional.fromNullable(scopes)
+                .or(Lists.<String>newArrayList()));
     }
 
     /**

--- a/ehri-frames/src/main/java/eu/ehri/project/views/AnnotationViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/AnnotationViews.java
@@ -46,6 +46,7 @@ import eu.ehri.project.persistence.BundleDAO;
 import eu.ehri.project.persistence.Serializer;
 import eu.ehri.project.persistence.TraversalCallback;
 
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -97,7 +98,7 @@ public final class AnnotationViews implements Scoped<AnnotationViews> {
      * @throws ValidationError
      * @throws ItemNotFound
      */
-    public Annotation createFor(String id, String did, Bundle bundle, Accessor user, Iterable<Accessor> accessibleTo)
+    public Annotation createFor(String id, String did, Bundle bundle, Accessor user, Collection<Accessor> accessibleTo)
             throws PermissionDenied, AccessDenied, ValidationError, ItemNotFound {
         AccessibleEntity entity = manager.getFrame(id, AccessibleEntity.class);
         AnnotatableEntity dep = manager.getFrame(did, AnnotatableEntity.class);

--- a/ehri-frames/src/main/java/eu/ehri/project/views/Query.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/Query.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -416,7 +417,7 @@ public final class Query<E extends AccessibleEntity> implements Scoped<Query> {
      *
      * @param orderSpecs list of orderSpecs
      */
-    public Query<E> orderBy(Iterable<String> orderSpecs) {
+    public Query<E> orderBy(Collection<String> orderSpecs) {
         SortedMap<String, Sort> tmp = QueryUtils.parseOrderSpecs(orderSpecs);
         Query<E> query = this;
         for (Entry<String, Sort> entry : tmp.entrySet()) {
@@ -518,7 +519,7 @@ public final class Query<E extends AccessibleEntity> implements Scoped<Query> {
      * @param filters list of filters
      * @return a new query object
      */
-    public Query<E> filter(Iterable<String> filters) {
+    public Query<E> filter(Collection<String> filters) {
         // FIXME: This is really gross, but we want to allow the arguments
         // to .filter() to be a mix of property filters and traversal path
         // filters, because they'll usually just come straight from some

--- a/ehri-frames/src/main/java/eu/ehri/project/views/QueryUtils.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/QueryUtils.java
@@ -30,6 +30,7 @@ import org.neo4j.helpers.collection.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.SortedMap;
 
@@ -52,7 +53,7 @@ public class QueryUtils {
      * @return A map of filter specs
      */
     static SortedMap<String, Pair<Query.FilterPredicate, String>> parseFilters(
-            Iterable<String> filterList) {
+            Collection<String> filterList) {
         ImmutableSortedMap.Builder<String, Pair<Query.FilterPredicate, String>> builder = new ImmutableSortedMap.Builder<>(
                 Ordering.natural());
         Splitter psplit = Splitter.on("__");
@@ -81,7 +82,7 @@ public class QueryUtils {
      * @param orderSpecs A list of order spec strings
      * @return A map of order specs
      */
-    static SortedMap<String, Query.Sort> parseOrderSpecs(Iterable<String> orderSpecs) {
+    static SortedMap<String, Query.Sort> parseOrderSpecs(Collection<String> orderSpecs) {
         ImmutableSortedMap.Builder<String, Query.Sort> builder = new ImmutableSortedMap.Builder<>(
                 Ordering.natural());
         Splitter psplit = Splitter.on("__");

--- a/ehri-frames/src/test/java/eu/ehri/project/views/QueryTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/views/QueryTest.java
@@ -43,21 +43,18 @@ import static org.junit.Assert.assertTrue;
 
 public class QueryTest extends AbstractFixtureTest {
 
-    private AclManager aclManager;
-
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        aclManager = new AclManager(graph);
     }
 
     @Test
     public void testAdminCanListEverything() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Check we're not admin
-        assertTrue(aclManager.belongsToAdmin(validUser));
+        assertTrue(AclManager.belongsToAdmin(validUser));
 
         // Get the total number of DocumentaryUnits the old-fashioned way
         Iterable<Vertex> allDocs = manager
@@ -95,11 +92,11 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testPage() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Check we're not admin
-        assertTrue(aclManager.belongsToAdmin(validUser));
+        assertTrue(AclManager.belongsToAdmin(validUser));
 
         // Get the total number of DocumentaryUnits the old-fashioned way
         Iterable<Vertex> allDocs = manager
@@ -115,20 +112,20 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testCount() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph, DocumentaryUnit.class);
+        Query<DocumentaryUnit> query = new Query<>(graph, DocumentaryUnit.class);
         assertEquals(5, query.count());
     }
 
     @Test
     public void testUserCannotListPrivate() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Check we're not admin
         Accessor accessor = manager.getFrame("reto", Accessor.class);
         DocumentaryUnit cantRead = manager
                 .getFrame("c1", DocumentaryUnit.class);
-        assertFalse(aclManager.belongsToAdmin(accessor));
+        assertFalse(AclManager.belongsToAdmin(accessor));
 
         List<DocumentaryUnit> list = toList(query.page(accessor));
         assertFalse(list.isEmpty());
@@ -137,7 +134,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithFilter() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Query for document identifier c1.
@@ -149,7 +146,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithStreaming() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class).setStream(true);
 
         // Query for document identifier c1.
@@ -160,7 +157,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithDepthFilter() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Query for only top-level documentary units.
@@ -181,7 +178,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithPredicateFilter() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Query for document identifier c1.
@@ -254,7 +251,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithTraversalFilter() {
-        Query<DocumentaryUnit> query1 = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query1 = new Query<>(graph,
                 DocumentaryUnit.class);
         List<String> filters1 = ImmutableList.of(
           "<-describes.identifier:c1-desc"
@@ -263,7 +260,7 @@ public class QueryTest extends AbstractFixtureTest {
                 .filter(filters1).page(validUser);
         assertEquals(1, Iterables.size(list1));
 
-        Query<Repository> query2 = new Query<Repository>(graph,
+        Query<Repository> query2 = new Query<>(graph,
                 Repository.class);
         List<String> filters2 = ImmutableList.of(
                 "<-describes->hasAddress.city:Brussels"
@@ -276,13 +273,13 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithTraversalOrder() {
-        Query<Repository> query1 = new Query<Repository>(graph, Repository.class);
+        Query<Repository> query1 = new Query<>(graph, Repository.class);
         Iterable<Repository> out1 = query1
                 .orderBy(ImmutableList.of("<-describes.identifier"))
                 .page(validUser);
         List<Repository> list1 = Lists.newLinkedList(out1);
 
-        Query<Repository> query2 = new Query<Repository>(graph, Repository.class);
+        Query<Repository> query2 = new Query<>(graph, Repository.class);
         Iterable<Repository> out2 = query2
                 .orderBy(ImmutableList.of("<-describes.identifier__DESC"))
                 .page(validUser);
@@ -294,7 +291,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithSort() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Query for document identifier c1.
@@ -323,7 +320,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithGlobFilter() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Get the total number of DocumentaryUnits the old-fashioned way
@@ -340,7 +337,7 @@ public class QueryTest extends AbstractFixtureTest {
 
     @Test
     public void testListWithFailFilter() throws Exception {
-        Query<DocumentaryUnit> query = new Query<DocumentaryUnit>(graph,
+        Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
 
         // Do a query that won't match anything.

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/AbstractImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/AbstractImporter.java
@@ -83,7 +83,7 @@ public abstract class AbstractImporter<T> {
 
     public BundleDAO getPersister(List<String> scopeIds) {
         return new BundleDAO(framedGraph,
-                Iterables.concat(permissionScope.idPath(), scopeIds));
+                Lists.newArrayList(Iterables.concat(permissionScope.idPath(), scopeIds)));
     }
 
     public BundleDAO getPersister() {


### PR DESCRIPTION
Addesses #82. Some additional test cleanup.