### PR TITLE
Various cleanups to the importer module.

### DIFF
--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -29,7 +29,7 @@ import eu.ehri.project.core.GraphManagerFactory;
 import eu.ehri.project.importers.AbstractImporter;
 import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.SaxImportManager;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.SaxXmlHandler;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.UserProfile;

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
@@ -24,7 +24,7 @@ import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
-import eu.ehri.project.importers.CsvImportManager;
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.MapImporter;
 import eu.ehri.project.models.UserProfile;

--- a/ehri-extension/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/ImportResource.java
@@ -28,7 +28,7 @@ import eu.ehri.project.exceptions.DeserializationError;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporter;
-import eu.ehri.project.importers.CsvImportManager;
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.EacHandler;
 import eu.ehri.project.importers.EacImporter;
 import eu.ehri.project.importers.EadHandler;
@@ -36,8 +36,8 @@ import eu.ehri.project.importers.EadImporter;
 import eu.ehri.project.importers.EagHandler;
 import eu.ehri.project.importers.EagImporter;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.ImportManager;
-import eu.ehri.project.importers.SaxImportManager;
+import eu.ehri.project.importers.managers.ImportManager;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.SaxXmlHandler;
 import eu.ehri.project.importers.cvoc.SkosImporter;
 import eu.ehri.project.importers.cvoc.SkosImporterFactory;
@@ -354,7 +354,7 @@ public class ImportResource extends AbstractRestResource {
     }
 
     private ImportLog importArchive(ImportManager importManager, String logMessage, InputStream data)
-            throws IOException, ValidationError, ArchiveException {
+            throws IOException, ValidationError, ArchiveException, InputParseError {
         logger.info("Import via compressed archive...");
         try (BufferedInputStream bis = new BufferedInputStream(data);
              ArchiveInputStream archiveInputStream = new

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
@@ -29,6 +29,7 @@ import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Description;
@@ -36,14 +37,13 @@ import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.models.cvoc.AuthoritativeItem;
 import eu.ehri.project.models.cvoc.AuthoritativeSet;
 import eu.ehri.project.persistence.Bundle;
-
-import java.util.List;
-import java.util.Map;
-
 import eu.ehri.project.persistence.BundleDAO;
 import eu.ehri.project.persistence.Mutation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Importer of authoritative items such as historical agents and concepts, loaded
@@ -110,18 +110,18 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
         item.put(Ontology.CREATION_PROCESS, Description.CreationProcess.IMPORT.toString());
 
 
-        SaxXmlHandler.putPropertyInGraph(item, Ontology.NAME_KEY, itemData.get("name").toString());
+        Helpers.putPropertyInGraph(item, Ontology.NAME_KEY, itemData.get("name").toString());
         for (String key : itemData.keySet()) {
             if (!key.equals("id") && !key.equals("name")) {
-                    SaxXmlHandler.putPropertyInGraph(item, key, itemData.get(key).toString());
+                    Helpers.putPropertyInGraph(item, key, itemData.get(key).toString());
             }
 
         }
         if (!item.containsKey("typeOfEntity")) {
-            SaxXmlHandler.putPropertyInGraph(item, "typeOfEntity", "subject");
+            Helpers.putPropertyInGraph(item, "typeOfEntity", "subject");
         }
         if (!item.containsKey(Ontology.LANGUAGE_OF_DESCRIPTION)) {
-            SaxXmlHandler.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, "en");
+            Helpers.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, "en");
         }
         return item;
     }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/DcEuropeanaHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/DcEuropeanaHandler.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.Annotation;
 import eu.ehri.project.models.base.Frame;
 import org.slf4j.Logger;
@@ -65,7 +66,7 @@ private final ImmutableMap<String, Class<? extends Frame>> possibleSubnodes
                     extractIdentifier(currentMap);
                     extractName(currentMap);
                     
-                    putPropertyInGraph(currentMap, "sourceFileId", currentMap.get("objectIdentifier").toString());
+                    Helpers.putPropertyInGraph(currentMap, "sourceFileId", currentMap.get("objectIdentifier").toString());
                     importer.importItem(currentMap, new Stack<String>());
 //                importer.importTopLevelExtraNodes(topLevel, current);
                     //importer.importItem(currentGraphPath.pop(), Lists.<String>newArrayList());

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EadHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EadHandler.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.MaintenanceEvent;
@@ -454,7 +455,7 @@ public class EadHandler extends SaxXmlHandler {
 
     private void addAuthor(Map<String, Object> currentGraph) {
         if (getAuthor() != null) {
-            putPropertyInGraph(currentGraph, "processInfo", getAuthor());
+            Helpers.putPropertyInGraph(currentGraph, "processInfo", getAuthor());
         }
     }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/PersonalitiesImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/PersonalitiesImporter.java
@@ -26,6 +26,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.base.AccessibleEntity;
@@ -126,23 +127,23 @@ public class PersonalitiesImporter extends MapImporter {
         item.put(Ontology.CREATION_PROCESS, Description.CreationProcess.IMPORT.toString());
 
 
-        SaxXmlHandler.putPropertyInGraph(item, Ontology.NAME_KEY, getName(itemData));
+        Helpers.putPropertyInGraph(item, Ontology.NAME_KEY, getName(itemData));
         for (String key : itemData.keySet()) {
             if (!key.equals("id")) {
                 if (!p.containsProperty(key)) {
-                    SaxXmlHandler.putPropertyInGraph(item, SaxXmlHandler.UNKNOWN + key, itemData.get(key).toString());
+                    Helpers.putPropertyInGraph(item, SaxXmlHandler.UNKNOWN + key, itemData.get(key).toString());
                 } else {
-                    SaxXmlHandler.putPropertyInGraph(item, p.getProperty(key), itemData.get(key).toString());
+                    Helpers.putPropertyInGraph(item, p.getProperty(key), itemData.get(key).toString());
                 }
             }
 
         }
         //create all otherFormsOfName
         if (!item.containsKey("typeOfEntity")) {
-            SaxXmlHandler.putPropertyInGraph(item, "typeOfEntity", "person");
+            Helpers.putPropertyInGraph(item, "typeOfEntity", "person");
         }
         if (!item.containsKey(Ontology.LANGUAGE_OF_DESCRIPTION)) {
-            SaxXmlHandler.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, "en");
+            Helpers.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, "en");
         }
         return item;
     }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/UkrainianUnitImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/UkrainianUnitImporter.java
@@ -25,6 +25,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
@@ -165,23 +166,23 @@ public class UkrainianUnitImporter extends MapImporter {
                     (!key.equals("language_of_description"))  //dealt with in importItem
                     ) {
                 if (!p.containsProperty(key)) {
-                    SaxXmlHandler.putPropertyInGraph(item, SaxXmlHandler.UNKNOWN + key, itemData.get(key).toString());
+                    Helpers.putPropertyInGraph(item, SaxXmlHandler.UNKNOWN + key, itemData.get(key).toString());
                 } else {
                     Object value = itemData.get(key);
                     // TODO: Check if the property is an allowedMultivalue one...
                     if (value.toString().contains(MULTIVALUE_SEP)) {
                         for (String v : value.toString().split(MULTIVALUE_SEP)) {
-                            SaxXmlHandler.putPropertyInGraph(item, p.getProperty(key), v);
+                            Helpers.putPropertyInGraph(item, p.getProperty(key), v);
                         }
                     } else {
-                        SaxXmlHandler.putPropertyInGraph(item, p.getProperty(key), value.toString());
+                        Helpers.putPropertyInGraph(item, p.getProperty(key), value.toString());
                     }
                 }
             }
 
         }
         //replace the language from the itemData with the one specified in the param
-        SaxXmlHandler.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, language);
+        Helpers.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, language);
         return item;
     }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/Wp2PersonalitiesImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/Wp2PersonalitiesImporter.java
@@ -26,6 +26,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.properties.XmlImportProperties;
+import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.base.AccessibleEntity;
@@ -106,19 +107,19 @@ public abstract class Wp2PersonalitiesImporter extends MapImporter {
         for (String key : itemData.keySet()) {
             if (!key.equals("id")) {
                 if (!p.containsProperty(key)) {
-                    SaxXmlHandler.putPropertyInGraph(item, SaxXmlHandler.UNKNOWN + key, itemData.get(key).toString());
+                    Helpers.putPropertyInGraph(item, SaxXmlHandler.UNKNOWN + key, itemData.get(key).toString());
                 } else {
-                    SaxXmlHandler.putPropertyInGraph(item, p.getProperty(key), itemData.get(key).toString());
+                    Helpers.putPropertyInGraph(item, p.getProperty(key), itemData.get(key).toString());
                 }
             }
 
         }
         //create all otherFormsOfName
         if (!item.containsKey("typeOfEntity")) {
-            SaxXmlHandler.putPropertyInGraph(item, "typeOfEntity", "person");
+            Helpers.putPropertyInGraph(item, "typeOfEntity", "person");
         }
         if (!item.containsKey(Ontology.LANGUAGE_OF_DESCRIPTION)) {
-            SaxXmlHandler.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, "en");
+            Helpers.putPropertyInGraph(item, Ontology.LANGUAGE_OF_DESCRIPTION, "en");
         }
         return item;
     }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/exceptions/InputParseError.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/exceptions/InputParseError.java
@@ -21,7 +21,7 @@ package eu.ehri.project.importers.exceptions;
 
 /**
  * The input data supplied was invalid in some way, detailed by @param cause.
- * 
+ *
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public class InputParseError extends Exception {
@@ -29,10 +29,29 @@ public class InputParseError extends Exception {
 
     /**
      * Constructor.
-     * 
-     * @param cause
+     *
+     * @param cause the root exception
      */
     public InputParseError(Throwable cause) {
         super(cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message a description of the error
+     */
+    public InputParseError(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message a description of the error
+     * @param cause the root exception
+     */
+    public InputParseError(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/exceptions/InvalidXmlDocument.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/exceptions/InvalidXmlDocument.java
@@ -25,7 +25,7 @@ package eu.ehri.project.importers.exceptions;
  * @author Mike Bryant (http://github.com/mikesname)
  *
  */
-public class InvalidXmlDocument extends Exception {
+public class InvalidXmlDocument extends InputParseError {
     private static final long serialVersionUID = -3771058149749123884L;
 
     public InvalidXmlDocument(String type) {

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/managers/ImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/managers/ImportManager.java
@@ -17,9 +17,10 @@
  * permissions and limitations under the Licence.
  */
 
-package eu.ehri.project.importers;
+package eu.ehri.project.importers.managers;
 
 import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 
@@ -29,20 +30,19 @@ import java.util.List;
 
 /**
  * An Import Manager takes a single file or stream, or a list of files, and a log message
- * and imports the data from the file into the database, 
+ * and imports the data from the file into the database,
  * linking the import as an action with the given log message.
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
 public interface ImportManager {
-    
+
     /**
      * Import a file by specifying its path.
-     * 
-     * @param filePath         path to the file to import
-     * @param logMessage       an optional message to describe the import
-     * @return                 an ImportLog for the given file
      *
+     * @param filePath   path to the file to import
+     * @param logMessage an optional message to describe the import
+     * @return an ImportLog for the given file
      * @throws IOException     when reading or writing files fails
      * @throws InputParseError when parsing the file fails
      * @throws ValidationError when the content of the file is invalid
@@ -50,12 +50,42 @@ public interface ImportManager {
     ImportLog importFile(String filePath, String logMessage)
             throws IOException, InputParseError, ValidationError;
 
+    /**
+     * Import an item via an input stream.
+     *
+     * @param ios        the input stream
+     * @param logMessage an optional log message to describe the import
+     * @return an ImportLog for the given stream
+     * @throws IOException     when reading or writing fails
+     * @throws InputParseError when parsing the stream data fails
+     * @throws ValidationError when the content of the file is invalid
+     */
     ImportLog importFile(InputStream ios, String logMessage)
             throws IOException, InputParseError, ValidationError;
-    
-    ImportLog importFiles(List<String> paths, String logMessage)
-            throws IOException, ValidationError;
 
+    /**
+     * Import multiple files via a list of file paths.
+     *
+     * @param paths      the input stream
+     * @param logMessage an optional log message to describe the import
+     * @return an ImportLog for the given stream
+     * @throws IOException     when reading or writing fails
+     * @throws InputParseError when parsing the stream data fails
+     * @throws ValidationError when the content of the file is invalid
+     */
+    ImportLog importFiles(List<String> paths, String logMessage)
+            throws IOException, InputParseError, ValidationError;
+
+    /**
+     * Import multiple items via an archive input stream.
+     *
+     * @param inputStream the archive input stream
+     * @param logMessage  an optional log message to describe the import
+     * @return an ImportLog for the given stream
+     * @throws IOException     when reading or writing fails
+     * @throws InputParseError when parsing the stream data fails
+     * @throws ValidationError when the content of the file is invalid
+     */
     ImportLog importFiles(ArchiveInputStream inputStream, String logMessage)
-            throws IOException, ValidationError;
+            throws IOException, InputParseError, ValidationError;
 }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
@@ -25,6 +25,7 @@ import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.AbstractImportManager;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Description;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Bbwo2HandlerTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Bbwo2HandlerTest.java
@@ -25,6 +25,7 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveSplitTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveSplitTest.java
@@ -23,6 +23,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveVcTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveVcTest.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.VirtualUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAATest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAATest.java
@@ -24,6 +24,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaABTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaABTest.java
@@ -25,6 +25,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAraTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaAraTest.java
@@ -23,6 +23,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.base.PermissionScope;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaCATest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CegesomaCATest.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CsvAuthItemImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CsvAuthItemImporterTest.java
@@ -23,6 +23,7 @@
  */
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.AuthoritativeSet;
 import org.junit.Test;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CsvConceptImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CsvConceptImporterTest.java
@@ -23,6 +23,7 @@
  */
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Description;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/CsvDossinImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/CsvDossinImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/DansEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/DansEadImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/EacImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/EacImporterTest.java
@@ -23,22 +23,26 @@ import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.HistoricalAgentDescription;
-import eu.ehri.project.models.Link;
 import eu.ehri.project.models.UnknownProperty;
-import eu.ehri.project.models.base.*;
+import eu.ehri.project.models.base.AccessibleEntity;
+import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.events.SystemEvent;
-import java.io.InputStream;
-import java.util.List;
-import static org.junit.Assert.*;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
- *
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
 public class EacImporterTest extends AbstractImporterTest {
@@ -46,67 +50,21 @@ public class EacImporterTest extends AbstractImporterTest {
     private static final Logger logger = LoggerFactory.getLogger(EacImporterTest.class);
 
     @Test
-    @Ignore("these referred nodes are done differently now")
-    public void testAbwehrWithAllReferredNodes() throws Exception {
-        final String SINGLE_EAC = "abwehr.xml";
-        final String logMessage = "Importing EAC " + SINGLE_EAC + " and creating all two relations with previously created HistoricalAgents";
-        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAC);
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class).setTolerant(Boolean.TRUE).importFile(ClassLoader.getSystemResourceAsStream("geheime-feldpolizei.xml"), logMessage);
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class).setTolerant(Boolean.TRUE).importFile(ClassLoader.getSystemResourceAsStream("ss-rasse.xml"), logMessage);
-        //import abwehr last, so it will find the other UR's
-        ImportLog log = new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
-        printGraph(graph);
-        HistoricalAgent abwehr = manager.getFrame("381", HistoricalAgent.class);
-        logger.debug(abwehr.getId());
-        assertEquals(Entities.HISTORICAL_AGENT, abwehr.getType());
-        assertTrue(abwehr != null);
-        for(Description abwehrDesc : abwehr.getDescriptions()){
-            logger.debug(abwehrDesc.getName());
-        }
-        for(Link a : abwehr.getLinks()){
-            logger.info(a.getId() + " has targets: " + toList(a.getLinkTargets()).size());
-            for (LinkableEntity e : a.getLinkTargets()){
-                logger.debug(e.getType());
-            }
-            assertEquals(2, toList(a.getLinkBodies()).size());
-        }
-        assertEquals(2, toList(abwehr.getLinks()).size());
-
-        HistoricalAgent ssrasse = manager.getFrame("418", HistoricalAgent.class);
-        logger.debug(ssrasse.getId());
-        assertEquals(Entities.HISTORICAL_AGENT, ssrasse.getType());
-        assertEquals(1, toList(ssrasse.getLinks()).size());
-
-        HistoricalAgent feldpolizei = manager.getFrame("717", HistoricalAgent.class);
-        logger.debug(feldpolizei.getId());
-        assertEquals(Entities.HISTORICAL_AGENT, feldpolizei.getType());
-        assertEquals(1, toList(feldpolizei.getLinks()).size());
-        for(Description polizeiDesc : feldpolizei.getDescriptions()){
-            assertEquals("Geheime Feldpolizei", polizeiDesc.getName());
-        }
-
-    }
-
-        @Test
     public void testAbwehrWithOUTAllReferredNodes() throws Exception {
-        final String SINGLE_EAC = "abwehr.xml";
-        final String logMessage = "Importing EAC " + SINGLE_EAC + " without creating any annotation, since the targets are not present in the graph";
+        String eacFile = "abwehr.xml";
+        String logMessage = "Importing EAC " + eacFile + " without creating any annotation, since the targets are not present in the graph";
         int count = getNodeCount(graph);
-        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAC);
-        
-                // Before...
-       List<VertexProxy> graphState1 = getGraphState(graph);
-        ImportLog log = new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
+        InputStream ios = ClassLoader.getSystemResourceAsStream(eacFile);
+
+        // Before...
+        List<VertexProxy> graphState1 = getGraphState(graph);
+        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
                 EacHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
         // After...
-       List<VertexProxy> graphState2 = getGraphState(graph);
-       GraphDiff diff = diffGraph(graphState1, graphState2);
-       diff.printDebug(System.out);
+        List<VertexProxy> graphState2 = getGraphState(graph);
+        GraphDiff diff = diffGraph(graphState1, graphState2);
+        diff.printDebug(System.out);
 
-//        printGraph(graph);
         /**
          * How many new nodes will have been created? We should have
          * null: 2
@@ -115,77 +73,78 @@ public class EacImporterTest extends AbstractImporterTest {
          * maintenanceEvent: 2
          * systemEvent: 1
          * historicalAgentDescription: 1
-        **/
+         **/
         assertEquals(count + 8, getNodeCount(graph));
-        
+
         HistoricalAgent abwehr = manager.getFrame("381", HistoricalAgent.class);
         logger.debug(abwehr.getId());
         assertEquals(Entities.HISTORICAL_AGENT, abwehr.getType());
         assertNotNull(abwehr);
         assertEquals(0, toList(abwehr.getAnnotations()).size());
-        
-        for(Description desc : abwehr.getDescriptions()){
+
+        for (Description desc : abwehr.getDescriptions()) {
             logger.debug(desc.getLanguageOfDescription());
-            for(UnknownProperty u: desc.getUnknownProperties()){
+            for (UnknownProperty u : desc.getUnknownProperties()) {
                 logger.debug(u.getType());
             }
         }
-        
+
     }
 
-//        @Test
+    @Test
     public void testImportItemsAlgemeyner() throws Exception {
-        final String SINGLE_EAC = "algemeyner-yidisher-arbeter-bund-in-lite-polyn-un-rusland.xml";
-        // Depends on fixtures
-        final String TEST_REPO = "r1";
-        // Depends on hierarchical-ead.xml
-        final String IMPORTED_ITEM_ID = "159#object";
-        final String AUTHORITY_DESC = "159";
+        String eacFile = "algemeyner-yidisher-arbeter-bund-in-lite-polyn-un-rusland.xml";
+        String itemId = "159#object";
+        String itemDesc = "159";
 
-        final String logMessage = "Importing EAC " + SINGLE_EAC;
+        String logMessage = "Importing EAC " + eacFile;
 
         int count = getNodeCount(graph);
         logger.debug("count of nodes before importing: " + count);
 
-        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAC);
+        List<VertexProxy> before = getGraphState(graph);
+
+        InputStream ios = ClassLoader.getSystemResourceAsStream(eacFile);
         ImportLog log = new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
                 EacHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
-        printGraph(graph);
+
+        List<VertexProxy> after = getGraphState(graph);
+        diffGraph(before, after).printDebug(System.err);
         // How many new nodes will have been created? We should have
         // - 1 more HistoricalAgent
         // - 1 more HistoricalAgentDescription
+        // - 1 property
         // - 2 more MaintenanceEvent 
         // - 2 more linkEvents (1 for the HistoricalAgent, 1 for the User)
         // - 1 more SystemEvent
-        assertEquals(count + 7, getNodeCount(graph));
+        assertEquals(count + 8, getNodeCount(graph));
 
-            Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY,
-                    IMPORTED_ITEM_ID);
-            assertTrue(docs.iterator().hasNext());
-            HistoricalAgent unit = graph.frame(
-                    getVertexByIdentifier(graph,IMPORTED_ITEM_ID),
-                    HistoricalAgent.class);
+        Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY,
+                itemId);
+        assertTrue(docs.iterator().hasNext());
+        HistoricalAgent unit = graph.frame(
+                getVertexByIdentifier(graph, itemId),
+                HistoricalAgent.class);
 
         // check the child items
         HistoricalAgentDescription c1 = graph.frame(
-                getVertexByIdentifier(graph, AUTHORITY_DESC),
+                getVertexByIdentifier(graph, itemDesc),
                 HistoricalAgentDescription.class);
         assertEquals(Entities.HISTORICAL_AGENT_DESCRIPTION, c1.getType());
 
 
         assertTrue(c1.asVertex().getProperty(Ontology.NAME_KEY) instanceof String);
-        assertTrue(c1.asVertex().getProperty("otherFormsOfName") instanceof String);
+        assertNotNull(c1.asVertex().getProperty("otherFormsOfName"));
+        // Alt names should be an array
+        assertFalse(c1.asVertex().getProperty("otherFormsOfName") instanceof String);
 
         // Ensure that c1 is a description of the unit
         for (Description d : unit.getDescriptions()) {
 
             assertEquals(d.getName(), c1.getName());
-                assertEquals(d.getEntity().getId(), unit.getId());
-            }
+            assertEquals(d.getEntity().getId(), unit.getId());
+        }
 
-//TODO: find out why the unit and the action are not connected ...
-//            Iterable<Action> actions = unit.getHistory();
-//            assertEquals(1, toList(actions).size());
         // Check we've only got one action
         assertEquals(1, log.getCreated());
         SystemEvent ev = actionManager.getLatestGlobalEvent();
@@ -195,9 +154,5 @@ public class EacImporterTest extends AbstractImporterTest {
         List<AccessibleEntity> subjects = toList(ev.getSubjects());
         assertEquals(1, subjects.size());
         assertEquals(log.getChanged(), subjects.size());
-
-
-//        System.out.println("created: " + log.getCreated());
-
     }
 }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Eag2896Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Eag2896Test.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.Country;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.RepositoryDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/FinlandXmlImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/FinlandXmlImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/GenericEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/GenericEadImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import java.io.InputStream;
 import java.util.List;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadImporterTest.java
@@ -21,6 +21,8 @@ package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.ImportManager;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.base.AccessibleEntity;
@@ -58,7 +60,7 @@ public class IcaAtomEadImporterTest extends AbstractImporterTest{
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        AbstractImportManager importManager = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        ImportManager importManager = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .setTolerant(Boolean.TRUE);
         ImportLog log = importManager.importFile(ios, logMessage);
 //        printGraph(graph);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadSingleEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomEadSingleEadTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.base.AccessibleEntity;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomJohnCageTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomJohnCageTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import java.io.InputStream;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomMultiLeveledTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IcaAtomMultiLeveledTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Vertex;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Description;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IfzTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IfzTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/IpnTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/IpnTest.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/ItsTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.*;
 import java.io.InputStream;
 import java.util.List;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Jmp130Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Jmp130Test.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/JmpEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/JmpEadTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/MemShoahTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/MemShoahTest.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/NiodEadXsdTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/NiodEadXsdTest.java
@@ -23,6 +23,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.AuthoritativeSet;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesV2Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesV2Test.java
@@ -25,6 +25,7 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/StadsarchiefAdamTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/StadsarchiefAdamTest.java
@@ -22,6 +22,7 @@ package eu.ehri.project.importers;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/UkrainianUnitImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/UkrainianUnitImporterTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.importers;
 
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.Country;
 import eu.ehri.project.models.EntityClass;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/UshmmTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/UshmmTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Description;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/VC_ARAImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/VC_ARAImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import java.io.InputStream;
 import java.util.List;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/VirtualEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/VirtualEadTest.java
@@ -24,6 +24,7 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/WegwijzerEadImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/WegwijzerEadImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import java.io.InputStream;
 import java.util.List;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/WienerLibraryTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/WienerLibraryTest.java
@@ -29,6 +29,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.base.AccessibleEntity;
@@ -85,7 +86,7 @@ public class WienerLibraryTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, 
+        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class,
                 new XmlImportProperties("wienerlib.properties"))
                 .setTolerant(Boolean.FALSE);
         ImportLog log = importManager.importFile(ios, logMessage);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2JmpEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2JmpEadTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2PersonalitiesImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2PersonalitiesImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.AuthoritativeSet;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
@@ -21,6 +21,7 @@ package eu.ehri.project.importers;
 
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/YadVashemTest.java
@@ -24,6 +24,7 @@
 package eu.ehri.project.importers;
 
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;


### PR DESCRIPTION
 - move import managers to sub-package
 - clean up exceptions the main interface throws
 - refactor some dependencies between SAX and CSV stuff
 - cleanup some tests, remove @Ignore'd code
 - various Javadoc cleanups