### PR TITLE
Fix graphson export.

### DIFF
--- a/assembly/src/main/assembly/unix.xml
+++ b/assembly/src/main/assembly/unix.xml
@@ -37,6 +37,7 @@
                 <include>com.tinkerpop.*:*</include>
                 <include>stax:stax-api</include>
                 <include>org.javassist:javassist</include>
+                <include>org.codehaus.jettison:jettison</include>
                 <include>org.neo4j:neo4j-graphviz</include>
 
                 <!-- Additional EHRI deps -->


### PR DESCRIPTION
It turns out that we did need the jettison dependency for GraphSON export support. Whoops.