### PR TITLE
Fix incorrect use of graph local/global IDs in SKOS export.

### DIFF
--- a/ehri-extension/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-extension/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -231,9 +231,10 @@ public class VocabularyResource extends AbstractAccessibleEntityResource<Vocabul
     @Produces({TURTLE_MIMETYPE, RDF_XML_MIMETYPE, N3_MIMETYPE})
     public Response exportSkos(@PathParam("id") String id,
             final @QueryParam("format") String format,
-            final @QueryParam("baseUri") @DefaultValue(SkosRDFVocabulary.DEFAULT_BASE_URI) String baseUri)
+            final @QueryParam("baseUri") String baseUri)
             throws IOException, ItemNotFound {
         final String rdfFormat = getRdfFormat(format, "TTL");
+        final String base = baseUri == null ? SkosRDFVocabulary.DEFAULT_BASE_URI : baseUri;
         final MediaType mediaType = MediaType.valueOf(RDF_MIMETYPE_FORMATS
                 .inverse().get(rdfFormat));
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -245,9 +246,9 @@ public class VocabularyResource extends AbstractAccessibleEntityResource<Vocabul
             return Response.ok(new StreamingOutput() {
                 @Override
                 public void write(OutputStream outputStream) throws IOException, WebApplicationException {
-                    skosImporter.export(outputStream, baseUri);
+                    skosImporter.export(outputStream, base);
                 }
-            }).type(mediaType +"; charset=utf-8").build();
+            }).type(mediaType + "; charset=utf-8").build();
         } catch (Exception e) {
             tx.close();
             throw e;

--- a/ehri-importers/src/main/java/eu/ehri/project/exporters/cvoc/JenaSkosExporter.java
+++ b/ehri-importers/src/main/java/eu/ehri/project/exporters/cvoc/JenaSkosExporter.java
@@ -133,15 +133,15 @@ public class JenaSkosExporter implements SkosExporter {
             }
 
             for (Concept other : concept.getBroaderConcepts()) {
-                Resource otherResource = model.createResource(baseUri + other.getId());
+                Resource otherResource = model.createResource(baseUri + other.getIdentifier());
                 model.add(resource, model.createProperty(SkosRDFVocabulary.BROADER.getURI().toString()), otherResource);
             }
             for (Concept other : concept.getNarrowerConcepts()) {
-                Resource otherResource = model.createResource(baseUri + other.getId());
+                Resource otherResource = model.createResource(baseUri + other.getIdentifier());
                 model.add(resource, model.createProperty(SkosRDFVocabulary.NARROWER.getURI().toString()), otherResource);
             }
             for (Concept other : concept.getRelatedConcepts()) {
-                Resource otherResource = model.createResource(baseUri + other.getId());
+                Resource otherResource = model.createResource(baseUri + other.getIdentifier());
                 model.add(resource, model.createProperty(SkosRDFVocabulary.RELATED.getURI().toString()), otherResource);
             }
         }

--- a/ehri-importers/src/test/java/eu/ehri/project/exporters/cvoc/JenaSkosExporterTest.java
+++ b/ehri-importers/src/test/java/eu/ehri/project/exporters/cvoc/JenaSkosExporterTest.java
@@ -24,11 +24,13 @@ import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.cvoc.AbstractSkosTest;
 import eu.ehri.project.importers.cvoc.JenaSkosImporter;
 import eu.ehri.project.importers.cvoc.SkosImporter;
+import eu.ehri.project.importers.cvoc.SkosRDFVocabulary;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -52,6 +54,8 @@ public class JenaSkosExporterTest extends AbstractSkosTest {
             importer.setFormat(entry.getValue().equalsIgnoreCase("") ? null : entry.getValue())
                     .importFile(ClassLoader.getSystemResourceAsStream(entry.getKey()), "test");
 
+            List<VertexProxy> before = getGraphState(graph);
+            int edgeCountBefore = getEdgeCount(graph);
             SkosExporter exporter = new JenaSkosExporter(graph, vocabulary)
                     .setFormat(entry.getValue().equalsIgnoreCase("") ? null : entry.getValue());
             OutputStream outputStream = new ByteArrayOutputStream();
@@ -60,11 +64,16 @@ public class JenaSkosExporterTest extends AbstractSkosTest {
             ImportLog log = importer.setFormat(entry.getValue())
                     .importFile(new ByteArrayInputStream(skos.getBytes()), "test");
             log.printReport();
+            List<VertexProxy> after = getGraphState(graph);
             assertTrue(log.getUnchanged() > 0);
             assertEquals(0, log.getChanged());
             assertEquals(0, log.getCreated());
             assertEquals(0, log.getErrored());
-
+            GraphDiff graphDiff = diffGraph(before, after);
+            assertTrue(graphDiff.added.isEmpty());
+            assertTrue(graphDiff.removed.isEmpty());
+            int edgeCountAfter = getEdgeCount(graph);
+            assertEquals(edgeCountBefore, edgeCountAfter);
         }
     }
 
@@ -84,6 +93,7 @@ public class JenaSkosExporterTest extends AbstractSkosTest {
             String skos = outputStream.toString();
             //System.out.println(skos);
             assertTrue(skos.contains(baseUri));
+            assertTrue(skos.contains(baseUri + "989"));
         }
     }
 }


### PR DESCRIPTION
Fixes #190.

Also, add more test assertions and fix a default value on the web service endpoint that caused Enunciate to crash.