### PR TITLE
Switch from OpenCSV to Jackson Dataformat CSV.

### DIFF
--- a/assembly/src/main/assembly/unix.xml
+++ b/assembly/src/main/assembly/unix.xml
@@ -45,8 +45,8 @@
                 <include>org.yaml:snakeyaml</include>
                 <include>com.fasterxml.uuid:*</include>
                 <include>com.fasterxml.jackson.core:*</include>
+                <include>com.fasterxml.jackson.dataformat:*</include>
                 <include>com.google.guava:guava</include>
-                <include>net.sf.opencsv:opencsv</include>
                 <include>commons-cli:commons-cli</include>
                 <include>net.sourceforge.owlapi:owlapi-distribution</include>
                 <include>org.apache.jena:*</include>

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -80,11 +80,11 @@
             <version>1.0.0</version>
         </dependency>
 
-        <!-- OpenCSV -->
+        <!-- Jackson CSV -->
         <dependency>
-            <groupId>net.sf.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>2.3</version>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+            <version>2.7.1</version>
         </dependency>
 
         <dependency>

--- a/ehri-io/src/test/java/eu/ehri/project/importers/PersonalitiesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/PersonalitiesImporterTest.java
@@ -23,19 +23,20 @@ import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.cvoc.AuthoritativeSet;
-import java.io.InputStream;
-
 import eu.ehri.project.models.events.SystemEvent;
 import org.junit.Test;
-import static org.junit.Assert.*;
-
 import org.neo4j.helpers.collection.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 
-public class PersonalitiesImporterTest extends AbstractImporterTest{
-    
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class PersonalitiesImporterTest extends AbstractImporterTest {
+
     private static final Logger logger = LoggerFactory.getLogger(PersonalitiesImporterTest.class);
     protected final String SINGLE_EAD = "Personalities_small.csv";
 
@@ -45,19 +46,18 @@ public class PersonalitiesImporterTest extends AbstractImporterTest{
         int voccount = toList(authoritativeSet.getAuthoritativeItems()).size();
         assertEquals(2, voccount);
         logger.debug("number of items: " + voccount);
-        
+
         final String logMessage = "Importing some WP18 Personalities records";
         XmlImportProperties p = new XmlImportProperties("personalities.properties");
         assertTrue(p.containsProperty("Othernames"));
         assertTrue(p.containsProperty("DateofbirthYYYY-MM-DD"));
         assertTrue(p.containsProperty("Pseudonyms"));
-        
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser, PersonalitiesImporter.class).importFile(ios, logMessage);
+        new CsvImportManager(graph, authoritativeSet, validUser, PersonalitiesImporter.class).importFile(ios, logMessage);
         SystemEvent ev = actionManager.getLatestGlobalEvent();
-        System.out.println(Iterables.toList(authoritativeSet.getAuthoritativeItems()));
+
         /*
          * 8 HistAgent
          * 8 HistAgentDesc
@@ -65,7 +65,7 @@ public class PersonalitiesImporterTest extends AbstractImporterTest{
          * 9 more import Event links (1 for every Unit, 1 for the User)
          * 1 more import Event
          */
-        assertEquals(count+34, getNodeCount(graph));
+        assertEquals(count + 34, getNodeCount(graph));
         assertEquals(voccount + 8, toList(authoritativeSet.getAuthoritativeItems()).size());
 
         // Check permission scopes are correct.

--- a/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -19,7 +19,9 @@
 
 package eu.ehri.extension;
 
-import au.com.bytecode.opencsv.CSVWriter;
+import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.CloseableIterable;
@@ -57,7 +59,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
@@ -492,13 +493,9 @@ public class ToolsResource extends AbstractRestResource {
     // Helpers
 
     private String makeCsv(List<List<String>> rows) throws IOException {
-        StringWriter writer = new StringWriter();
-        CSVWriter csvWriter = new CSVWriter(writer, '\t', CSVWriter.NO_QUOTE_CHARACTER);
-        for (List<String> remap : rows) {
-            String[] strings = remap.toArray(new String[2]);
-            csvWriter.writeNext(strings);
-        }
-        csvWriter.close();
-        return writer.toString();
+        CsvMapper mapper = new CsvMapper()
+                .enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING);
+        CsvSchema schema = mapper.schemaFor(List.class).withoutHeader();
+        return mapper.writer(schema).writeValueAsString(rows);
     }
 }


### PR DESCRIPTION
Since we're already using Jackson extensively this makes sense, also:

 - the reader API is a bit nicer and more full-features
 - quote when writing can be strict on-demand (not just on or off)

Additional small test cleanups.