### PR TITLE
Renaming, formatting, code smell and dead code removal.

### DIFF
--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/CountryAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/CountryAdd.java
@@ -92,7 +92,7 @@ public class CountryAdd extends BaseCommand {
                 .withDataValue(Ontology.IDENTIFIER_KEY, countryId)
                 .withDataValue(Ontology.NAME_KEY, countryName);
 
-        String nodeId = EntityClass.COUNTRY.getIdgen().generateId(SystemScope.getInstance().idPath(), bundle);
+        String nodeId = EntityClass.COUNTRY.getIdGen().generateId(SystemScope.getInstance().idPath(), bundle);
         bundle = bundle.withId(nodeId);
 
         try {

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/EntityAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/EntityAdd.java
@@ -114,7 +114,7 @@ public class EntityAdd extends BaseCommand {
             builder.addDataValue((String) prop, properties.getProperty((String) prop));
         }
         Bundle bundle = builder.build();
-        String id = entityClass.getIdgen().generateId(scope.idPath(), bundle);
+        String id = entityClass.getIdGen().generateId(scope.idPath(), bundle);
 
         try {
             createItem(graph, cmdLine, id, bundle, scope, user, logMessage);

--- a/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserAdd.java
+++ b/ehri-cmdline/src/main/java/eu/ehri/project/commands/UserAdd.java
@@ -97,7 +97,7 @@ public class UserAdd extends BaseCommand {
                 Maps.<String, Object> newHashMap())
                 .withDataValue(Ontology.IDENTIFIER_KEY, userId)
                 .withDataValue(Ontology.NAME_KEY, userName);
-        String nodeId = EntityClass.USER_PROFILE.getIdgen()
+        String nodeId = EntityClass.USER_PROFILE.getIdGen()
                 .generateId(SystemScope.getInstance().idPath(), bundle);
         bundle = bundle.withId(nodeId);
 

--- a/ehri-definitions/src/main/java/eu/ehri/project/definitions/Entities.java
+++ b/ehri-definitions/src/main/java/eu/ehri/project/definitions/Entities.java
@@ -51,7 +51,7 @@ public class Entities {
     public static final String CVOC_CONCEPT_DESCRIPTION = "cvocConceptDescription";
     public static final String SYSTEM = "system";
     public static final String MAINTENANCE_EVENT ="maintenanceEvent";
-    public static final String UNDETERMINED_RELATIONSHIP = "relationship";
+    public static final String ACCESS_POINT = "relationship";
     public static final String AUTHORITATIVE_SET = "authoritativeSet";
     public static final String VIRTUAL_UNIT = "virtualUnit";
     public static final String EVENT_LINK = "eventLink";

--- a/ehri-definitions/src/main/java/eu/ehri/project/definitions/Ontology.java
+++ b/ehri-definitions/src/main/java/eu/ehri/project/definitions/Ontology.java
@@ -42,7 +42,7 @@ public class Ontology {
     public static final String LANGUAGE_OF_DESCRIPTION = "languageCode";
     public static final String LANGUAGE = LANGUAGE_OF_DESCRIPTION; //"languageCode";
 
-    public static final String UNDETERMINED_RELATIONSHIP_TYPE = "type";
+    public static final String ACCESS_POINT_TYPE = "type";
 
     // Links
     public static final String LINK_HAS_BODY = "hasLinkBody";

--- a/ehri-extension/src/main/java/eu/ehri/extension/DescriptionResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/DescriptionResource.java
@@ -23,7 +23,7 @@ import com.google.common.base.Charsets;
 import eu.ehri.project.core.Tx;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.exceptions.*;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.DescribedEntity;
@@ -136,7 +136,7 @@ public class DescriptionResource extends AbstractAccessibleEntityResource<Descri
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
-    @Path("/{id:.+}/{did:.+}/" + Entities.UNDETERMINED_RELATIONSHIP)
+    @Path("/{id:.+}/{did:.+}/" + Entities.ACCESS_POINT)
     public Response createAccessPoint(@PathParam("id") String id,
                                       @PathParam("did") String did, Bundle bundle)
             throws PermissionDenied, ValidationError,
@@ -145,9 +145,9 @@ public class DescriptionResource extends AbstractAccessibleEntityResource<Descri
             Accessor user = getRequesterUserProfile();
             DescribedEntity item = views.detail(id, user);
             Description desc = manager.getFrame(did, Description.class);
-            UndeterminedRelationship rel = descriptionViews.create(id, bundle,
-                    UndeterminedRelationship.class, user, getLogMessage());
-            desc.addUndeterminedRelationship(rel);
+            AccessPoint rel = descriptionViews.create(id, bundle,
+                    AccessPoint.class, user, getLogMessage());
+            desc.addAccessPoint(rel);
             Response response = buildResponse(item, rel, Response.Status.CREATED);
             tx.success();
             return response;
@@ -158,7 +158,7 @@ public class DescriptionResource extends AbstractAccessibleEntityResource<Descri
 
     @SuppressWarnings("unused")
     @DELETE
-    @Path("/{id:.+}/{did:.+}/" + Entities.UNDETERMINED_RELATIONSHIP + "/{apid:.+}")
+    @Path("/{id:.+}/{did:.+}/" + Entities.ACCESS_POINT + "/{apid:.+}")
     public Response deleteAccessPoint(@PathParam("id") String id,
                                       @PathParam("did") String did, @PathParam("apid") String apid)
             throws AccessDenied, PermissionDenied, ValidationError,

--- a/ehri-extension/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/LinkResource.java
@@ -30,7 +30,7 @@ import eu.ehri.project.definitions.EventTypes;
 import eu.ehri.project.exceptions.*;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.base.*;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.DescriptionViews;
@@ -141,7 +141,7 @@ public class LinkResource extends AbstractAccessibleEntityResource<Link>
             throws AccessDenied, PermissionDenied, ItemNotFound, ValidationError, SerializationError {
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
             Accessor userProfile = getRequesterUserProfile();
-            UndeterminedRelationship rel = manager.getFrame(id, UndeterminedRelationship.class);
+            AccessPoint rel = manager.getFrame(id, AccessPoint.class);
             Description description = rel.getDescription();
             if (description == null) {
                 throw new ItemNotFound(id);

--- a/ehri-extension/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -378,7 +378,7 @@ public class ToolsResource extends AbstractRestResource {
                                     : Lists.<String>newArrayList();
                             idPath.add(entity.getIdentifier());
                             Bundle descBundle = depSerializer.vertexFrameToBundle(desc);
-                            String newId = entityClass.getIdgen().generateId(idPath, descBundle);
+                            String newId = entityClass.getIdGen().generateId(idPath, descBundle);
                             if (!newId.equals(desc.getId()) && commit) {
                                 manager.renameVertex(desc.asVertex(), desc.getId(), newId);
                                 done++;

--- a/ehri-extension/src/test/java/eu/ehri/extension/test/DescriptionRestClientTest.java
+++ b/ehri-extension/src/test/java/eu/ehri/extension/test/DescriptionRestClientTest.java
@@ -106,7 +106,7 @@ public class DescriptionRestClientTest extends BaseRestClientTest {
     @Test
     public void testCreateDeleteAccessPoints() throws Exception {
         ClientResponse response = jsonCallAs(getAdminUserProfileId(),
-                ehriUri(ENDPOINT, "c2", "cd2", Entities.UNDETERMINED_RELATIONSHIP))
+                ehriUri(ENDPOINT, "c2", "cd2", Entities.ACCESS_POINT))
                 .entity(accessPointTestStr).post(ClientResponse.class);
         assertStatus(CREATED, response);
         JsonNode rootNode = jsonMapper.readValue(response.getEntity(String.class),
@@ -118,7 +118,7 @@ public class DescriptionRestClientTest extends BaseRestClientTest {
 
         response = jsonCallAs(getAdminUserProfileId(),
                 ehriUri(ENDPOINT, "c2", "cd2",
-                        Entities.UNDETERMINED_RELATIONSHIP, value))
+                        Entities.ACCESS_POINT, value))
                 .delete(ClientResponse.class);
         assertStatus(OK, response);
     }

--- a/ehri-frames/src/main/java/eu/ehri/project/acl/AclManager.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/acl/AclManager.java
@@ -600,7 +600,7 @@ public final class AclManager {
     private PermissionGrant createPermissionGrant() {
         try {
             Vertex vertex = manager.createVertex(
-                    EntityClass.PERMISSION_GRANT.getIdgen()
+                    EntityClass.PERMISSION_GRANT.getIdGen()
                             .generateId(Lists.<String>newArrayList(), null),
                     EntityClass.PERMISSION_GRANT,
                     Maps.<String, Object>newHashMap());

--- a/ehri-frames/src/main/java/eu/ehri/project/models/AccessPoint.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/AccessPoint.java
@@ -36,8 +36,8 @@ import eu.ehri.project.models.base.NamedEntity;
  * 
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
-@EntityType(EntityClass.UNDETERMINED_RELATIONSHIP)
-public interface UndeterminedRelationship extends AccessibleEntity, NamedEntity, Annotator {
+@EntityType(EntityClass.ACCESS_POINT)
+public interface AccessPoint extends AccessibleEntity, NamedEntity, Annotator {
 
     /**
      * Fetch the description to which this UR belongs.
@@ -61,7 +61,7 @@ public interface UndeterminedRelationship extends AccessibleEntity, NamedEntity,
      * @return A type string
      */
     @Mandatory
-    @Property(Ontology.UNDETERMINED_RELATIONSHIP_TYPE)
+    @Property(Ontology.ACCESS_POINT_TYPE)
     String getRelationshipType();
 }
 

--- a/ehri-frames/src/main/java/eu/ehri/project/models/EntityClass.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/EntityClass.java
@@ -36,70 +36,59 @@ import eu.ehri.project.models.idgen.IdentifiableEntityIdGenerator;
 
 /**
  * Mapping of Entity type names to Frames interfaces classes and
- * their associated IdGenerator functors.
- * 
- * @author Mike Bryant (http://github.com/mikesname)
+ * their associated id generator classes.
  *
+ * @author Mike Bryant (http://github.com/mikesname)
  */
 public enum EntityClass {
 
-    // @formatter:off
-    DOCUMENTARY_UNIT(Entities.DOCUMENTARY_UNIT, "c", DocumentaryUnit.class, IdentifiableEntityIdGenerator.INSTANCE),
-    REPOSITORY(Entities.REPOSITORY, "r", Repository.class, IdentifiableEntityIdGenerator.INSTANCE),
-    HISTORICAL_AGENT(Entities.HISTORICAL_AGENT, "a", HistoricalAgent.class, IdentifiableEntityIdGenerator.INSTANCE),
-    GROUP(Entities.GROUP, "g", Group.class, IdentifiableEntityIdGenerator.INSTANCE),
-    USER_PROFILE(Entities.USER_PROFILE, "u", UserProfile.class, IdentifiableEntityIdGenerator.INSTANCE),
-    AUTHORITATIVE_SET(Entities.AUTHORITATIVE_SET, "as", AuthoritativeSet.class, IdentifiableEntityIdGenerator.INSTANCE),
-    COUNTRY(Entities.COUNTRY, "ct", Country.class, IdentifiableEntityIdGenerator.INSTANCE),
-    CVOC_VOCABULARY(Entities.CVOC_VOCABULARY, "cvv", Vocabulary.class, IdentifiableEntityIdGenerator.INSTANCE),
-    CVOC_CONCEPT(Entities.CVOC_CONCEPT, "cv", Concept.class, IdentifiableEntityIdGenerator.INSTANCE),
+    DOCUMENTARY_UNIT(Entities.DOCUMENTARY_UNIT, DocumentaryUnit.class, IdentifiableEntityIdGenerator.INSTANCE),
+    REPOSITORY(Entities.REPOSITORY, Repository.class, IdentifiableEntityIdGenerator.INSTANCE),
+    HISTORICAL_AGENT(Entities.HISTORICAL_AGENT, HistoricalAgent.class, IdentifiableEntityIdGenerator.INSTANCE),
+    GROUP(Entities.GROUP, Group.class, IdentifiableEntityIdGenerator.INSTANCE),
+    USER_PROFILE(Entities.USER_PROFILE, UserProfile.class, IdentifiableEntityIdGenerator.INSTANCE),
+    AUTHORITATIVE_SET(Entities.AUTHORITATIVE_SET, AuthoritativeSet.class, IdentifiableEntityIdGenerator.INSTANCE),
+    COUNTRY(Entities.COUNTRY, Country.class, IdentifiableEntityIdGenerator.INSTANCE),
+    CVOC_VOCABULARY(Entities.CVOC_VOCABULARY, Vocabulary.class, IdentifiableEntityIdGenerator.INSTANCE),
+    CVOC_CONCEPT(Entities.CVOC_CONCEPT, Concept.class, IdentifiableEntityIdGenerator.INSTANCE),
+    VIRTUAL_UNIT(Entities.VIRTUAL_UNIT, VirtualUnit.class, IdentifiableEntityIdGenerator.INSTANCE),
+
+    DOCUMENT_DESCRIPTION(Entities.DOCUMENT_DESCRIPTION, DocumentDescription.class, DescriptionIdGenerator.INSTANCE),
+    REPOSITORY_DESCRIPTION(Entities.REPOSITORY_DESCRIPTION, RepositoryDescription.class, DescriptionIdGenerator.INSTANCE),
+    HISTORICAL_AGENT_DESCRIPTION(Entities.HISTORICAL_AGENT_DESCRIPTION, HistoricalAgentDescription.class, DescriptionIdGenerator.INSTANCE),
+    CVOC_CONCEPT_DESCRIPTION(Entities.CVOC_CONCEPT_DESCRIPTION, ConceptDescription.class, DescriptionIdGenerator.INSTANCE),
 
     // Generic entities.
-    DOCUMENT_DESCRIPTION(Entities.DOCUMENT_DESCRIPTION, "dd", DocumentDescription.class, DescriptionIdGenerator.INSTANCE),
-    REPOSITORY_DESCRIPTION(Entities.REPOSITORY_DESCRIPTION, "rd", RepositoryDescription.class, DescriptionIdGenerator.INSTANCE),
-    HISTORICAL_AGENT_DESCRIPTION(Entities.HISTORICAL_AGENT_DESCRIPTION, "ad", HistoricalAgentDescription.class, DescriptionIdGenerator.INSTANCE),
-    DATE_PERIOD(Entities.DATE_PERIOD, "dp", DatePeriod.class),
-    ANNOTATION(Entities.ANNOTATION, "ann", Annotation.class),
-    ADDRESS(Entities.ADDRESS, "adr", Address.class),
-    SYSTEM_EVENT(Entities.SYSTEM_EVENT, "ev", SystemEvent.class, GenericIdGenerator.INSTANCE),
-    VERSION(Entities.VERSION, "ver", Version.class),
-    SYSTEM(Entities.SYSTEM, "sys", SystemEventQueue.class),
-    UNKNOWN_PROPERTY(Entities.UNKNOWN_PROPERTY, "p", UnknownProperty.class),
-    PERMISSION(Entities.PERMISSION, "pm", Permission.class),
-    PERMISSION_GRANT(Entities.PERMISSION_GRANT, "pmg", PermissionGrant.class),
-    CONTENT_TYPE(Entities.CONTENT_TYPE, "ct", ContentType.class),
-    CVOC_CONCEPT_DESCRIPTION(Entities.CVOC_CONCEPT_DESCRIPTION, "cvd", ConceptDescription.class, DescriptionIdGenerator.INSTANCE),
-    MAINTENANCE_EVENT ( Entities.MAINTENANCE_EVENT, "me", MaintenanceEvent.class),
-    UNDETERMINED_RELATIONSHIP (Entities.UNDETERMINED_RELATIONSHIP, "rs", UndeterminedRelationship.class),
-    LINK (Entities.LINK, "lnk", Link.class),
-    VIRTUAL_UNIT(Entities.VIRTUAL_UNIT, "vu", VirtualUnit.class, IdentifiableEntityIdGenerator.INSTANCE),
-    EVENT_LINK(Entities.EVENT_LINK, "elnk", EventLink.class);
-    // @formatter:on
+    DATE_PERIOD(Entities.DATE_PERIOD, DatePeriod.class),
+    ANNOTATION(Entities.ANNOTATION, Annotation.class),
+    ADDRESS(Entities.ADDRESS, Address.class),
+    SYSTEM_EVENT(Entities.SYSTEM_EVENT, SystemEvent.class),
+    VERSION(Entities.VERSION, Version.class),
+    SYSTEM(Entities.SYSTEM, SystemEventQueue.class),
+    UNKNOWN_PROPERTY(Entities.UNKNOWN_PROPERTY, UnknownProperty.class),
+    PERMISSION(Entities.PERMISSION, Permission.class),
+    PERMISSION_GRANT(Entities.PERMISSION_GRANT, PermissionGrant.class),
+    CONTENT_TYPE(Entities.CONTENT_TYPE, ContentType.class),
+    MAINTENANCE_EVENT(Entities.MAINTENANCE_EVENT, MaintenanceEvent.class),
+    ACCESS_POINT(Entities.ACCESS_POINT, AccessPoint.class),
+    LINK(Entities.LINK, Link.class),
+    EVENT_LINK(Entities.EVENT_LINK, EventLink.class);
 
     // Accessors.
 
     /**
      * Get the string name of this EntityType.
-     * 
-     * @return
+     *
+     * @return the type's name
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Get the abbreviation code of this entityType.
-     * 
-     * @return
-     */
-    public String getAbbreviation() {
-        return abbr;
-    }
-
-    /**
      * Get the interface to which this EntityType refers.
-     * 
-     * @return
+     *
+     * @return the Java model class associated with the type
      */
     public Class<? extends Frame> getJavaClass() {
         return cls;
@@ -107,11 +96,11 @@ public enum EntityClass {
 
     /**
      * Get the ID generator class for this entityType.
-     * 
-     * @return
+     *
+     * @return the IdGenerator instance associated with the type
      */
-    public IdGenerator getIdgen() {
-        return idgen;
+    public IdGenerator getIdGen() {
+        return idGen;
     }
 
     public static EntityClass withName(String name) {
@@ -123,28 +112,17 @@ public enum EntityClass {
     }
 
     private final String name;
-    private final String abbr;
     private final Class<? extends Frame> cls;
-    private final IdGenerator idgen;
+    private final IdGenerator idGen;
 
-    EntityClass(String name, String abbr,
-            Class<? extends Frame> cls, IdGenerator idgen) {
+    EntityClass(String name, Class<? extends Frame> cls, IdGenerator idGen) {
         this.name = name;
-        this.abbr = abbr;
         this.cls = cls;
-        this.idgen = idgen;
+        this.idGen = idGen;
     }
 
-    /**
-     * Short constructor.
-     * 
-     * @param name
-     * @param abbr
-     * @param cls
-     */
-    EntityClass(String name, String abbr,
-            Class<? extends Frame> cls) {
-        this(name, abbr, cls, GenericIdGenerator.INSTANCE);
+    EntityClass(String name, Class<? extends Frame> cls) {
+        this(name, cls, GenericIdGenerator.INSTANCE);
     }
 
     @Override

--- a/ehri-frames/src/main/java/eu/ehri/project/models/base/Description.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/models/base/Description.java
@@ -24,7 +24,7 @@ import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.MaintenanceEvent;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.UnknownProperty;
 import eu.ehri.project.models.annotations.Dependent;
 import eu.ehri.project.models.annotations.Fetch;
@@ -83,13 +83,10 @@ public interface Description extends NamedEntity, AccessibleEntity {
     @Dependent
     @Fetch(value = Ontology.HAS_ACCESS_POINT, whenNotLite = true)
     @Adjacency(label = Ontology.HAS_ACCESS_POINT)
-    Iterable<UndeterminedRelationship> getUndeterminedRelationships();
+    Iterable<AccessPoint> getAccessPoints();
 
     @Adjacency(label = Ontology.HAS_ACCESS_POINT)
-    void setUndeterminedRelationships(Iterable<UndeterminedRelationship> relationship);
-
-    @Adjacency(label = Ontology.HAS_ACCESS_POINT)
-    void addUndeterminedRelationship(UndeterminedRelationship relationship);
+    void addAccessPoint(AccessPoint accessPoint);
 
     @Dependent
     @Fetch(value = Ontology.HAS_UNKNOWN_PROPERTY, ifLevel = 1, whenNotLite = true)

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -640,7 +640,7 @@ public final class Bundle {
      */
     public Bundle generateIds(Collection<String> scopes) {
         boolean isTemp = id == null;
-        IdGenerator idGen = getType().getIdgen();
+        IdGenerator idGen = getType().getIdGen();
         String newId = isTemp ? idGen.generateId(scopes, this) : id;
         Multimap<String, Bundle> idRels = ArrayListMultimap.create();
         List<String> nextScopes = Lists.newArrayList(scopes);

--- a/ehri-frames/src/main/java/eu/ehri/project/persistence/BundleValidator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/persistence/BundleValidator.java
@@ -221,7 +221,7 @@ public final class BundleValidator {
         }
         if (manager.exists(bundle.getId())) {
             ListMultimap<String, String> idErrors = bundle
-                    .getType().getIdgen().handleIdCollision(scopes, bundle);
+                    .getType().getIdGen().handleIdCollision(scopes, bundle);
             for (Map.Entry<String, String> entry : idErrors.entries()) {
                 builder.addError(entry.getKey(), entry.getValue());
             }

--- a/ehri-frames/src/main/java/eu/ehri/project/tools/IdRegenerator.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/tools/IdRegenerator.java
@@ -121,7 +121,7 @@ public class IdRegenerator {
 
         EntityClass entityClass = manager.getEntityClass(item);
         try {
-            IdGenerator idgen = entityClass.getIdgen();
+            IdGenerator idgen = entityClass.getIdGen();
             Bundle itemBundle = depSerializer.vertexFrameToBundle(item);
             String newId = idgen.generateId(idChain, itemBundle);
             if (collisionMode) {
@@ -149,7 +149,7 @@ public class IdRegenerator {
                             descIdChain.add(idBase);
                             for (Description d : manager.cast(item, DescribedEntity.class).getDescriptions()) {
                                 Bundle desc = depSerializer.vertexFrameToBundle(d);
-                                String newDescriptionId = desc.getType().getIdgen().generateId(descIdChain, desc);
+                                String newDescriptionId = desc.getType().getIdGen().generateId(descIdChain, desc);
                                 manager.renameVertex(d.asVertex(), d.getId(), newDescriptionId);
                             }
 

--- a/ehri-frames/src/main/java/eu/ehri/project/tools/Linker.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/tools/Linker.java
@@ -33,7 +33,7 @@ import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;
 import eu.ehri.project.models.Repository;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.models.cvoc.Vocabulary;
@@ -124,7 +124,7 @@ public class Linker {
 
         for (DocumentaryUnit doc : repository.getAllCollections()) {
             for (DocumentDescription description : doc.getDocumentDescriptions()) {
-                for (UndeterminedRelationship relationship : description.getUndeterminedRelationships()) {
+                for (AccessPoint relationship : description.getAccessPoints()) {
                     if (accessPointTypes.isEmpty() || accessPointTypes
                             .contains(relationship.getRelationshipType())) {
                         String trimmedName = relationship.getName().trim();
@@ -211,7 +211,7 @@ public class Linker {
         long linkCount = 0L;
         for (DocumentaryUnit doc : repository.getAllCollections()) {
             for (DocumentDescription description : doc.getDocumentDescriptions()) {
-                for (UndeterminedRelationship relationship : description.getUndeterminedRelationships()) {
+                for (AccessPoint relationship : description.getAccessPoints()) {
                     if (accessPointTypes.isEmpty() || accessPointTypes
                             .contains(relationship.getRelationshipType())) {
 
@@ -348,7 +348,7 @@ public class Linker {
         return true;
     }
 
-    private static String getIdentifier(UndeterminedRelationship relationship) {
+    private static String getIdentifier(AccessPoint relationship) {
         return Slugify.slugify(relationship.getName().trim())
                 .replaceAll("^-+", "")
                 .replaceAll("-+$", "");

--- a/ehri-frames/src/main/java/eu/ehri/project/utils/fixtures/impl/YamlFixtureLoader.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/utils/fixtures/impl/YamlFixtureLoader.java
@@ -268,7 +268,7 @@ public class YamlFixtureLoader implements FixtureLoader {
 
         // If the given id is a placeholder, generate it according to type rules
         if (id.trim().contentEquals(GENERATE_ID_PLACEHOLDER)) {
-            String newId = type.getIdgen().generateId(Lists.<String>newArrayList(), b);
+            String newId = type.getIdGen().generateId(Lists.<String>newArrayList(), b);
             b = b.withId(newId);
         }
         return b;

--- a/ehri-frames/src/main/java/eu/ehri/project/views/LinkViews.java
+++ b/ehri-frames/src/main/java/eu/ehri/project/views/LinkViews.java
@@ -32,7 +32,7 @@ import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Actioner;
@@ -140,12 +140,12 @@ public final class LinkViews implements Scoped<LinkViews> {
         //helper.checkEntityPermission(t2, user, PermissionType.ANNOTATE);
         helper.checkEntityPermission(description.getEntity(), user, PermissionType.UPDATE);
         Link link = new BundleDAO(graph).create(bundle, Link.class);
-        Bundle relBundle = new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP)
+        Bundle relBundle = new Bundle(EntityClass.ACCESS_POINT)
                 .withDataValue(Ontology.NAME_KEY, bodyName)
-                .withDataValue(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, bodyType)
+                .withDataValue(Ontology.ACCESS_POINT_TYPE, bodyType)
                 .withDataValue(Ontology.LINK_HAS_DESCRIPTION, link.getDescription());
-        UndeterminedRelationship rel = new BundleDAO(graph).create(relBundle, UndeterminedRelationship.class);
-        description.addUndeterminedRelationship(rel);
+        AccessPoint rel = new BundleDAO(graph).create(relBundle, AccessPoint.class);
+        description.addAccessPoint(rel);
         link.addLinkTarget(t1);
         link.addLinkTarget(t2);
         link.setLinker(user);

--- a/ehri-frames/src/test/java/eu/ehri/project/models/LinkTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/models/LinkTest.java
@@ -48,7 +48,7 @@ public class LinkTest extends AbstractFixtureTest {
     @Test
     public void testGetLinkBodies() throws Exception {
         Link link = manager.getFrame("link2", Link.class);
-        UndeterminedRelationship ur1 = manager.getFrame("ur1", UndeterminedRelationship.class);
+        AccessPoint ur1 = manager.getFrame("ur1", AccessPoint.class);
         assertTrue(Iterables.contains(link.getLinkBodies(), ur1));
     }
 }

--- a/ehri-frames/src/test/java/eu/ehri/project/views/ActionViewsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/views/ActionViewsTest.java
@@ -163,7 +163,7 @@ public class ActionViewsTest extends AbstractFixtureTest {
         for (; descIter.hasNext(); shouldDelete++) {
             DocumentDescription d = graph.frame(descIter.next().asVertex(), DocumentDescription.class);
             shouldDelete += Iterables.count(d.getDatePeriods());
-            shouldDelete += Iterables.count(d.getUndeterminedRelationships());
+            shouldDelete += Iterables.count(d.getAccessPoints());
         }
 
         String log = "Deleting item";

--- a/ehri-frames/src/test/java/eu/ehri/project/views/CrudViewsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/views/CrudViewsTest.java
@@ -30,7 +30,7 @@ import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Group;
 import eu.ehri.project.models.Repository;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.PermissionGrantTarget;
@@ -221,7 +221,7 @@ public class CrudViewsTest extends AbstractFixtureTest {
         for (; descIter.hasNext(); shouldDelete++) {
             DocumentDescription d = graph.frame(descIter.next().asVertex(), DocumentDescription.class);
             for (DatePeriod ignored : d.getDatePeriods()) shouldDelete++;
-            for (UndeterminedRelationship ignored : d.getUndeterminedRelationships()) shouldDelete++;
+            for (AccessPoint ignored : d.getAccessPoints()) shouldDelete++;
         }
 
         Integer deleted = docViews.delete(item.getId(), validUser);

--- a/ehri-frames/src/test/java/eu/ehri/project/views/LinkViewsTest.java
+++ b/ehri-frames/src/test/java/eu/ehri/project/views/LinkViewsTest.java
@@ -28,7 +28,7 @@ import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.Link;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.LinkableEntity;
 import eu.ehri.project.persistence.ActionManager;
@@ -69,7 +69,7 @@ public class LinkViewsTest extends AbstractFixtureTest {
     public void testCreateLink() throws Exception {
         DocumentaryUnit src = manager.getFrame("c1", DocumentaryUnit.class);
         HistoricalAgent dst = manager.getFrame("a1", HistoricalAgent.class);
-        UndeterminedRelationship rel = manager.getFrame("ur1", UndeterminedRelationship.class);
+        AccessPoint rel = manager.getFrame("ur1", AccessPoint.class);
         String linkDesc = "Test Link";
         String linkType = "subjectAccess";
         Bundle linkBundle = getLinkBundle(linkDesc, linkType);
@@ -107,8 +107,8 @@ public class LinkViewsTest extends AbstractFixtureTest {
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
         assertTrue(Iterables.contains(link.getLinkTargets(), dst));
         assertEquals(1L, Iterables.size(link.getLinkBodies()));
-        UndeterminedRelationship rel = manager.cast(link.getLinkBodies().iterator().next(),
-                UndeterminedRelationship.class);
+        AccessPoint rel = manager.cast(link.getLinkBodies().iterator().next(),
+                AccessPoint.class);
         assertEquals(rel.getName(), linkDesc);
         assertEquals(rel.getRelationshipType(), linkType);
         Description d = rel.getDescription();

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/AraEadImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/AraEadImporter.java
@@ -101,7 +101,7 @@ public class AraEadImporter extends EadImporter {
             for (String s : rel.keySet()) {
                 logger.debug(s);
             }
-            descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT, new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP, rel));
+            descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT, new Bundle(EntityClass.ACCESS_POINT, rel));
         }
         Map<String, Object> unknowns = extractUnknownProperties(itemData);
         if (!unknowns.isEmpty()) {

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvAuthoritativeItemImporter.java
@@ -53,8 +53,6 @@ import java.util.Map;
  */
 public class CsvAuthoritativeItemImporter extends MapImporter {
 
-//    private final XmlImportProperties p = new XmlImportProperties("csvconcept.properties");
-
     private static final Logger logger = LoggerFactory.getLogger(CsvAuthoritativeItemImporter.class);
 
     public CsvAuthoritativeItemImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, ImportLog log) {
@@ -65,25 +63,21 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
     public AccessibleEntity importItem(Map<String, Object> itemData) throws ValidationError {
 
         BundleDAO persister = getPersister();
-
-        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData));
-
-        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
-
-        unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
+        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION,
+                extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
+        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData))
+                .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
         Mutation<AuthoritativeItem> mutation = persister.createOrUpdate(unit, AuthoritativeItem.class);
         AuthoritativeItem frame = mutation.getNode();
 
-        if (!permissionScope.equals(SystemScope.getInstance())
-                && mutation.created()) {
+        if (!permissionScope.equals(SystemScope.getInstance()) && mutation.created()) {
             manager.cast(permissionScope, AuthoritativeSet.class).addItem(frame);
             frame.setPermissionScope(permissionScope);
         }
 
         handleCallbacks(mutation);
         return frame;
-
     }
 
     @Override
@@ -103,19 +97,15 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
         return item;
     }
 
-  
-
     protected Map<String, Object> extractUnitDescription(Map<String, Object> itemData, EntityClass entityClass) {
         Map<String, Object> item = Maps.newHashMap();
         item.put(Ontology.CREATION_PROCESS, Description.CreationProcess.IMPORT.toString());
 
-
         Helpers.putPropertyInGraph(item, Ontology.NAME_KEY, itemData.get("name").toString());
         for (String key : itemData.keySet()) {
             if (!key.equals("id") && !key.equals("name")) {
-                    Helpers.putPropertyInGraph(item, key, itemData.get(key).toString());
+                Helpers.putPropertyInGraph(item, key, itemData.get(key).toString());
             }
-
         }
         if (!item.containsKey("typeOfEntity")) {
             Helpers.putPropertyInGraph(item, "typeOfEntity", "subject");
@@ -126,11 +116,6 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
         return item;
     }
 
-
-    /**
-     * @param itemData
-     * @return returns a List with Maps with DatePeriod.DATE_PERIOD_START_DATE and DatePeriod.DATE_PERIOD_END_DATE values
-     */
     @Override
     public List<Map<String, Object>> extractDates(Map<String, Object> itemData) {
 
@@ -139,7 +124,6 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
 
         String end = (String) itemData.get("DateofdeathYYYY-MM-DD");
         String start = (String) itemData.get("DateofbirthYYYY-MM-DD");
-
         if (start != null && start.endsWith("00-00")) {
             start = start.substring(0, 4);
         }
@@ -155,5 +139,4 @@ public class CsvAuthoritativeItemImporter extends MapImporter {
         }
         return l;
     }
-
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvConceptImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvConceptImporter.java
@@ -54,25 +54,20 @@ public class CsvConceptImporter extends CsvAuthoritativeItemImporter {
     public AccessibleEntity importItem(Map<String, Object> itemData) throws ValidationError {
 
         BundleDAO persister = getPersister();
-
-        Bundle unit = new Bundle(EntityClass.CVOC_CONCEPT, extractUnit(itemData));
-
-        Bundle descBundle = new Bundle(EntityClass.CVOC_CONCEPT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.CVOC_CONCEPT_DESCRIPTION));
-
-        unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
+        Bundle descBundle = new Bundle(EntityClass.CVOC_CONCEPT_DESCRIPTION,
+                extractUnitDescription(itemData, EntityClass.CVOC_CONCEPT_DESCRIPTION));
+        Bundle unit = new Bundle(EntityClass.CVOC_CONCEPT, extractUnit(itemData))
+                .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
         Mutation<Concept> mutation = persister.createOrUpdate(unit, Concept.class);
         Concept frame = mutation.getNode();
 
-        if (!permissionScope.equals(SystemScope.getInstance())
-                && mutation.created()) {
+        if (!permissionScope.equals(SystemScope.getInstance()) && mutation.created()) {
             manager.cast(permissionScope, Vocabulary.class).addItem(frame);
             frame.setPermissionScope(permissionScope);
         }
 
         handleCallbacks(mutation);
         return frame;
-
     }
-
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/CsvHistoricalAgentImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/CsvHistoricalAgentImporter.java
@@ -54,25 +54,20 @@ public class CsvHistoricalAgentImporter extends CsvAuthoritativeItemImporter {
     public AccessibleEntity importItem(Map<String, Object> itemData) throws ValidationError {
 
         BundleDAO persister = getPersister();
-
-        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData));
-
-        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
-
-        unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
+        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION,
+                extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
+        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData))
+                .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
         Mutation<HistoricalAgent> mutation = persister.createOrUpdate(unit, HistoricalAgent.class);
         HistoricalAgent frame = mutation.getNode();
 
-        if (!permissionScope.equals(SystemScope.getInstance())
-                && mutation.created()) {
+        if (!permissionScope.equals(SystemScope.getInstance()) && mutation.created()) {
             manager.cast(permissionScope, AuthoritativeSet.class).addItem(frame);
             frame.setPermissionScope(permissionScope);
         }
 
         handleCallbacks(mutation);
         return frame;
-
     }
-
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/DcEuropeanaHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/DcEuropeanaHandler.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
@@ -83,11 +82,6 @@ private final ImmutableMap<String, Class<? extends Frame>> possibleSubnodes
         
         
 
-    }
-    
-    @Override
-    protected List<String> getSchemas() {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EaHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EaHandler.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Base handler for EAD, EAC and EAG files, based on a SAX reader.
  * This only contains a utility method.
- * 
+ *
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
 public abstract class EaHandler extends SaxXmlHandler {
@@ -45,31 +45,31 @@ public abstract class EaHandler extends SaxXmlHandler {
         if (names instanceof String) {
             nameValue = names.toString();
         } else if (names instanceof List) {
-            Object firstname = ((List) names).get(0);
-            if (firstname instanceof String) {
-                nameValue = firstname.toString();
+            Object firstName = ((List) names).get(0);
+            if (firstName instanceof String) {
+                nameValue = firstName.toString();
             } else {
-                Map<String, Object> nameMap = (Map) firstname;
-                if(nameMap.get("namePart") instanceof String){
-                  nameValue = nameMap.get("namePart").toString();  
-                }else if(nameMap.get("namePart") instanceof List){
-                    nameValue="";
-                    for(Object p : (List)nameMap.get("namePart")){
-                        nameValue += p+ " ";
+                Map nameMap = (Map) firstName;
+                if (nameMap.get("namePart") instanceof String) {
+                    nameValue = nameMap.get("namePart").toString();
+                } else if (nameMap.get("namePart") instanceof List) {
+                    nameValue = "";
+                    for (Object p : (List) nameMap.get("namePart")) {
+                        nameValue += p + " ";
                     }
-                    
-                }else{
+
+                } else {
                     nameValue = nameMap.get("namePart").toString();
                 }
             }
-//            nameValue = ((List) names).get(0).toString();
+
             for (int i = 1; i < ((List) names).size(); i++) {
-                Map<String, Object> m = (Map) ((List) names).get(i);
-                logger.debug("other name: " + m.get("namePart"));
+                Map m = (Map) ((List) names).get(i);
+                logger.debug("other name: {}", m.get("namePart"));
                 putPropertyInCurrentGraph("otherFormsOfName", m.get("namePart").toString());
             }
         } else {
-            logger.warn("no " + Ontology.NAME_KEY + " found");
+            logger.warn("no {} found", Ontology.NAME_KEY);
             nameValue = "no title";
         }
         return nameValue.trim();

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EaImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EaImporter.java
@@ -74,7 +74,7 @@ public abstract class EaImporter extends MapImporter {
     /**
      * Extract DocumentaryUnit properties from the itemData and return them as a new Map.
      * This implementation only extracts the objectIdentifier.
-     * <p>
+     * <p/>
      * This implementation does not throw ValidationErrors.
      *
      * @param itemData a Map containing raw properties of a DocumentaryUnit
@@ -115,31 +115,31 @@ public abstract class EaImporter extends MapImporter {
      * @return an Iterable of new Maps representing related nodes and their types
      */
     protected Iterable<Map<String, Object>> extractRelations(Map<String, Object> itemData) {
-        String REL = "relation";
+        String relName = "relation";
         List<Map<String, Object>> listOfRelations = Lists.newArrayList();
         for (Entry<String, Object> itemProperty : itemData.entrySet()) {
-            if (itemProperty.getKey().equals(REL)) {
+            if (itemProperty.getKey().equals(relName)) {
                 //type, targetUrl, targetName, notes
                 for (Map<String, Object> origRelation : (List<Map<String, Object>>) itemProperty.getValue()) {
                     Map<String, Object> relationNode = Maps.newHashMap();
                     for (Entry<String, Object> relationProperty : origRelation.entrySet()) {
-                        if (relationProperty.getKey().equals(REL + "/type")) {
-                            relationNode.put(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, relationProperty.getValue());
-                        } else if (relationProperty.getKey().equals(REL + "/url")) {
+                        if (relationProperty.getKey().equals(relName + "/type")) {
+                            relationNode.put(Ontology.ACCESS_POINT_TYPE, relationProperty.getValue());
+                        } else if (relationProperty.getKey().equals(relName + "/url")) {
                             //try to find the original identifier
                             relationNode.put(LINK_TARGET, relationProperty.getValue());
-                        } else if (relationProperty.getKey().equals(REL + "/" + Ontology.NAME_KEY)) {
+                        } else if (relationProperty.getKey().equals(relName + "/" + Ontology.NAME_KEY)) {
                             //try to find the original identifier
                             relationNode.put(Ontology.NAME_KEY, relationProperty.getValue());
-                        } else if (relationProperty.getKey().equals(REL + "/notes")) {
+                        } else if (relationProperty.getKey().equals(relName + "/notes")) {
                             relationNode.put(Ontology.LINK_HAS_DESCRIPTION, relationProperty.getValue());
                         } else {
                             relationNode.put(relationProperty.getKey(), relationProperty.getValue());
                         }
                     }
                     // Set a default relationship type if no type was found in the relationship
-                    if (!relationNode.containsKey(Ontology.UNDETERMINED_RELATIONSHIP_TYPE)) {
-                        relationNode.put(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, "corporateBodyAccess");
+                    if (!relationNode.containsKey(Ontology.ACCESS_POINT_TYPE)) {
+                        relationNode.put(Ontology.ACCESS_POINT_TYPE, "corporateBodyAccess");
                     }
                     listOfRelations.add(relationNode);
                 }
@@ -166,7 +166,7 @@ public abstract class EaImporter extends MapImporter {
             if (itemProperty.getKey().equals("descriptionIdentifier")) {
                 description.put(Ontology.IDENTIFIER_KEY, itemProperty.getValue());
             } else if (itemProperty.getKey().equals("conditionsOfAccess")) {
-                description.put(itemProperty.getKey(), changeForbiddenMultivaluedProperties(
+                description.put(itemProperty.getKey(), flattenNonMultivaluedProperties(
                         itemProperty.getKey(), itemProperty.getValue(), entity));
             } else if (!itemProperty.getKey().startsWith(SaxXmlHandler.UNKNOWN)
                     && !itemProperty.getKey().equals("objectIdentifier")
@@ -178,7 +178,7 @@ public abstract class EaImporter extends MapImporter {
                     && !itemProperty.getKey().startsWith("address/")
                     && !itemProperty.getKey().endsWith("Access")
                     && !itemProperty.getKey().endsWith("AccessPoint")) {
-                description.put(itemProperty.getKey(), changeForbiddenMultivaluedProperties(
+                description.put(itemProperty.getKey(), flattenNonMultivaluedProperties(
                         itemProperty.getKey(), itemProperty.getValue(), entity));
             }
         }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EacHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EacHandler.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
-import java.util.List;
 import java.util.Map;
 
 
@@ -47,21 +46,23 @@ public class EacHandler extends EaHandler {
 
     private final ImmutableMap<String, Class<? extends Frame>> possibleSubnodes
             = ImmutableMap.<String, Class<? extends Frame>>builder()
-                .put("maintenanceEvent", MaintenanceEvent.class)
-                .put("relation", Annotation.class)
-                .put("book", Annotation.class)
-                .put("bookentry", Annotation.class)
-                .put("accessPoint", Annotation.class)
-                .put("name", UnknownProperty.class).build();
+            .put("maintenanceEvent", MaintenanceEvent.class)
+            .put("relation", Annotation.class)
+            .put("book", Annotation.class)
+            .put("bookentry", Annotation.class)
+            .put("accessPoint", Annotation.class)
+            .put("name", UnknownProperty.class).build();
 
     private static final Logger logger = LoggerFactory.getLogger(EacHandler.class);
 
     public EacHandler(AbstractImporter<Map<String, Object>> importer) {
         super(importer, new XmlImportProperties("eac.properties"));
     }
+
     public EacHandler(AbstractImporter<Map<String, Object>> importer, XmlImportProperties properties) {
         super(importer, properties);
     }
+
     @Override
     protected boolean needToCreateSubNode(String key) {
         return possibleSubnodes.containsKey(getImportantPath(currentPath));
@@ -106,8 +107,4 @@ public class EacHandler extends EaHandler {
         }
     }
 
-    @Override
-    protected List<String> getSchemas() {
-        return Lists.newArrayList("eac.xsd");
-    }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EagHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EagHandler.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,7 +65,6 @@ public class EagHandler extends SaxXmlHandler {
             logger.debug("just before popping: " + depth + "-" + getImportantPath(currentPath) + "-" + qName);
             Map<String, Object> currentGraph = currentGraphPath.pop();
             putSubGraphInCurrentGraph(getImportantPath(currentPath), currentGraph);
-//            currentGraphPath.pop();
             depth--;
         }
 
@@ -101,10 +99,5 @@ public class EagHandler extends SaxXmlHandler {
                 logger.error(ex.getMessage());
             }
         }
-    }
-
-    @Override
-    protected List<String> getSchemas() {
-        return Lists.newArrayList("eag.xsd");
     }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/EagImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/EagImporter.java
@@ -70,7 +70,6 @@ public class EagImporter extends EaImporter {
     @Override
     public Map<String, Object> extractUnit(Map<String, Object> itemData) throws ValidationError {
         Map<String, Object> data = super.extractUnit(itemData);
-
         // MB: Hack hack hack - extract EHRI-specific 'priority' field out of the
         // pattern "Priority: <digit>" in the maintenanceNotes field.
         Object notes = itemData.get(MAINTENANCE_NOTES);
@@ -99,8 +98,6 @@ public class EagImporter extends EaImporter {
 
         BundleDAO persister = new BundleDAO(framedGraph, permissionScope.idPath());
 
-        Bundle unit = new Bundle(EntityClass.REPOSITORY, extractUnit(itemData));
-
         Map<String, Object> descmap = extractUnitDescription(itemData, EntityClass.REPOSITORY_DESCRIPTION);
         descmap.put(Ontology.IDENTIFIER_KEY, descmap.get(Ontology.IDENTIFIER_KEY) + "#desc");
         Bundle descBundle = new Bundle(EntityClass.REPOSITORY_DESCRIPTION, descmap);
@@ -127,7 +124,8 @@ public class EagImporter extends EaImporter {
             descBundle = descBundle.withRelation(Ontology.HAS_MAINTENANCE_EVENT, new Bundle(EntityClass.MAINTENANCE_EVENT, dpb));
         }
 
-        unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
+        Bundle unit = new Bundle(EntityClass.REPOSITORY, extractUnit(itemData))
+                .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
         Mutation<Repository> mutation = persister.createOrUpdate(unit, Repository.class);
         handleCallbacks(mutation);

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/IcaAtomEadHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/IcaAtomEadHandler.java
@@ -44,6 +44,7 @@ public class IcaAtomEadHandler extends EadHandler {
 
     /**
      * Set a custom resolver so EAD DTDs are never looked up online.
+     *
      * @param publicId the public component of the EAD DTD
      * @param systemId the system component of the EAD DTD
      * @return returns essentially an empty dtd file
@@ -55,17 +56,19 @@ public class IcaAtomEadHandler extends EadHandler {
         // This is the equivalent of returning a null dtd.
         return new org.xml.sax.InputSource(new java.io.StringReader(""));
     }
+
     public IcaAtomEadHandler(AbstractImporter<Map<String, Object>> importer, XmlImportProperties properties) {
         super(importer, properties);
         children[depth] = Lists.newArrayList();
     }
+
     public IcaAtomEadHandler(AbstractImporter<Map<String, Object>> importer) {
         this(importer, new XmlImportProperties("icaatom.properties"));
     }
 
     @Override
     protected void extractTitle(Map<String, Object> currentGraph) {
-    	if (!currentGraph.containsKey(Ontology.NAME_KEY)) {
+        if (!currentGraph.containsKey(Ontology.NAME_KEY)) {
             //finding some name for this unit:
             if (currentGraph.containsKey("title")) {
                 currentGraph.put(Ontology.NAME_KEY, currentGraph.get("title"));
@@ -74,7 +77,5 @@ public class IcaAtomEadHandler extends EadHandler {
                 currentGraph.put(Ontology.NAME_KEY, "UNKNOWN title");
             }
         }
-
     }
-
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/IcaAtomEadImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/IcaAtomEadImporter.java
@@ -95,7 +95,7 @@ public class IcaAtomEadImporter extends EaImporter {
         }
         for (Map<String, Object> rel : extractRelations(data)) {//, (String) unit.getErrors().get(IdentifiableEntity.IDENTIFIER_KEY)
             logger.debug("relation found " + rel.get(Ontology.IDENTIFIER_KEY));
-            descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT, new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP, rel));
+            descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT, new Bundle(EntityClass.ACCESS_POINT, rel));
         }
         Map<String, Object> unknowns = extractUnknownProperties(data);
         if (!unknowns.isEmpty()) {
@@ -210,14 +210,14 @@ public class IcaAtomEadImporter extends EaImporter {
                     for (String eventkey : origRelation.keySet()) {
                         logger.debug(eventkey);
                         if (eventkey.endsWith(REL)) {
-                            relationNode.put(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, eventkey);
+                            relationNode.put(Ontology.ACCESS_POINT_TYPE, eventkey);
                             relationNode.put(Ontology.NAME_KEY, origRelation.get(eventkey));
                         } else {
                             relationNode.put(eventkey, origRelation.get(eventkey));
                         }
                     }
-                    if (!relationNode.containsKey(Ontology.UNDETERMINED_RELATIONSHIP_TYPE)) {
-                        relationNode.put(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, "corporateBodyAccessPoint");
+                    if (!relationNode.containsKey(Ontology.ACCESS_POINT_TYPE)) {
+                        relationNode.put(Ontology.ACCESS_POINT_TYPE, "corporateBodyAccessPoint");
                     }
                     list.add(relationNode);
                 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/ImportLog.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/ImportLog.java
@@ -39,8 +39,8 @@ public class ImportLog {
     private int updated;
     private int unchanged;
     private int errored;
-    private EventContext eventContext;
-    private Map<String, String> errors = Maps.newHashMap();
+    private final EventContext eventContext;
+    private final Map<String, String> errors = Maps.newHashMap();
 
 
     /**

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/MapImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/MapImporter.java
@@ -56,27 +56,26 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
 
     private static final Logger logger = LoggerFactory.getLogger(MapImporter.class);
     protected final String OBJECT_ID = "objectIdentifier";
-    protected final String DESCRIPTION_ID = "descriptionIdentifier";
     private final XmlImportProperties dates = new XmlImportProperties("dates.properties");
 
     // Various date patterns
     private final Pattern[] datePatterns = {
-        // Yad Vashem, ICA-Atom style: 1924-1-1 - 1947-12-31
-        // Yad Vashem in Wp2: 12-15-1941, 9-30-1944
-        Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})\\s?-\\s?(\\d{4}-\\d{1,2}-\\d{1,2})$"),
-        Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})$"),
-        Pattern.compile("^(\\d{4})\\s?-\\s?(\\d{4})$"),
-        Pattern.compile("^(\\d{4})-\\[(\\d{4})\\]$"),
-        Pattern.compile("^(\\d{4})-\\[(\\d{4})\\]$"),
-        Pattern.compile("^(\\d{4}s)-\\[(\\d{4}s)\\]$"),
-        Pattern.compile("^\\[(\\d{4})\\]$"), Pattern.compile("^(\\d{4})$"),
-        Pattern.compile("^(\\d{2})th century$"),
-        Pattern.compile("^\\s*(\\d{4})\\s*-\\s*(\\d{4})"),
-        //bundesarchive: 1906/19
-        Pattern.compile("^\\s*(\\d{4})/(\\d{2})"),
-        Pattern.compile("^\\s*(\\d{4})\\s*/\\s*(\\d{4})"),
-        Pattern.compile("^(\\d{4}-\\d{1,2})/(\\d{4}-\\d{1,2})"),
-        Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})/(\\d{4}-\\d{1,2}-\\d{1,2})")
+            // Yad Vashem, ICA-Atom style: 1924-1-1 - 1947-12-31
+            // Yad Vashem in Wp2: 12-15-1941, 9-30-1944
+            Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})\\s?-\\s?(\\d{4}-\\d{1,2}-\\d{1,2})$"),
+            Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})$"),
+            Pattern.compile("^(\\d{4})\\s?-\\s?(\\d{4})$"),
+            Pattern.compile("^(\\d{4})-\\[(\\d{4})\\]$"),
+            Pattern.compile("^(\\d{4})-\\[(\\d{4})\\]$"),
+            Pattern.compile("^(\\d{4}s)-\\[(\\d{4}s)\\]$"),
+            Pattern.compile("^\\[(\\d{4})\\]$"), Pattern.compile("^(\\d{4})$"),
+            Pattern.compile("^(\\d{2})th century$"),
+            Pattern.compile("^\\s*(\\d{4})\\s*-\\s*(\\d{4})"),
+            //bundesarchive: 1906/19
+            Pattern.compile("^\\s*(\\d{4})/(\\d{2})"),
+            Pattern.compile("^\\s*(\\d{4})\\s*/\\s*(\\d{4})"),
+            Pattern.compile("^(\\d{4}-\\d{1,2})/(\\d{4}-\\d{1,2})"),
+            Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})/(\\d{4}-\\d{1,2}-\\d{1,2})")
     };
 
     public MapImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, ImportLog log) {
@@ -84,14 +83,13 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
     }
 
     private void extractDateFromValue(List<Map<String, Object>> extractedDates, String value) throws ValidationError {
-        logger.debug("date: " + value);
+        logger.debug("date: {}", value);
         Map<String, Object> dpb;
         dpb = extractDate(value);
         if (dpb != null) {
             extractedDates.add(dpb);
         }
-        logger.debug("nr of dates found: " + extractedDates.size());
-
+        logger.debug("nr of dates found: {}", extractedDates.size());
     }
 
     /**
@@ -133,61 +131,60 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
             try {
                 extractDateFromValue(extractedDates, s);
             } catch (ValidationError e) {
-                System.out.println("ERROR WITH DATES");
                 e.printStackTrace();
                 throw new RuntimeException(e);
             }
         }
         return extractedDates;
     }
-    
+
     /**
      * The dates that have been extracted to the extractedDates will be removed from the data map
      *
-     * @param data the data map
+     * @param data           the data map
      * @param extractedDates the set of extracted dates
      */
-    protected void replaceDates(Map<String, Object> data, List<Map<String, Object>> extractedDates){
+    protected void replaceDates(Map<String, Object> data, List<Map<String, Object>> extractedDates) {
         Map<String, String> datevalues = returnDatesAsString(data, dates);
         Map<String, String> datetypes = Maps.newHashMap();
-        for(String datevalue: datevalues.keySet()){
+        for (String datevalue : datevalues.keySet()) {
             datetypes.put(datevalues.get(datevalue), null);
         }
-            
-        
-        for(Map<String, Object> datemap : extractedDates){
+
+
+        for (Map<String, Object> datemap : extractedDates) {
             datevalues.remove(datemap.get(Ontology.DATE_HAS_DESCRIPTION));
         }
         //replace dates in data map
-        for(String datevalue : datevalues.keySet()){
+        for (String datevalue : datevalues.keySet()) {
             String datetype = datevalues.get(datevalue);
             logger.debug("{} -- {}", datevalue, datetype);
-            if(datetypes.containsKey(datetype) && datetypes.get(datetype) != null){
-                datetypes.put(datetype, datetypes.get(datetype)+", "+datevalue.trim());
-            }else{
+            if (datetypes.containsKey(datetype) && datetypes.get(datetype) != null) {
+                datetypes.put(datetype, datetypes.get(datetype) + ", " + datevalue.trim());
+            } else {
                 datetypes.put(datetype, datevalue.trim());
             }
         }
-        for(String datetype : datetypes.keySet()){
+        for (String datetype : datetypes.keySet()) {
             logger.debug("datetype {} -- {}", datetype, datetypes.get(datetype));
-            if(datetypes.get(datetype) == null){
+            if (datetypes.get(datetype) == null) {
                 data.remove(datetype);
-            }else{
+            } else {
                 data.put(datetype, datetypes.get(datetype));
             }
-            logger.debug(""+data.get(datetype));
+            logger.debug("" + data.get(datetype));
         }
-        
+
     }
-    
+
     /**
      * Extract an Iterable of representations of maintenance events from the itemData.
-     * 
+     *
      * @param itemData a Map containing raw properties of a unit
      * @return a List of node representations of maintenance events (may be empty)
      */
     @Override
-    public Iterable<Map<String, Object>> extractMaintenanceEvent(Map<String, Object> itemData)  {
+    public Iterable<Map<String, Object>> extractMaintenanceEvent(Map<String, Object> itemData) {
         List<Map<String, Object>> list = Lists.newArrayList();
         for (String key : itemData.keySet()) {
             if (key.equals("maintenanceEvent")) {
@@ -199,11 +196,11 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         }
         return list;
     }
-    
+
     /**
      * Convert a representation of a maintenance event from the maintenanceEvent data,
      * using property names from MaintenanceEvent.
-     * 
+     *
      * @param event a Map of event properties
      * @return a correct node representation of a single maintenance event
      */
@@ -224,7 +221,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         }
         return me;
     }
-    
+
 
     @Override
     public MaintenanceEvent importMaintenanceEvent(Map<String, Object> event) {
@@ -252,7 +249,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
      * @return returns a Map with DatePeriod.DATE_PERIOD_START_DATE and DatePeriod.DATE_PERIOD_END_DATE values
      */
     private Map<String, Object> extractDate(Object date) /*throws ValidationError*/ {
-        logger.debug("date value: " + date);
+        logger.debug("date value: {}", date);
         Map<String, Object> data = matchDate((String) date);
         return data.isEmpty() ? null : data;
     }
@@ -262,7 +259,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         for (Pattern re : datePatterns) {
             Matcher matcher = re.matcher(date);
             if (matcher.matches()) {
-                logger.debug("matched "+ date);
+                logger.debug("matched {}", date);
                 data.put(Ontology.DATE_PERIOD_START_DATE, normaliseDate(matcher.group(1)));
                 data.put(Ontology.DATE_PERIOD_END_DATE, normaliseDate(matcher.group(matcher
                         .groupCount() > 1 ? 2 : 1), Ontology.DATE_PERIOD_END_DATE));
@@ -276,13 +273,13 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
     private static String normaliseDate(String date) {
         return normaliseDate(date, Ontology.DATE_PERIOD_START_DATE);
     }
-    
+
     /**
      * Normalise a date in a string.
-     * 
-     * @param date a String date that needs formatting
+     *
+     * @param date       a String date that needs formatting
      * @param beginOrEnd a string signifying whether this date is the begin of
-     * a period or the end of a period
+     *                   a period or the end of a period
      * @return a String containing the formatted date.
      */
     public static String normaliseDate(String date, String beginOrEnd) {
@@ -309,8 +306,9 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         }
         return returndate;
     }
-    
+
     //TODO: for now, it only returns 1 unknown node object, but it could be more accurate to return several
+
     /**
      * extract data nodes from the data, that are not covered by their respectable properties file.
      *
@@ -329,5 +327,4 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         return l;
 
     }
-    
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/PersonalitiesImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/PersonalitiesImporter.java
@@ -44,7 +44,7 @@ import java.util.Map;
 
 /**
  * Importer of historical agents encoded in {@link Map}s.
- * <p>
+ * <p/>
  * Before importing the file: delete the columns with the reordering of the first and last name
  * add a column 'id' with a unique identifier, prefixed with EHRI-Personalities or some such.
  *
@@ -64,28 +64,24 @@ public class PersonalitiesImporter extends MapImporter {
     public AccessibleEntity importItem(Map<String, Object> itemData) throws ValidationError {
 
         BundleDAO persister = getPersister();
-
-        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData));
-
         Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
-
         for (Map<String, Object> dpb : extractDates(itemData)) {
             descBundle = descBundle.withRelation(Ontology.ENTITY_HAS_DATE, new Bundle(EntityClass.DATE_PERIOD, dpb));
         }
-        unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
+
+        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData))
+            .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
         Mutation<HistoricalAgent> mutation = persister.createOrUpdate(unit, HistoricalAgent.class);
         HistoricalAgent frame = mutation.getNode();
 
-        if (!permissionScope.equals(SystemScope.getInstance())
-                && mutation.created()) {
+        if (!permissionScope.equals(SystemScope.getInstance()) && mutation.created()) {
             manager.cast(permissionScope, AuthoritativeSet.class).addItem(frame);
             frame.setPermissionScope(permissionScope);
         }
 
         handleCallbacks(mutation);
         return frame;
-
     }
 
     @Override
@@ -147,7 +143,6 @@ public class PersonalitiesImporter extends MapImporter {
         }
         return item;
     }
-
 
     /**
      * @param itemData the item data map

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/TerezinDataConverter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/TerezinDataConverter.java
@@ -53,7 +53,7 @@ public class TerezinDataConverter {
                 values = line.split(";");
             } else {
                 if (quotes[0].length() <= 1) {
-                    logger.error(quotes[0] + " has a problem: " + line);
+                    logger.error("Problem found at line: {}: {}", line, quotes[0]);
                     break;
                 }
                 values = new String[2];
@@ -71,9 +71,7 @@ public class TerezinDataConverter {
                 }
             } else {
                 logger.error(values[0] + " has a problem: " + line);
-
             }
-
         }
         scanner.close();
     }
@@ -83,22 +81,22 @@ public class TerezinDataConverter {
         List<Calendar> dates = Lists.newArrayList();
         dates.add(Calendar.getInstance());
 
-        if(trimmedDate.startsWith("before ")){
+        if (trimmedDate.startsWith("before ")) {
             dates = parseDate(trimmedDate.substring(6));
-            if(dates ==  null)
+            if (dates == null)
                 return null;
-            
+
             dates.add(0, Calendar.getInstance());
             dates.get(0).set(Calendar.YEAR, 1900);
             dates.get(0).set(Calendar.DATE, 1);
             dates.get(0).set(Calendar.MONTH, Calendar.JANUARY);
             return dates;
         }
-        if(trimmedDate.startsWith("after ")){
+        if (trimmedDate.startsWith("after ")) {
             dates = parseDate(trimmedDate.substring(5));
-            if(dates ==  null)
+            if (dates == null)
                 return null;
-            dates.get(0).set(Calendar.YEAR, dates.get(0).get(Calendar.YEAR)+1);
+            dates.get(0).set(Calendar.YEAR, dates.get(0).get(Calendar.YEAR) + 1);
             dates.add(1, Calendar.getInstance());
             return dates;
         }
@@ -112,10 +110,10 @@ public class TerezinDataConverter {
             dates.get(0).setTime(d);
             dates.add(Calendar.getInstance());
             dates.get(1).setTime(d);
-            
+
             dates.get(0).set(Calendar.DATE, 1);
-            
-            dates.get(1).set(Calendar.MONTH, dates.get(1).get(Calendar.MONTH)+1);
+
+            dates.get(1).set(Calendar.MONTH, dates.get(1).get(Calendar.MONTH) + 1);
             dates.get(1).set(Calendar.DATE, 0);
             return dates;
         }
@@ -132,7 +130,7 @@ public class TerezinDataConverter {
             d = monthDateFormat.parse(m.group(2), p);
             if (p.getIndex() > 0) {
                 dates.get(1).setTime(d);
-                dates.get(1).set(Calendar.MONTH, dates.get(1).get(Calendar.MONTH)+1);
+                dates.get(1).set(Calendar.MONTH, dates.get(1).get(Calendar.MONTH) + 1);
                 dates.get(1).set(Calendar.DATE, 0);
             }
 
@@ -153,7 +151,7 @@ public class TerezinDataConverter {
             d = monthDateFormat.parse(m.group(2), p);
             if (p.getIndex() > 0) {
                 dates.get(1).setTime(d);
-                dates.get(1).set(Calendar.MONTH, dates.get(1).get(Calendar.MONTH)+1);
+                dates.get(1).set(Calendar.MONTH, dates.get(1).get(Calendar.MONTH) + 1);
                 dates.get(1).set(Calendar.DATE, 0);
                 dates.get(0).set(Calendar.YEAR, dates.get(1).get(Calendar.YEAR));
             }
@@ -220,7 +218,7 @@ public class TerezinDataConverter {
             dates.get(0).set(Calendar.DATE, 1);
 
             dates.add(Calendar.getInstance());
-            dates.get(1).set(Calendar.YEAR, 1900+ new Integer(m.group(2)));
+            dates.get(1).set(Calendar.YEAR, 1900 + new Integer(m.group(2)));
             dates.get(1).set(Calendar.MONTH, Calendar.DECEMBER);
             dates.get(1).set(Calendar.DATE, 31);
 
@@ -237,7 +235,7 @@ public class TerezinDataConverter {
         if ((m = parseDate(trimmedDate, "(\\d*)\\.(\\d*)\\.(\\d{2})")) != null) {
             dates.get(0).set(Calendar.DATE, new Integer(m.group(1)));
             dates.get(0).set(Calendar.MONTH, new Integer(m.group(2)) - 1);
-            dates.get(0).set(Calendar.YEAR, 1900+ new Integer(m.group(3)));
+            dates.get(0).set(Calendar.YEAR, 1900 + new Integer(m.group(3)));
             return dates;
         }
         //1942

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/UkrainianUnitImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/UkrainianUnitImporter.java
@@ -49,7 +49,7 @@ import java.util.Map;
 public class UkrainianUnitImporter extends MapImporter {
 
     public static final String MULTIVALUE_SEP = ",,";
-    private XmlImportProperties p;
+    private final XmlImportProperties p;
     private static final Logger logger = LoggerFactory.getLogger(UkrainianUnitImporter.class);
 
     public UkrainianUnitImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, ImportLog log) {

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/UshmmHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/UshmmHandler.java
@@ -18,7 +18,7 @@
  */
 
 /**
- * 
+ *
  */
 package eu.ehri.project.importers;
 
@@ -26,71 +26,63 @@ import eu.ehri.project.importers.properties.XmlImportProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Handler for importing EAD files converted from the USHMM Solr index file.
  * These files were converted using the solr2ead XSLT stylesheet.
+ *
  * @author Ben Companjen (http://github.com/bencomp)
  */
 public class UshmmHandler extends EadHandler {
 
-	private static final Logger logger = LoggerFactory.getLogger(UshmmHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(UshmmHandler.class);
 
-    // Default language to use in units without language
-    protected String defaultLanguage = "en";
+    private int count;
 
-	private int ushmmcount;
-    
-	/**
-	 * @param importer
-	 */
-	public UshmmHandler(AbstractImporter<Map<String, Object>> importer) {
-		super(importer, new XmlImportProperties("ushmm.properties"));
-		
-	}
-	
-	/**
-	 * Generic constructor, available so that the generic REST call can be made on the USHMM Handler.
-	 * @param importer
-	 * @param props
-	 */
-	public UshmmHandler(AbstractImporter<Map<String, Object>> importer, XmlImportProperties props) {
-        super(importer, props);
-        
+    /**
+     * @param importer
+     */
+    public UshmmHandler(AbstractImporter<Map<String, Object>> importer) {
+        super(importer, new XmlImportProperties("ushmm.properties"));
+
     }
 
-	/**
-	 * Handler specific code for extraction of unit IDs
-	 * @param currentGraph
-	 */
-	@Override
-	protected void extractIdentifier(Map<String, Object> currentGraph) {
-		//not all units have ids, and some have multiple, find the "irn"
-		if (currentGraph.containsKey("objectIdentifier")) {
-			if (currentGraph.get("objectIdentifier") instanceof List) {
-				logger.debug("class of identifier: " + currentGraph.get("objectIdentifier").getClass());
-				ArrayList<String> identifiers = (ArrayList<String>) currentGraph.get("objectIdentifier");
-				ArrayList<String> identifiertypes = (ArrayList<String>) currentGraph.get("objectIdentifierType");
-				for (int i = 0; i < identifiers.size(); i++) {
-					if (identifiertypes.get(i).equals("irn")) {
-						logger.debug("found official id: " + identifiers.get(i));
-						currentGraph.put("objectIdentifier", identifiers.get(i));
-					}else {
-						logger.debug("found other form of identifier: " + identifiers.get(i));
-						addOtherIdentifier(currentGraph, identifiers.get(i));
-						//currentGraph.put("otherIdentifiers", identifiers.get(i));
-					}
-				}
-				currentGraph.remove("objectIdentifierType");
-			}
-		} else {
-			logger.error("no unitid found, setting " + ++ushmmcount);
-			currentGraph.put("objectIdentifier", "ushmmID"+ushmmcount);
+    /**
+     * Generic constructor, available so that the generic REST call can be made on the USHMM Handler.
+     *
+     * @param importer
+     * @param props
+     */
+    public UshmmHandler(AbstractImporter<Map<String, Object>> importer, XmlImportProperties props) {
+        super(importer, props);
 
-		}
-	}
+    }
 
+    @Override
+    protected void extractIdentifier(Map<String, Object> currentGraph) {
+        //not all units have ids, and some have multiple, find the "irn"
+        if (currentGraph.containsKey("objectIdentifier")) {
+            if (currentGraph.get("objectIdentifier") instanceof List) {
+                logger.debug("class of identifier: " + currentGraph.get("objectIdentifier").getClass());
+                List<String> identifiers = (List<String>) currentGraph.get("objectIdentifier");
+                List<String> identifierType = (List<String>) currentGraph.get("objectIdentifierType");
+                for (int i = 0; i < identifiers.size(); i++) {
+                    if (identifierType.get(i).equals("irn")) {
+                        logger.debug("found official id: " + identifiers.get(i));
+                        currentGraph.put("objectIdentifier", identifiers.get(i));
+                    } else {
+                        logger.debug("found other form of identifier: " + identifiers.get(i));
+                        addOtherIdentifier(currentGraph, identifiers.get(i));
+                        //currentGraph.put("otherIdentifiers", identifiers.get(i));
+                    }
+                }
+                currentGraph.remove("objectIdentifierType");
+            }
+        } else {
+            logger.error("no unitid found, setting {}", ++count);
+            currentGraph.put("objectIdentifier", "ushmmID" + count);
+        }
+    }
 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/VirtualEadHandler.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/VirtualEadHandler.java
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
 public class VirtualEadHandler extends SaxXmlHandler {
     public static final String AUTHOR = "authors",
             SOURCEFILEID = "sourceFileId";
-    List<MaintenanceEvent> maintenanceEvents = Lists.newArrayList();
+    final List<MaintenanceEvent> maintenanceEvents = Lists.newArrayList();
     private final ImmutableMap<String, Class<? extends Frame>> possibleSubnodes = ImmutableMap.<String, Class<?
             extends Frame>>of("maintenanceEvent", MaintenanceEvent.class);
 
@@ -299,17 +299,6 @@ public class VirtualEadHandler extends SaxXmlHandler {
     }
 
     /**
-     * Handler-specific code for extraction or generation of description languages.
-     * Default method is empty; override when necessary.
-     *
-     * @param currentGraph
-     */
-    protected void extractEadLanguage(Map<String, Object> currentGraph) {
-        // TODO Auto-generated method stub
-
-    }
-
-    /**
      * Checks given currentGraph for a language and sets a default language code
      * for the description if no language is found.
      *
@@ -402,11 +391,6 @@ public class VirtualEadHandler extends SaxXmlHandler {
             need = need || path.endsWith("AccessPoint");
         }
         return need || possibleSubnodes.containsKey(getImportantPath(currentPath));
-    }
-
-    @Override
-    protected List<String> getSchemas() {
-        return Lists.newArrayList("xlink.xsd", "ead.xsd");
     }
 
     /**

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/VirtualEadImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/VirtualEadImporter.java
@@ -113,7 +113,7 @@ public class VirtualEadImporter extends EaImporter {
             }
             for (Map<String, Object> rel : extractRelations(itemData)) {//, (String) unit.getErrors().get(IdentifiableEntity.IDENTIFIER_KEY)
                 logger.debug("relation found: " + rel.get(Ontology.NAME_KEY));
-                descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT, new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP, rel));
+                descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT, new Bundle(EntityClass.ACCESS_POINT, rel));
             }
             Map<String, Object> unknowns = extractUnknownProperties(itemData);
             if (!unknowns.isEmpty()) {
@@ -166,14 +166,14 @@ public class VirtualEadImporter extends EaImporter {
                     for (String eventkey : origRelation.keySet()) {
                         logger.debug(eventkey);
                         if (eventkey.endsWith(REL)) {
-                            relationNode.put(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, eventkey);
+                            relationNode.put(Ontology.ACCESS_POINT_TYPE, eventkey);
                             relationNode.put(Ontology.NAME_KEY, origRelation.get(eventkey));
                         } else {
                             relationNode.put(eventkey, origRelation.get(eventkey));
                         }
                     }
-                    if (!relationNode.containsKey(Ontology.UNDETERMINED_RELATIONSHIP_TYPE)) {
-                        relationNode.put(Ontology.UNDETERMINED_RELATIONSHIP_TYPE, "corporateBodyAccessPoint");
+                    if (!relationNode.containsKey(Ontology.ACCESS_POINT_TYPE)) {
+                        relationNode.put(Ontology.ACCESS_POINT_TYPE, "corporateBodyAccessPoint");
                     }
                     list.add(relationNode);
                 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/Wp2PersonalitiesImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/Wp2PersonalitiesImporter.java
@@ -61,28 +61,25 @@ public abstract class Wp2PersonalitiesImporter extends MapImporter {
 
     @Override
     public AccessibleEntity importItem(Map<String, Object> itemData) throws ValidationError {
-        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData));
-
-        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION, extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
-
+        Bundle descBundle = new Bundle(EntityClass.HISTORICAL_AGENT_DESCRIPTION,
+                extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
         for (Map<String, Object> dpb : extractDates(itemData)) {
             descBundle = descBundle.withRelation(Ontology.ENTITY_HAS_DATE, new Bundle(EntityClass.DATE_PERIOD, dpb));
         }
-        unit = unit.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
+        Bundle unit = new Bundle(EntityClass.HISTORICAL_AGENT, extractUnit(itemData))
+                .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
 
         BundleDAO persister = getPersister();
         Mutation<HistoricalAgent> mutation = persister.createOrUpdate(unit, HistoricalAgent.class);
         HistoricalAgent frame = mutation.getNode();
 
-        if (!permissionScope.equals(SystemScope.getInstance())
-                && mutation.created()) {
+        if (!permissionScope.equals(SystemScope.getInstance()) && mutation.created()) {
             manager.cast(permissionScope, AuthoritativeSet.class).addItem(frame);
             frame.setPermissionScope(permissionScope);
         }
 
         handleCallbacks(mutation);
         return frame;
-
     }
 
     public AccessibleEntity importItem(Map<String, Object> itemData, int depth) throws ValidationError {
@@ -99,7 +96,6 @@ public abstract class Wp2PersonalitiesImporter extends MapImporter {
         }
         return item;
     }
-
 
     private Map<String, Object> extractUnitDescription(Map<String, Object> itemData, EntityClass entityClass) {
         Map<String, Object> item = Maps.newHashMap();
@@ -123,7 +119,6 @@ public abstract class Wp2PersonalitiesImporter extends MapImporter {
         }
         return item;
     }
-
 
     /**
      * @param itemData the item data map

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
@@ -319,7 +319,7 @@ public final class JenaSkosImporter implements SkosImporter {
         for (Map.Entry<String, URI> rel : RELATION_PROPS.entrySet()) {
             for (RDFNode annotation : getObjectWithPredicate(item, rel.getValue())) {
                 if (annotation.isLiteral()) {
-                    undetermined.add(new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP)
+                    undetermined.add(new Bundle(EntityClass.ACCESS_POINT)
                             .withDataValue(Ontology.ANNOTATION_TYPE, rel.getKey())
                             .withDataValue(Ontology.NAME_KEY, annotation.toString()));
                 } else {
@@ -329,7 +329,7 @@ public final class JenaSkosImporter implements SkosImporter {
                         if (found != null) {
                             linkedItems.put(found, rel.getKey());
                         } else {
-                            undetermined.add(new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP)
+                            undetermined.add(new Bundle(EntityClass.ACCESS_POINT)
                                     .withDataValue(Ontology.ANNOTATION_TYPE, "associate")
                                     .withDataValue(prefix, rel.getKey().substring(rel.getKey().indexOf(":") + 1))
                                     .withDataValue(Ontology.NAME_KEY, annotation.toString()));

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/OwlApiSkosImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/OwlApiSkosImporter.java
@@ -214,7 +214,7 @@ public final class OwlApiSkosImporter implements SkosImporter {
             Set<OWLAnnotation> annotations = item.getAnnotations(dataset, propName);
             for (OWLAnnotation annotation : annotations) {
                 if (annotation.getValue() instanceof OWLLiteral) {
-                    undetermined.add(new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP)
+                    undetermined.add(new Bundle(EntityClass.ACCESS_POINT)
                             .withDataValue(Ontology.ANNOTATION_TYPE, rel.getKey())
                             .withDataValue(Ontology.NAME_KEY, rel.getValue().toString()));
                 }

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/SkosRDFVocabulary.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/SkosRDFVocabulary.java
@@ -66,7 +66,7 @@ public enum SkosRDFVocabulary {
     DEFINITION("definition"),
     CHANGE_NOTE("changeNote");
 
-    private String NAMESPACE = "http://www.w3.org/2004/02/skos/core#";
+    private final String NAMESPACE = "http://www.w3.org/2004/02/skos/core#";
     private final URI uri;
 
     SkosRDFVocabulary(String localName) {

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/XmlSkosImporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/cvoc/XmlSkosImporter.java
@@ -172,7 +172,7 @@ public final class XmlSkosImporter implements SkosImporter {
 
     private void importFile(InputStream ios, ActionManager.EventContext eventContext,
             ImportLog log) throws IOException, ValidationError,
-            InputParseError, InvalidXmlDocument, InvalidInputFormatError {
+            InputParseError, InvalidInputFormatError {
 
         // XML parsing boilerplate...
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -311,7 +311,7 @@ public final class XmlSkosImporter implements SkosImporter {
             Map<String, Object> rel = extractRelations(element, "owl:sameAs");
             if (!rel.isEmpty()) {
                 descBundle = descBundle.withRelation(Ontology.HAS_ACCESS_POINT,
-                        new Bundle(EntityClass.UNDETERMINED_RELATIONSHIP, rel));
+                        new Bundle(EntityClass.ACCESS_POINT, rel));
             }
 
             // NOTE maybe test if prefLabel is there?
@@ -502,7 +502,7 @@ public final class XmlSkosImporter implements SkosImporter {
         for (Concept relatedBy : from.concept.getRelatedByConcepts()) {
             //logger.debug("Related By: " + relatedBy.asVertex().getProperty(EntityType.ID_KEY));
             String relatedByStoreId = relatedBy.asVertex().getProperty(EntityType.ID_KEY);
-            if (relatedByStoreId == to.storeId) {
+            if (relatedByStoreId.equals(to.storeId)) {
                 result = true;
                 break; // found
             }
@@ -718,10 +718,10 @@ public final class XmlSkosImporter implements SkosImporter {
      * Used in the lookup which is needed for creating the Vocabulary structure
      */
     private class ConceptPlaceholder {
-        public String storeId; // the identifier used for storage and referring in the repository
-        List<String> broaderIds;
-        List<String> relatedIds;
-        Concept concept;
+        public final String storeId; // the identifier used for storage and referring in the repository
+        final List<String> broaderIds;
+        final List<String> relatedIds;
+        final Concept concept;
 
         public ConceptPlaceholder(String storeId,
                 List<String> broaderIds,

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -57,7 +57,7 @@ public abstract class AbstractImportManager implements ImportManager {
     // and reporting errors usefully...
     protected String currentFile;
     protected Integer currentPosition;
-    protected Class<? extends AbstractImporter> importerClass;
+    protected final Class<? extends AbstractImporter> importerClass;
 
     /**
      * Constructor.

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/properties/NodeProperties.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/properties/NodeProperties.java
@@ -38,10 +38,10 @@ public class NodeProperties {
     public final static String MULTIVALUED = "multivalued?";
     public final static String REQUIRED = "required?";
     public final static String HANDLERNAME = "handlerTempName";
-    private List<String> titles;
+    private final List<String> titles;
     public static final String SEP = ",";
-    private Map<String, List<PropertiesRow>> p;
-    private Set<String> allKnownNodes;
+    private final Map<String, List<PropertiesRow>> p;
+    private final Set<String> allKnownNodes;
 
     public NodeProperties() {
         titles = Lists.newArrayList();

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/properties/PropertiesChecker.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/properties/PropertiesChecker.java
@@ -32,7 +32,7 @@ import java.util.Set;
 public class PropertiesChecker {
 
     private static final Logger logger = LoggerFactory.getLogger(PropertiesChecker.class);
-    private NodeProperties allowed;
+    private final NodeProperties allowed;
 
     public PropertiesChecker(NodeProperties allowedproperties) {
         allowed = allowedproperties;

--- a/ehri-importers/src/main/java/eu/ehri/project/importers/properties/PropertiesRow.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/importers/properties/PropertiesRow.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class PropertiesRow {
 
-    Map<String, String> properties;
+    final Map<String, String> properties;
 
     protected PropertiesRow() {
         properties = Maps.newHashMap();

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Bbwo2HandlerTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Bbwo2HandlerTest.java
@@ -31,7 +31,7 @@ import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.LinkableEntity;
 import eu.ehri.project.models.base.PermissionScope;
@@ -70,8 +70,8 @@ public class Bbwo2HandlerTest extends AbstractImporterTest {
                                 .withDataValue(Ontology.NAME_KEY, "NIOD Keywords");
         Bundle conceptBundle = new Bundle(EntityClass.CVOC_CONCEPT)
                                 .withDataValue(Ontology.IDENTIFIER_KEY, "joodse-raad");
-        Vocabulary vocabulary = new CrudViews<Vocabulary>(graph, Vocabulary.class).create(vocabularyBundle, validUser);
-        Concept concept_716 = new CrudViews<Concept>(graph, Concept.class).create(conceptBundle, validUser); 
+        Vocabulary vocabulary = new CrudViews<>(graph, Vocabulary.class).create(vocabularyBundle, validUser);
+        Concept concept_716 = new CrudViews<>(graph, Concept.class).create(conceptBundle, validUser);
         vocabulary.addItem(concept_716);
         
         
@@ -122,7 +122,7 @@ public class Bbwo2HandlerTest extends AbstractImporterTest {
         boolean passTest = false;
         DocumentaryUnit person = manager.getFrame("nl-r1-1505", DocumentaryUnit.class);
         for (Description d : person.getDescriptions()) {
-            for (UndeterminedRelationship rel : d.getUndeterminedRelationships()) {
+            for (AccessPoint rel : d.getAccessPoints()) {
                 if (rel.getRelationshipType().equals("subjectAccess")) {
                     if (rel.getName().equals("kinderen")) {
                         assertEquals(1, toList(rel.getLinks()).size());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveSplitTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/BundesarchiveSplitTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers;
 
+import com.google.common.collect.Lists;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
@@ -29,57 +30,62 @@ import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentDescription;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.base.PermissionScope;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
-public class BundesarchiveSplitTest extends AbstractImporterTest{
-    
+public class BundesarchiveSplitTest extends AbstractImporterTest {
+
     protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "BA_split.xml";
     protected final String ARCHDESC = "NS 1";
-    int origCount=0;
-            
+
     @Test
     public void bundesarchiveTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
-        
+
         PermissionScope agent = manager.getFrame(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of the Split Bundesarchive EAD";
 
-        origCount = getNodeCount(graph);
-        
-         // Before...
-       List<VertexProxy> graphState1 = getGraphState(graph);
+        int origCount = getNodeCount(graph);
+
+        // Before...
+        List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("bundesarchive.properties")).importFile(ios, logMessage);
-        
- // After...
-       List<VertexProxy> graphState2 = getGraphState(graph);
-       GraphDiff diff = diffGraph(graphState1, graphState2);
-       diff.printDebug(System.out);
+        new SaxImportManager(graph, agent, validUser,
+                EadImporter.class, EadHandler.class,
+                new XmlImportProperties("bundesarchive.properties")).importFile(ios, logMessage);
+
+        // After...
+        List<VertexProxy> graphState2 = getGraphState(graph);
+        GraphDiff diff = diffGraph(graphState1, graphState2);
+        diff.printDebug(System.out);
 
         // How many new nodes will have been created? We should have
         // - 1 more DocumentaryUnits (archdesc)
-       	// - 1 more DocumentDescription
+        // - 1 more DocumentDescription
         // - 1 more DatePeriod
         // - 1 more UnknownProperties
         // - 3 more Relationships
         // - 2 more import Event links (1 for every Unit, 1 for the User)
         // - 1 more import Event
         // - 5 more MaintenanceEvents (4 revised, 1 created)
-        int newCount = origCount + 9+1+4+1;
+        int newCount = origCount + 9 + 1 + 4 + 1;
         printGraph(graph);
 
         assertEquals(newCount, getNodeCount(graph));
-        
+
         DocumentaryUnit archUnit = graph.frame(
-                getVertexByIdentifier(graph,ARCHDESC),
+                getVertexByIdentifier(graph, ARCHDESC),
                 DocumentaryUnit.class);
 
         // Test ID generation andhierarchy
@@ -90,35 +96,18 @@ public class BundesarchiveSplitTest extends AbstractImporterTest{
         assertEquals(agent, archUnit.getRepository());
         assertEquals(agent, archUnit.getPermissionScope());
 
-
-    //test titles
-        for(DocumentDescription d : archUnit.getDocumentDescriptions()){
+        //test titles
+        for (DocumentDescription d : archUnit.getDocumentDescriptions()) {
             assertEquals("Reichsschatzmeister der NSDAP", d.getName());
         }
-    //test dates
-        for(DocumentDescription d : archUnit.getDocumentDescriptions()){
-        	// Single date is just a string
-        	assertFalse(d.asVertex().getPropertyKeys().contains("unitDates"));
-        	for (DatePeriod dp : d.getDatePeriods()){
-        		assertEquals("1906-01-01", dp.getStartDate());
-        		assertEquals("1919-12-31", dp.getEndDate());
-                        break;
-        	}
+        //test dates
+        for (DocumentDescription d : archUnit.getDocumentDescriptions()) {
+            // Single date is just a string
+            assertFalse(d.asVertex().getPropertyKeys().contains("unitDates"));
+            List<DatePeriod> datePeriods = Lists.newArrayList(d.getDatePeriods());
+            assertEquals(1, datePeriods.size());
+            assertEquals("1906-01-01", datePeriods.get(0).getStartDate());
+            assertEquals("1919-12-31", datePeriods.get(0).getEndDate());
         }
-        
-//        // Second fonds has two dates with different types -> list
-//        for(DocumentDescription d : c7_2.getDocumentDescriptions()){
-//        	// unitDates still around?
-//        	assertEquals("1943-1944", d.asVertex().getProperty("unitDates"));
-//        	// start and end dates correctly parsed and setup
-//        	for(DatePeriod dp : d.getDatePeriods()){
-//        		assertEquals("1943-01-01", dp.getStartDate());
-//        		assertEquals("1944-12-31", dp.getEndDate());
-//        	}
-//        	
-//        	// Since there was a list of unitDateTypes, it should now be deleted
-//        	assertNull(d.asVertex().getProperty("unitDatesTypes"));
-//        }
-        
     }
 }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Eag2896Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Eag2896Test.java
@@ -94,7 +94,7 @@ public class Eag2896Test extends AbstractImporterTest {
         // MB: Test priority hack - this should be pulled out of the
         // maintenanceNotes field into its own int field
         Object priority = unit.asVertex().getProperty(EagImporter.PRIORITY);
-        assertEquals(Integer.valueOf(5), priority);
+        assertEquals(5, priority);
 
         // Check scope
         assertEquals(country, unit.getPermissionScope());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesV2Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/PersonalitiesV2Test.java
@@ -30,7 +30,7 @@ import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.Link;
-import eu.ehri.project.models.UndeterminedRelationship;
+import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.base.*;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.models.cvoc.Vocabulary;
@@ -137,9 +137,9 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
                                 .withDataValue(Ontology.NAME_KEY, "FAST Keywords");
         Bundle conceptBundle = new Bundle(EntityClass.CVOC_CONCEPT)
                                 .withDataValue(Ontology.IDENTIFIER_KEY, "fst894382");
-        Vocabulary vocabulary = new CrudViews<Vocabulary>(graph, Vocabulary.class).create(vocabularyBundle, validUser);
+        Vocabulary vocabulary = new CrudViews<>(graph, Vocabulary.class).create(vocabularyBundle, validUser);
         logger.debug(vocabulary.getId());
-        Concept concept_716 = new CrudViews<Concept>(graph, Concept.class).create(conceptBundle, validUser); 
+        Concept concept_716 = new CrudViews<>(graph, Concept.class).create(conceptBundle, validUser);
         vocabulary.addItem(concept_716);
         
         
@@ -174,7 +174,7 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
 //        printGraph(graph);
         HistoricalAgent person = manager.getFrame("ehri_pers_000051", HistoricalAgent.class);
         for (Description d : person.getDescriptions()) {
-            for (UndeterminedRelationship rel : d.getUndeterminedRelationships()) {
+            for (AccessPoint rel : d.getAccessPoints()) {
                 if (rel.getRelationshipType().equals("subjectAccess")) {
                     if (rel.getName().equals("Diplomatic documents")) {
                         assertEquals(1, toList(rel.getLinks()).size());

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/UkrainianUnitImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/UkrainianUnitImporterTest.java
@@ -52,7 +52,7 @@ public class UkrainianUnitImporterTest extends AbstractImporterTest{
                 .withDataValue(Ontology.LANGUAGE_OF_DESCRIPTION, "uk");
         repoBundle = repoBundle.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, repoDescBundle);
         repoBundle = repoBundle.withRelation(Ontology.REPOSITORY_HAS_COUNTRY, ukrainianBundle);
-        Repository repo = new CrudViews<Repository>(graph, Repository.class).create(repoBundle, validUser);
+        Repository repo = new CrudViews<>(graph, Repository.class).create(repoBundle, validUser);
 
         int count = getNodeCount(graph);
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/VirtualEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/VirtualEadTest.java
@@ -154,15 +154,15 @@ public void setStageTest() throws PermissionDenied, ValidationError {
                                 .withDataValue(Ontology.NAME_KEY, UNIT2+"title")
                                 .withDataValue(Ontology.LANGUAGE_OF_DESCRIPTION, "cze");
 
-        repository1 = new CrudViews<Repository>(graph, Repository.class).create(repo1Bundle, validUser);
-        repository2 = new CrudViews<Repository>(graph, Repository.class).create(repo2Bundle, validUser);
+        repository1 = new CrudViews<>(graph, Repository.class).create(repo1Bundle, validUser);
+        repository2 = new CrudViews<>(graph, Repository.class).create(repo2Bundle, validUser);
         
         documentaryUnit1Bundle = documentaryUnit1Bundle.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, documentDescription1Bundle);
-        unit1 = new CrudViews<DocumentaryUnit>(graph, DocumentaryUnit.class).create(documentaryUnit1Bundle, validUser);
+        unit1 = new CrudViews<>(graph, DocumentaryUnit.class).create(documentaryUnit1Bundle, validUser);
         unit1.setRepository(repository1);
         
         documentaryUnit2Bundle = documentaryUnit2Bundle.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, documentDescription2Bundle);
-        unit2 = new CrudViews<DocumentaryUnit>(graph, DocumentaryUnit.class).create(documentaryUnit2Bundle, validUser);
+        unit2 = new CrudViews<>(graph, DocumentaryUnit.class).create(documentaryUnit2Bundle, validUser);
         unit2.setRepository(repository2);
 
     }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2BtEadTest.java
@@ -69,9 +69,9 @@ public class Wp2BtEadTest extends AbstractImporterTest {
                                 .withDataValue(Ontology.NAME_KEY, "WP2 Keywords");
         Bundle conceptBundle = new Bundle(EntityClass.CVOC_CONCEPT)
                                 .withDataValue(Ontology.IDENTIFIER_KEY, "KEYWORD.JMP.716");
-        Vocabulary vocabulary = new CrudViews<Vocabulary>(graph, Vocabulary.class).create(vocabularyBundle, validUser);
+        Vocabulary vocabulary = new CrudViews<>(graph, Vocabulary.class).create(vocabularyBundle, validUser);
         logger.debug(vocabulary.getId());
-        Concept concept_716 = new CrudViews<Concept>(graph, Concept.class).create(conceptBundle, validUser); 
+        Concept concept_716 = new CrudViews<>(graph, Concept.class).create(conceptBundle, validUser);
         vocabulary.addItem(concept_716);
         
         

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/Wp2YvEadTest.java
@@ -65,10 +65,10 @@ public class Wp2YvEadTest extends AbstractImporterTest {
                                 .withDataValue(Ontology.NAME_KEY, "WP2 Keywords");
         Bundle conceptBundle = new Bundle(EntityClass.CVOC_CONCEPT)
                                 .withDataValue(Ontology.IDENTIFIER_KEY, "KEYWORD.JMP.288");
-        Vocabulary vocabulary = new CrudViews<Vocabulary>(graph, Vocabulary.class).create(vocabularyBundle,
+        Vocabulary vocabulary = new CrudViews<>(graph, Vocabulary.class).create(vocabularyBundle,
                 validUser);
         logger.debug(vocabulary.getId());
-        Concept concept_288 = new CrudViews<Concept>(graph, Concept.class).create(conceptBundle, validUser);
+        Concept concept_288 = new CrudViews<>(graph, Concept.class).create(conceptBundle, validUser);
         vocabulary.addItem(concept_288);
 
         Vocabulary vocabularyTest = manager.getFrame("wp2_keywords", Vocabulary.class);

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosImporterTest.java
@@ -36,11 +36,11 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractSkosImporterTest extends AbstractFixtureTest {
     private static final Logger logger = LoggerFactory.getLogger(AbstractSkosImporterTest.class);
-    public static String FILE1 = "cvoc/simple.xml";
-    public static String FILE2 = "cvoc/simple.n3";
-    public static String FILE3 = "cvoc/repository-types.xml";
-    public static String FILE4 = "cvoc/camps.rdf";
-    public static String FILE5 = "cvoc/ghettos.rdf";
+    public static final String FILE1 = "cvoc/simple.xml";
+    public static final String FILE2 = "cvoc/simple.n3";
+    public static final String FILE3 = "cvoc/repository-types.xml";
+    public static final String FILE4 = "cvoc/camps.rdf";
+    public static final String FILE5 = "cvoc/ghettos.rdf";
 
     protected Actioner actioner;
     protected ActionManager actionManager;

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/CampsImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/CampsImporterTest.java
@@ -26,22 +26,18 @@ import eu.ehri.project.models.base.AccessibleEntity;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.models.cvoc.Vocabulary;
 import eu.ehri.project.views.Query;
+import org.junit.Test;
 
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Linda Reijnhoudt (https://github.com/lindareijnhoudt)
  */
 public class CampsImporterTest extends AbstractImporterTest {
-    private static final Logger logger = LoggerFactory.getLogger(CampsImporterTest.class);
     protected final String SKOS_FILE = "cvoc/camps.rdf";
     protected final String SKOS_FILE_VERSION2 = "cvoc/campsv02.rdf";
 
@@ -55,7 +51,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
         assertNotNull(ios);
-        
+
         SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
         importer.setTolerant(true);
         ImportLog log = importer.importFile(ios, logMessage);
@@ -65,7 +61,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         /*  How many new nodes will have been created? We should have
          * 8 more Concepts
        	 * 8 more ConceptDescription
-	 * 9 more import Event links (8 for every Unit, 1 for the User)
+	     * 9 more import Event links (8 for every Unit, 1 for the User)
          * 1 more import Event
          */
         int afterNodeCount = count + 26;
@@ -74,7 +70,7 @@ public class CampsImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "675";
-        Query<Concept> query = new Query<Concept>(graph, Concept.class);
+        Query<Concept> query = new Query<>(graph, Concept.class);
         // Query for document identifier.
         List<Concept> list = toList(query.setLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, validUser));
@@ -95,16 +91,15 @@ public class CampsImporterTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
-//        SkosCoreCvocImporter importer = new SkosCoreCvocImporter(graph, validUser, vocabulary);
         SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
         importer.setTolerant(true);
-        ImportLog log = importer.importFile(ios, "Importing the camps as a SKOS file");
+        importer.importFile(ios, "Importing the camps as a SKOS file");
 
         printGraph(graph);
         /*  How many new nodes will have been created? We should have
          * 8 more Concepts
        	 * 8 more ConceptDescription
-	 * 9 more import Event links (8 for every Unit, 1 for the User)
+     	 * 9 more import Event links (8 for every Unit, 1 for the User)
          * 1 more import Event
          */
         int afterNodeCount = count + 26;
@@ -113,7 +108,7 @@ public class CampsImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "675";
-        Query<Concept> query = new Query<Concept>(graph, Concept.class);
+        Query<Concept> query = new Query<>(graph, Concept.class);
         // Query for document identifier.
         List<Concept> list = toList(query.setLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, validUser));
@@ -124,26 +119,24 @@ public class CampsImporterTest extends AbstractImporterTest {
         for (AccessibleEntity e : actionManager.getLatestGlobalEvent().getSubjects()) {
             assertEquals(vocabulary, e.getPermissionScope());
         }
-        
+
         //import version 2
         ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE_VERSION2);
-//        importer = new SkosCoreCvocImporter(graph, validUser, vocabulary);
         importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
 
         importer.setTolerant(true);
-        log = importer.importFile(ios, "Importing the modified camps as a SKOS file");
+        importer.importFile(ios, "Importing the modified camps as a SKOS file");
 
-         printGraph(graph);
+        printGraph(graph);
         /*  How many new nodes will have been created? We should have
          * 0 new concepts, 2 modified concepts (counts as 0)
        	 * 0 new ConceptDescription, 2 modified (counts as 0)
          * 2 more import Event links (2 for every modified Unit, 1 for the User)
          * 1 more import Event
          */
-         afterNodeCount = count + 26 + 3;
+        afterNodeCount = count + 26 + 3;
         assertEquals(afterNodeCount, getNodeCount(graph));
         assertEquals(voccount + 8, toList(vocabulary.getConcepts()).size());
-
     }
 
 }

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterTest.java
@@ -67,7 +67,7 @@ public class GhettosImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "0";
-        Query<Concept> query = new Query<Concept>(graph, Concept.class);
+        Query<Concept> query = new Query<>(graph, Concept.class);
 
         // Query for document identifier.
         List<Concept> list = toList(query.setLimit(1).page(

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
@@ -68,7 +68,7 @@ public class GhettosImporterV20140831Test extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "0";
-        Query<Concept> query = new Query<Concept>(graph, Concept.class);
+        Query<Concept> query = new Query<>(graph, Concept.class);
 
         // Query for document identifier.
         List<Concept> list = toList(query.setLimit(1).page(

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
@@ -85,7 +85,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "698";
-        Query<Concept> query = new Query<Concept>(graph, Concept.class);
+        Query<Concept> query = new Query<>(graph, Concept.class);
         // Query for document identifier.
         List<Concept> list = toList(query.setLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, validUser));

--- a/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/Wp2PlacesImporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/importers/cvoc/Wp2PlacesImporterTest.java
@@ -66,7 +66,7 @@ public class Wp2PlacesImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "PLACE.ČSÚ.544256";
-        Query<Concept> query = new Query<Concept>(graph, Concept.class);
+        Query<Concept> query = new Query<>(graph, Concept.class);
 
         // Query for document identifier.
         List<Concept> list = toList(query.setLimit(1).page(


### PR DESCRIPTION
 - rename `UndeterminedRelationship` to `AccessPoint`
 - remove unneeded entity type name abbreviation

No functional change.