### PR TITLE
More fixes to prevent the ACL graph leaking non-ACL-aware primitives.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclEdge.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclEdge.java
@@ -3,22 +3,19 @@ package eu.ehri.project.acl.wrapper;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.pipes.PipeFunction;
-import eu.ehri.project.acl.AclManager;
 
 
 public class AclEdge extends AclElement implements Edge {
-    private final PipeFunction<Vertex,Boolean> aclFilter;
 
     protected AclEdge(Edge baseEdge, AclGraph<?> aclGraph) {
         super(baseEdge, aclGraph);
-        aclFilter = AclManager.getAclFilterFunction(aclGraph.getAccessor());
     }
 
     @Override
     public Vertex getVertex(Direction direction) throws IllegalArgumentException {
         Vertex vertex = ((Edge) baseElement).getVertex(direction);
-        return aclFilter.compute(vertex) ? new AclVertex(((Edge) baseElement).getVertex(direction), graph) : null;
+        return aclGraph.evaluateVertex(vertex) ? new AclVertex(((Edge) baseElement).getVertex(direction),
+                aclGraph) : null;
     }
 
     @Override

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclEdgeIterable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclEdgeIterable.java
@@ -1,11 +1,7 @@
 package eu.ehri.project.acl.wrapper;
 
 import com.tinkerpop.blueprints.CloseableIterable;
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.pipes.PipeFunction;
-import eu.ehri.project.acl.AclManager;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -14,21 +10,12 @@ import java.util.NoSuchElementException;
 public class AclEdgeIterable implements CloseableIterable<Edge> {
 
     private final Iterable<Edge> iterable;
-    private final AclGraph<?> graph;
-    private final PipeFunction<Vertex, Boolean> aclVertexFilter;
-    private final PipeFunction<Edge, Boolean> aclEdgeFilter;
+    private final AclGraph<?> aclGraph;
 
-    public AclEdgeIterable(Iterable<Edge> iterable, AclGraph<?> graph) {
+    public AclEdgeIterable(Iterable<Edge> iterable,
+            AclGraph<?> aclGraph) {
         this.iterable = iterable;
-        this.graph = graph;
-        this.aclVertexFilter = AclManager.getAclFilterFunction(graph.getAccessor());
-        this.aclEdgeFilter = new PipeFunction<Edge, Boolean>() {
-            @Override
-            public Boolean compute(Edge edge) {
-                return aclVertexFilter.compute(edge.getVertex(Direction.OUT))
-                        && aclVertexFilter.compute(edge.getVertex(Direction.IN));
-            }
-        };
+        this.aclGraph = aclGraph;
     }
 
     @Override
@@ -54,8 +41,8 @@ public class AclEdgeIterable implements CloseableIterable<Edge> {
                 }
                 while (this.itty.hasNext()) {
                     Edge edge = this.itty.next();
-                    if (aclEdgeFilter.compute(edge)) {
-                        nextEdge = new AclEdge(edge, graph);
+                    if (aclGraph.evaluateEdge(edge)) {
+                        nextEdge = new AclEdge(edge, aclGraph);
                         return true;
                     }
                 }
@@ -71,8 +58,8 @@ public class AclEdgeIterable implements CloseableIterable<Edge> {
                 } else {
                     while (this.itty.hasNext()) {
                         Edge edge = this.itty.next();
-                        if (aclEdgeFilter.compute(edge)) {
-                            return new AclEdge(edge, graph);
+                        if (aclGraph.evaluateEdge(edge)) {
+                            return new AclEdge(edge, aclGraph);
                         }
                     }
                     throw new NoSuchElementException();

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclElement.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclElement.java
@@ -1,19 +1,21 @@
 package eu.ehri.project.acl.wrapper;
 
+import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.util.ElementHelper;
-import eu.ehri.project.models.base.Accessor;
+import com.tinkerpop.pipes.PipeFunction;
 
 import java.util.Set;
 
 
 public abstract class AclElement implements Element {
     protected Element baseElement;
-    protected AclGraph<?> graph;
+    protected AclGraph<?> aclGraph;
 
-    protected AclElement(Element baseElement, AclGraph<?> graph) {
+    protected AclElement(Element baseElement, AclGraph<?> aclGraph) {
         this.baseElement = baseElement;
-        this.graph = graph;
+        this.aclGraph = aclGraph;
     }
 
     @Override
@@ -48,7 +50,7 @@ public abstract class AclElement implements Element {
 
     @Override
     public String toString() {
-        return "[" + getId() + " (" + graph.getAccessor().getId() + ")]";
+        return "[" + getId() + ")]";
     }
 
     @Override
@@ -66,9 +68,5 @@ public abstract class AclElement implements Element {
 
     public Element getBaseElement() {
         return baseElement;
-    }
-
-    public Accessor getAccessor() {
-        return graph.getAccessor();
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertex.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertex.java
@@ -9,18 +9,18 @@ import com.tinkerpop.blueprints.util.wrappers.WrapperVertexQuery;
 
 public class AclVertex extends AclElement implements Vertex {
 
-    protected AclVertex(Vertex baseVertex, AclGraph<?> graph) {
-        super(baseVertex, graph);
+    protected AclVertex(Vertex baseVertex, AclGraph<?> aclGraph) {
+        super(baseVertex, aclGraph);
     }
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String... strings) {
-        return new AclEdgeIterable(((Vertex) this.baseElement).getEdges(direction, strings), this.graph);
+        return new AclEdgeIterable(((Vertex) this.baseElement).getEdges(direction, strings), aclGraph);
     }
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String... strings) {
-        return new AclVertexIterable(((Vertex) this.baseElement).getVertices(direction, strings), this.graph);
+        return new AclVertexIterable(((Vertex) this.baseElement).getVertices(direction, strings), aclGraph);
     }
 
     @Override
@@ -28,7 +28,7 @@ public class AclVertex extends AclElement implements Vertex {
         return new WrapperVertexQuery(((Vertex) this.baseElement).query()) {
             @Override
             public Iterable<Vertex> vertices() {
-                return new AclVertexIterable(this.query.vertices(), graph);
+                return new AclVertexIterable(this.query.vertices(), aclGraph);
             }
 
             @Override
@@ -40,10 +40,15 @@ public class AclVertex extends AclElement implements Vertex {
 
     @Override
     public Edge addEdge(String label, Vertex vertex) {
-        return this.graph.addEdge(null, this, vertex, label);
+        return aclGraph.addEdge(null, this, vertex, label);
     }
 
     public Vertex getBaseVertex() {
         return (Vertex) this.baseElement;
+    }
+
+    @Override
+    public String toString() {
+        return "aclvertex(" + aclGraph.getAccessor().getId() + ")[" + getBaseVertex() + "]";
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertexIterable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertexIterable.java
@@ -2,8 +2,6 @@ package eu.ehri.project.acl.wrapper;
 
 import com.tinkerpop.blueprints.CloseableIterable;
 import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.pipes.PipeFunction;
-import eu.ehri.project.acl.AclManager;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -11,13 +9,11 @@ import java.util.NoSuchElementException;
 
 public class AclVertexIterable implements CloseableIterable<Vertex> {
     private final Iterable<Vertex> iterable;
-    private final AclGraph<?> graph;
-    private final PipeFunction<Vertex,Boolean> aclFilter;
+    private final AclGraph<?> aclGraph;
 
-    public AclVertexIterable(Iterable<Vertex> iterable, AclGraph<?> graph) {
+    public AclVertexIterable(Iterable<Vertex> iterable, AclGraph<?> aclGraph) {
         this.iterable = iterable;
-        this.graph = graph;
-        this.aclFilter = AclManager.getAclFilterFunction(graph.getAccessor());
+        this.aclGraph = aclGraph;
     }
 
     @Override
@@ -40,8 +36,8 @@ public class AclVertexIterable implements CloseableIterable<Vertex> {
                 }
                 while (this.itty.hasNext()) {
                     Vertex vertex = this.itty.next();
-                    if (aclFilter.compute(vertex)) {
-                        this.nextVertex = new AclVertex(vertex, graph);
+                    if (aclGraph.evaluateVertex(vertex)) {
+                        this.nextVertex = new AclVertex(vertex, aclGraph);
                         return true;
                     }
                 }
@@ -58,8 +54,8 @@ public class AclVertexIterable implements CloseableIterable<Vertex> {
                 } else {
                     while (this.itty.hasNext()) {
                         Vertex vertex = this.itty.next();
-                        if (aclFilter.compute(vertex)) {
-                            return new AclVertex(vertex, graph);
+                        if (aclGraph.evaluateVertex(vertex)) {
+                            return new AclVertex(vertex, aclGraph);
                         }
                     }
                     throw new NoSuchElementException();

--- a/ehri-core/src/main/java/eu/ehri/project/views/EventViews.java
+++ b/ehri-core/src/main/java/eu/ehri/project/views/EventViews.java
@@ -347,7 +347,6 @@ public class EventViews {
         // into a newest-first stream.
         if (users.isEmpty() && ids.isEmpty()) {
             // No item/user filter: scan the global queue...
-            System.out.println("GLOBAL QUEUE");
             return actionManager.getLatestGlobalEvents();
         } else  {
             List<Actioner> actioners = getItems(users, Actioner.class);

--- a/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
@@ -13,7 +13,6 @@ import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
-import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,13 +85,10 @@ public class AclGraphTest extends AbstractFixtureTest {
         // Invalid user can see repository r1
         assertNotNull(invalidUserVertex);
         // Because three of r1's doc unit nodes are restricted visibility, we
-        // should only get one node (c4) when we traverse 'heldBy'
+        // should only get two nodes (c4 and nl-r1-m19) when we traverse 'heldBy'
         Iterable<Vertex> docs = invalidUserVertex
                 .getVertices(Direction.IN, Ontology.DOC_HELD_BY_REPOSITORY);
-        for (Vertex doc : docs) {
-            System.out.println(doc.getProperty(EntityType.ID_KEY));
-        }
-        assertEquals(3L, Iterables.count(docs));
+        assertEquals(2, Iterables.count(docs));
     }
 
     @Test


### PR DESCRIPTION
Additionally, provide better toStrings and fix an erroneous test.