### PR TITLE
Fix loading of ACL-filtered exported graphs.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/acl/AclManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/AclManager.java
@@ -384,7 +384,7 @@ public final class AclManager {
                 if (!verts.iterator().hasNext()) {
                     return true;
                 }
-                // If it's promoted it's publically accessible
+                // If it's promoted it's publicly accessible
                 if (isPromoted(v)) {
                     return true;
                 }

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertex.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertex.java
@@ -15,12 +15,12 @@ public class AclVertex extends AclElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String... strings) {
-        return new AclEdgeIterable(((Vertex)this.baseElement).getEdges(direction, strings), this.graph);
+        return new AclEdgeIterable(((Vertex) this.baseElement).getEdges(direction, strings), this.graph);
     }
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String... strings) {
-        return new AclVertexIterable(((Vertex)this.baseElement).getVertices(direction, strings), this.graph);
+        return new AclVertexIterable(((Vertex) this.baseElement).getVertices(direction, strings), this.graph);
     }
 
     @Override


### PR DESCRIPTION
Logically, it should not have been possible to see edges that were connected to invisible nodes. However, because we weren't filtering edges based on start/end visibility, GraphSON dumps has inconsistent node/edge counts.

Fixes #216.