### PR TITLE
Add a class that can export the model schema as RDFS/Owl triples.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/models/AccessPoint.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/AccessPoint.java
@@ -42,6 +42,7 @@ public interface AccessPoint extends Accessible, Named, Annotator {
      *
      * @return a description frame
      */
+    @Mandatory
     @Adjacency(label = Ontology.HAS_ACCESS_POINT, direction = Direction.IN)
     Description getDescription();
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/DatePeriod.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/DatePeriod.java
@@ -24,6 +24,7 @@ import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.base.Annotatable;
 import eu.ehri.project.models.base.Temporal;
 
@@ -66,6 +67,7 @@ public interface DatePeriod extends Annotatable {
      *
      * @return a temporal item
      */
+    @Mandatory
     @Adjacency(label = Ontology.ENTITY_HAS_DATE, direction = Direction.IN)
     Temporal getEntity();
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/DocumentaryUnit.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/DocumentaryUnit.java
@@ -49,11 +49,20 @@ public interface DocumentaryUnit extends AbstractUnit {
     /**
      * Get the repository that holds this documentary unit.
      *
-     * @return the Repository that holds this DocumentaryUnit
+     * @return the repository that holds this DocumentaryUnit
      */
     @Fetch(Ontology.DOC_HELD_BY_REPOSITORY)
     @JavaHandler
     Repository getRepository();
+
+    /**
+     * Get the repository if this item is at the top of its hierarchy.
+     * Otherwise, return null.
+     *
+     * @return the repository, or null.
+     */
+    @Adjacency(label = Ontology.DOC_HELD_BY_REPOSITORY, direction = Direction.OUT)
+    Repository getRepositoryIfTopLevel();
 
     /**
      * Set the repository that holds this documentary unit.

--- a/ehri-core/src/main/java/eu/ehri/project/models/PermissionGrant.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/PermissionGrant.java
@@ -23,6 +23,7 @@ import com.tinkerpop.frames.Adjacency;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Fetch;
+import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Entity;
 import eu.ehri.project.models.base.PermissionGrantTarget;
@@ -35,6 +36,7 @@ import eu.ehri.project.models.base.PermissionScope;
 @EntityType(EntityClass.PERMISSION_GRANT)
 public interface PermissionGrant extends Entity {
 
+    @Mandatory
     @Fetch(value = Ontology.PERMISSION_GRANT_HAS_SUBJECT, ifBelowLevel = 1, numLevels = 1)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_SUBJECT)
     Accessor getSubject();
@@ -42,7 +44,8 @@ public interface PermissionGrant extends Entity {
     @Fetch(value = Ontology.PERMISSION_GRANT_HAS_GRANTEE, ifBelowLevel = 1, numLevels = 1)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_GRANTEE)
     Accessor getGrantee();
-    
+
+    @Mandatory
     @Fetch(value = Ontology.PERMISSION_GRANT_HAS_TARGET, ifBelowLevel = 1, numLevels = 1)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_TARGET)
     Iterable<PermissionGrantTarget> getTargets();
@@ -50,6 +53,7 @@ public interface PermissionGrant extends Entity {
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_TARGET)
     void addTarget(PermissionGrantTarget target);
 
+    @Mandatory
     @Fetch(Ontology.PERMISSION_GRANT_HAS_PERMISSION)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_PERMISSION)
     Permission getPermission();
@@ -60,7 +64,7 @@ public interface PermissionGrant extends Entity {
     @Fetch(value = Ontology.PERMISSION_GRANT_HAS_SCOPE, ifBelowLevel = 1, numLevels = 0)
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_SCOPE)
     PermissionScope getScope();
-    
+
     @Adjacency(label = Ontology.PERMISSION_GRANT_HAS_SCOPE)
     void setScope(PermissionScope scope);
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/Repository.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Repository.java
@@ -28,6 +28,7 @@ import com.tinkerpop.pipes.util.Pipeline;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Fetch;
+import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.annotations.Meta;
 import eu.ehri.project.models.base.Described;
 import eu.ehri.project.models.base.ItemHolder;
@@ -40,8 +41,7 @@ import eu.ehri.project.models.utils.JavaHandlerUtils;
  * items.
  */
 @EntityType(EntityClass.REPOSITORY)
-public interface Repository extends Described,
-        ItemHolder, Watchable {
+public interface Repository extends Described, ItemHolder, Watchable {
 
     /**
      * Count the number of top-level documentary unit items within
@@ -85,6 +85,7 @@ public interface Repository extends Described,
      *
      * @return a country frame
      */
+    @Mandatory
     @Fetch(Ontology.REPOSITORY_HAS_COUNTRY)
     @Adjacency(label = Ontology.REPOSITORY_HAS_COUNTRY, direction = Direction.OUT)
     Country getCountry();

--- a/ehri-core/src/main/java/eu/ehri/project/models/annotations/InverseOf.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/annotations/InverseOf.java
@@ -17,16 +17,24 @@
  * permissions and limitations under the Licence.
  */
 
-package eu.ehri.project.models;
+package eu.ehri.project.models.annotations;
 
-import eu.ehri.project.models.annotations.EntityType;
-import eu.ehri.project.models.base.Described;
-import eu.ehri.project.models.base.Watchable;
-import eu.ehri.project.models.cvoc.AuthoritativeItem;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * A frame class representing a historical agent item.
+ * Indicates an adjacency that is the logical inverse of
+ * another, and the label that should be used.
  */
-@EntityType(EntityClass.HISTORICAL_AGENT)
-public interface HistoricalAgent extends AuthoritativeItem, Described, Watchable {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface InverseOf {
+    /**
+     * The label used for the inverse relationship.
+     *
+     * @return the relation name
+     */
+    String value();
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/annotations/Mandatory.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/annotations/Mandatory.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  *   }
  * </pre>
  * 
- * Indicates that a property is mandatory.
+ * Indicates that a property or adjacency is mandatory.
  */
 public @interface Mandatory {
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Description.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Description.java
@@ -45,6 +45,7 @@ public interface Description extends Named, Accessible {
         MANUAL, IMPORT
     }
 
+    @Mandatory
     @Adjacency(label = Ontology.DESCRIPTION_FOR_ENTITY)
     Described getEntity();
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Entity.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Entity.java
@@ -25,13 +25,12 @@ import com.tinkerpop.frames.VertexFrame;
 import com.tinkerpop.frames.modules.javahandler.JavaHandler;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.models.annotations.Mandatory;
 
 import java.util.Set;
 
 /**
  * Base interface for all EHRI framed vertex types.
- *
-
  */
 public interface Entity extends VertexFrame {
 
@@ -47,15 +46,19 @@ public interface Entity extends VertexFrame {
 
     /**
      * Get the unique item id.
+     *
      * @return id
      */
+    @Mandatory
     @Property(EntityType.ID_KEY)
     String getId();
 
     /**
      * Get the type key for this frame.
+     *
      * @return type
      */
+    @Mandatory
     @Property(EntityType.TYPE_KEY)
     String getType();
 
@@ -78,10 +81,12 @@ public interface Entity extends VertexFrame {
 
     abstract class Impl implements JavaHandlerContext<Vertex>, Accessible {
 
+        @Override
         public <T extends Entity> T as(Class<T> cls) {
             return frame(it(), cls);
         }
 
+        @Override
         public <T> T getProperty(String key) {
             return it().getProperty(key);
         }

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeItem.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeItem.java
@@ -22,6 +22,7 @@ package eu.ehri.project.models.cvoc;
 import com.tinkerpop.frames.Adjacency;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.Fetch;
+import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.base.Identifiable;
 import eu.ehri.project.models.base.Linkable;
 
@@ -29,6 +30,7 @@ import eu.ehri.project.models.base.Linkable;
  * An item that belongs in some authoritative set.
  */
 public interface AuthoritativeItem extends Linkable, Identifiable {
+    @Mandatory
     @Fetch(Ontology.ITEM_IN_AUTHORITATIVE_SET)
     @Adjacency(label = Ontology.ITEM_IN_AUTHORITATIVE_SET)
     AuthoritativeSet getAuthoritativeSet();

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/Concept.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/Concept.java
@@ -29,6 +29,8 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Fetch;
+import eu.ehri.project.models.annotations.InverseOf;
+import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.base.Described;
 import eu.ehri.project.models.base.ItemHolder;
 import eu.ehri.project.models.utils.JavaHandlerUtils;
@@ -47,10 +49,10 @@ import eu.ehri.project.models.utils.JavaHandlerUtils;
  * http://www.willpowerinfo.co.uk/glossary.htm
  */
 @EntityType(EntityClass.CVOC_CONCEPT)
-public interface Concept extends
-        Described, AuthoritativeItem, ItemHolder {
+public interface Concept extends Described, AuthoritativeItem, ItemHolder {
 
     // NB: As an AuthoritativeItem the set will be @Fetched automatically
+    @Mandatory
     @Adjacency(label = Ontology.ITEM_IN_AUTHORITATIVE_SET)
     Vocabulary getVocabulary();
 
@@ -69,6 +71,7 @@ public interface Concept extends
 
     // NOTE: don't put a Fetch on it, because it can be a large tree of concepts
     @Adjacency(label = Ontology.CONCEPT_HAS_NARROWER, direction = Direction.OUT)
+    @InverseOf(Ontology.CONCEPT_HAS_BROADER)
     Iterable<Concept> getNarrowerConcepts();
 
     @JavaHandler

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/ConceptDescription.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/ConceptDescription.java
@@ -19,62 +19,13 @@
 
 package eu.ehri.project.models.cvoc;
 
-import com.tinkerpop.frames.Property;
-import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Description;
 
 /**
- * labels, notes and texts that describe the concept, for a specific language 
- * are combined into this description
- * 
- * NOTE: we should only allow one prefLabel (and thus one ConceptDescription) per language, 
- * but we cannot model that
+ * Description for a SKOS concept.
  */
 @EntityType(EntityClass.CVOC_CONCEPT_DESCRIPTION)
 public interface ConceptDescription extends Description {
-
-    /** 
-     * The language property has the codes for language. 
-     * what is the default? Likely it is "en". 
-     *  
-     * We want to be able to easily convert to SKOS and use standards, so 
-     * xml:lang: "This attribute must be set to a language identifier, 
-     * as defined by IETF RFC 4646 (http://www.ietf.org/rfc/rfc4646.txt) or successor."
-     * 
-     * Validation is complex, but wellformdness checks can be simpler. 
-     *   [a-z0-9] and minus sign '-' as separator betwen subtags  
-     *   and "All subtags have a maximum length of eight characters." 
-     *   and case insensitive comparison must be used 
-	 *   and the first subtag is the "Primary Language"
-     */  
-// NOTE already in Description
-//    @Property(LANGUAGE)
-//    public String getLanguage();
-//    @Property(LANGUAGE)
-//    public String setLanguage(String language);
-        
-
-    // Note: maybe we could make a OptionalProperty annotation?
-
-    @Property(Ontology.PREFLABEL)
-    String getPrefLabel();
-    
-// NOTE if it's optional then don't use this Entity interface!
-    
-//    // More than one!
-//    @Property(CONCEPT_ALTLABEL)
-//    public String[] getAltLabels();
-//    
-//    @Property(CONCEPT_DEFINITION)
-//    public String getDefinition();
-//
-//	// NOTE: why has SKOS definitions and scope notes, what is the difference?
-//	// scope notes seem to be used in a more flexible way 
-//	// and can contain some extra information besides describing the definition. 
-//
-//    @Property(CONCEPT_SCOPENOTE)
-//    public String getScopeNote();
-
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/events/SystemEvent.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/events/SystemEvent.java
@@ -117,6 +117,14 @@ public interface SystemEvent extends Accessible {
     Accessible getFirstSubject();
 
     /**
+     * Fetch the event chronologically prior to this one.
+     *
+     * @return an event item
+     */
+    @Adjacency(label = Ontology.ACTIONER_HAS_LIFECYCLE_ACTION)
+    SystemEvent getPriorEvent();
+
+    /**
      * Fetch the "scope" of this event, or the context in which a
      * given creation/modification/deletion event is happening.
      *

--- a/ehri-core/src/main/java/eu/ehri/project/models/events/SystemEventQueue.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/events/SystemEventQueue.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.models.events;
 
 import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.modules.javahandler.JavaHandler;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import com.tinkerpop.pipes.util.Pipeline;
@@ -38,6 +39,19 @@ public interface SystemEventQueue extends Entity {
 
     String STREAM_START = Ontology.ACTIONER_HAS_LIFECYCLE_ACTION + "Stream";
 
+    /**
+     * Fetch the latest global event.
+     *
+     * @return a system event frame
+     */
+    @Adjacency(label = SystemEventQueue.STREAM_START)
+    SystemEvent getLatestEvent();
+
+    /**
+     * Get a stream of system events, latest first.
+     *
+     * @return an iterable of event frames
+     */
     @JavaHandler
     Iterable<SystemEvent> getSystemEvents();
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/idgen/IdGeneratorUtils.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/idgen/IdGeneratorUtils.java
@@ -23,19 +23,16 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.persistence.Messages;
 import eu.ehri.project.utils.Slugify;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -72,10 +69,11 @@ public class IdGeneratorUtils {
      * @param ident  the item's identifier
      */
     public static String generateId(PermissionScope scope, Bundle bundle, String ident) {
-        LinkedList<String> scopeIds = Lists.newLinkedList();
+        List<String> scopeIds = Lists.newArrayList();
         if (scope != null && !scope.equals(SystemScope.getInstance())) {
-            for (PermissionScope s : scope.getPermissionScopes())
-                scopeIds.addFirst(s.getIdentifier());
+            for (PermissionScope s : scope.getPermissionScopes()) {
+                scopeIds.add(0, s.getIdentifier());
+            }
             scopeIds.add(scope.getIdentifier());
         }
         return generateId(scopeIds, bundle, ident);

--- a/ehri-core/src/main/java/eu/ehri/project/models/utils/ClassUtils.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/utils/ClassUtils.java
@@ -233,8 +233,10 @@ public class ClassUtils {
             Mandatory mandatory = method.getAnnotation(Mandatory.class);
             if (mandatory != null) {
                 Property ann = method.getAnnotation(Property.class);
-                if (ann != null)
+                // Ignore structural properties, beginning with '__'
+                if (ann != null && !ann.value().startsWith("__")) {
                     out.add(ann.value());
+                }
             }
 
         }

--- a/ehri-core/src/test/java/eu/ehri/project/models/CvocConceptTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/CvocConceptTest.java
@@ -175,7 +175,7 @@ public class CvocConceptTest extends ModelTestBase {
 		// that is the frames way of doning things
 		
 		ConceptDescription descr = graph.frame(description.asVertex(), ConceptDescription.class);		
-		assertEquals("pref1", descr.getPrefLabel());
+		assertEquals("pref1", descr.getName());
 		// etc. etc.
 		
 		//String[] altLabels = descr.getAltLabels();		

--- a/ehri-core/src/test/java/eu/ehri/project/models/DocumentaryUnitTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/DocumentaryUnitTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
@@ -46,6 +47,8 @@ public class DocumentaryUnitTest extends AbstractFixtureTest {
         DocumentaryUnit child = manager.getEntity("c3", DocumentaryUnit.class);
         assertNotNull(child.getRepository());
         assertNotNull(unit.getRepository());
+        assertNotNull(unit.getRepositoryIfTopLevel());
+        assertNull(child.getRepositoryIfTopLevel());
         assertEquals(unit.getRepository(), child.getRepository());
     }
 

--- a/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventQueueTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventQueueTest.java
@@ -1,0 +1,32 @@
+package eu.ehri.project.models.events;
+
+import com.google.common.collect.Iterators;
+import eu.ehri.project.definitions.EventTypes;
+import eu.ehri.project.models.base.Actioner;
+import eu.ehri.project.persistence.ActionManager;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SystemEventQueueTest extends AbstractFixtureTest {
+
+    @Test
+    public void testGetLatestEvent() throws Exception {
+        SystemEventQueue queue = manager.getEntity(ActionManager.GLOBAL_EVENT_ROOT, SystemEventQueue.class);
+        assertNull(queue.getLatestEvent());
+        ActionManager.EventContext ctx = new ActionManager(graph)
+                .newEventContext(validUser, validUser.as(Actioner.class), EventTypes.creation);
+        SystemEvent commit = ctx.commit();
+        assertEquals(commit, queue.getLatestEvent());
+    }
+
+    @Test
+    public void testGetSystemEvents() throws Exception {
+        SystemEventQueue queue = manager.getEntity(ActionManager.GLOBAL_EVENT_ROOT, SystemEventQueue.class);
+        new ActionManager(graph)
+                .newEventContext(validUser, validUser.as(Actioner.class), EventTypes.creation)
+                .commit();
+        assertEquals(1, Iterators.size(queue.getSystemEvents().iterator()));
+    }
+}

--- a/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventTest.java
@@ -104,6 +104,8 @@ public class SystemEventTest extends AbstractFixtureTest {
                 EventTypes.deletion);
         SystemEvent forth = ctx3.commit();
 
+        assertEquals(third, forth.getPriorEvent());
+
         // creation and modification are different
         assertFalse(sameAs(first, second));
 

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/cvoc/SchemaExporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/cvoc/SchemaExporter.java
@@ -1,0 +1,174 @@
+package eu.ehri.project.exporters.cvoc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.hp.hpl.jena.datatypes.xsd.XSDDatatype;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.hp.hpl.jena.rdf.model.RDFNode;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.vocabulary.OWL;
+import com.hp.hpl.jena.vocabulary.RDF;
+import com.hp.hpl.jena.vocabulary.RDFS;
+import com.hp.hpl.jena.vocabulary.XSD;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.frames.Adjacency;
+import com.tinkerpop.frames.Property;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.annotations.InverseOf;
+import eu.ehri.project.models.annotations.Mandatory;
+import eu.ehri.project.models.utils.ClassUtils;
+
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Dump an RDF schema + OWL representation of the model schema.
+ */
+public class SchemaExporter {
+
+    private final String rdfFormat;
+
+    public SchemaExporter(String rdfFormat) {
+        this.rdfFormat = rdfFormat;
+    }
+
+    public final static String DEFAULT_BASE_URI = "http://data.ehri-project.eu/ontology/";
+    public final static Map<String, String> NAMESPACES = ImmutableMap.<String, String>builder()
+            .put("owl", OWL.getURI())
+            .put("xsd", XSD.getURI())
+            .put("rdfs", RDFS.getURI())
+            .put("ehri", DEFAULT_BASE_URI)
+            .build();
+
+    public void dumpSchema(OutputStream outputStream, String baseUri) throws UnsupportedEncodingException {
+
+        Model model = ModelFactory.createDefaultModel();
+        model.setNsPrefixes(NAMESPACES);
+
+        Set<Class<?>> baseClasses = Sets.newHashSet();
+
+        for (EntityClass entityClass : EntityClass.values()) {
+            Collections.addAll(baseClasses, entityClass.getJavaClass().getInterfaces());
+        }
+
+        for (Class<?> sup : baseClasses) {
+            dumpEntityClass(model, sup);
+        }
+
+        for (EntityClass entityClass : EntityClass.values()) {
+            Class<?> cls = entityClass.getJavaClass();
+            Resource shape = dumpEntityClass(model, cls);
+
+            for (Class<?> sup : cls.getInterfaces()) {
+                model.add(shape, RDFS.subClassOf,
+                        model.createResource(DEFAULT_BASE_URI + sup.getSimpleName()));
+            }
+        }
+
+        model.getWriter(rdfFormat).write(model, outputStream, baseUri);
+    }
+
+    // Helpers
+    private XSDDatatype typeOf(Class<?> cls) {
+        if (Number.class.isAssignableFrom(cls)) {
+            return XSDDatatype.XSDinteger;
+        } else if (Boolean.class.isAssignableFrom(cls)) {
+            return XSDDatatype.XSDboolean;
+        } else {
+            return XSDDatatype.XSDstring;
+        }
+    }
+
+    private Resource dumpEntityClass(Model model, Class<?> cls) {
+        String name = cls.getSimpleName();
+
+        // Create the rdfClass...
+        Resource rdfClass = model.createResource(DEFAULT_BASE_URI + name);
+        model.add(rdfClass, RDF.type, OWL.Class);
+        model.add(rdfClass, RDFS.label, name);
+
+        for (Method method : cls.getDeclaredMethods()) {
+            Property property = method.getAnnotation(Property.class);
+            Class<?> returnType = method.getReturnType();
+
+            if (property != null) {
+                String propertyName = property.value();
+                boolean mandatory = method.getAnnotation(Mandatory.class) != null;
+                addDatatypeProperty(model, rdfClass, propertyName, returnType, mandatory);
+            } else {
+                Adjacency adjacency = method.getAnnotation(Adjacency.class);
+                InverseOf inverseOf = method.getAnnotation(InverseOf.class);
+                if (adjacency != null
+                        && method.getName().startsWith(ClassUtils.FETCH_METHOD_PREFIX)
+                        && (adjacency.direction().equals(Direction.OUT) || inverseOf != null)) {
+                    boolean mandatory = method.getAnnotation(Mandatory.class) != null;
+                    String label = inverseOf != null ? inverseOf.value() : adjacency.label();
+                    addObjectProperty(model, rdfClass, method, returnType, label, mandatory);
+                }
+            }
+        }
+
+        return rdfClass;
+    }
+
+    private void addObjectProperty(Model model, Resource rdfClass, Method method,
+            Class<?> returnType, String name, boolean mandatory) {
+        boolean collection = Iterable.class.isAssignableFrom(returnType);
+        if (collection) {
+            // This is (probably) an iterable frame rel
+            ParameterizedType type = (ParameterizedType) method.getGenericReturnType();
+            returnType = (Class<?>) type.getActualTypeArguments()[0];
+            mandatory = false;
+        }
+
+        Resource propResource = model.createResource(DEFAULT_BASE_URI + name);
+        model.add(propResource, RDF.type, OWL.ObjectProperty);
+        model.add(propResource, RDFS.domain, rdfClass);
+        model.add(propResource, RDFS.range,
+                model.createResource(DEFAULT_BASE_URI + returnType.getSimpleName()));
+
+        Resource restriction = model.createResource();
+        model.add(restriction, RDF.type, OWL.Restriction);
+        model.add(restriction, OWL.onProperty, propResource);
+        model.add(restriction, OWL.allValuesFrom,
+                model.createResource(DEFAULT_BASE_URI + returnType.getSimpleName()));
+        if (mandatory) {
+            model.add(restriction, OWL.cardinality,
+                    model.createTypedLiteral(1, XSDDatatype.XSDnonNegativeInteger));
+        }
+        model.add(rdfClass, RDFS.subClassOf, restriction);
+    }
+
+    private void addDatatypeProperty(Model model, Resource rdfClass,
+            String propertyName, Class<?> type, boolean mandatory) {
+        Resource propResource = model.createResource(DEFAULT_BASE_URI + propertyName);
+        model.add(propResource, RDF.type, OWL.DatatypeProperty);
+
+        model.add(propResource, RDFS.domain, rdfClass);
+        model.add(propResource, RDFS.range,
+                model.createResource(typeOf(type).getURI()));
+
+        Resource restriction = model.createResource();
+        model.add(restriction, RDF.type, OWL.Restriction);
+        model.add(restriction, OWL.onProperty, propResource);
+        model.add(restriction, mandatory ? OWL.cardinality : OWL.maxCardinality,
+                model.createTypedLiteral(1, XSDDatatype.XSDnonNegativeInteger));
+        model.add(rdfClass, RDFS.subClassOf, restriction);
+
+        if (type.isEnum()) {
+            List<RDFNode> inValues = Lists.newArrayList();
+            for (Object constValue : type.getEnumConstants()) {
+                inValues.add(model.createLiteral(constValue.toString()));
+            }
+            model.add(propResource, OWL.oneOf, model.createList(inValues.iterator()));
+        }
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/AbstractImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/AbstractImporter.java
@@ -62,7 +62,7 @@ public abstract class AbstractImporter<T> {
     protected final FramedGraph<?> framedGraph;
     protected final GraphManager manager;
     protected final ImportLog log;
-    protected final List<ImportCallback> callbacks = Lists.newLinkedList();
+    protected final List<ImportCallback> callbacks = Lists.newArrayList();
 
     private NodeProperties pc;
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/MapImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/MapImporter.java
@@ -124,7 +124,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
      */
     @Override
     public List<Map<String, Object>> extractDates(Map<String, Object> data) {
-        List<Map<String, Object>> extractedDates = Lists.newLinkedList();
+        List<Map<String, Object>> extractedDates = Lists.newArrayList();
         Map<String, String> dateValues = returnDatesAsString(data, dates);
         for (String s : dateValues.keySet()) {
             try {

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/cvoc/SchemaExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/cvoc/SchemaExporterTest.java
@@ -1,0 +1,28 @@
+package eu.ehri.project.exporters.cvoc;
+
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import eu.ehri.project.definitions.Entities;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertTrue;
+
+public class SchemaExporterTest {
+
+    @Test
+    public void testDumpSchema() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new SchemaExporter("TTL").dumpSchema(outputStream, null);
+        Model model = ModelFactory.createDefaultModel();
+        model.setNsPrefixes(SchemaExporter.NAMESPACES);
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
+            model.read(inputStream, null, "TTL");
+            //System.out.println(outputStream.toString("UTF-8"));
+            assertTrue(model.containsResource(model.createResource(SchemaExporter.DEFAULT_BASE_URI + Entities
+                    .USER_PROFILE)));
+        }
+    }
+}

--- a/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -205,15 +205,6 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
         }
     }
 
-    public final static String TURTLE_MIMETYPE = "text/turtle";
-    public final static String RDF_XML_MIMETYPE = "application/rdf+xml";
-    public final static String N3_MIMETYPE = "application/n-triples";
-    public final BiMap<String, String> RDF_MIMETYPE_FORMATS = ImmutableBiMap.of(
-            N3_MIMETYPE, "N3",
-            TURTLE_MIMETYPE, "TTL",
-            RDF_XML_MIMETYPE, "RDF/XML"
-    );
-
     /**
      * Export the given vocabulary as SKOS.
      *
@@ -248,20 +239,6 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
                     model.getWriter(rdfFormat).write(model, outputStream, base);
                 }
             }).type(mediaType + "; charset=utf-8").build();
-        }
-    }
-
-    private String getRdfFormat(String format, String defaultFormat) {
-        if (format == null) {
-            for (String mimeValue : RDF_MIMETYPE_FORMATS.keySet()) {
-                MediaType mime = MediaType.valueOf(mimeValue);
-                if (requestHeaders.getAcceptableMediaTypes().contains(mime)) {
-                    return RDF_MIMETYPE_FORMATS.get(mimeValue);
-                }
-            }
-            return defaultFormat;
-        } else {
-            return RDF_MIMETYPE_FORMATS.containsValue(format) ? format : defaultFormat;
         }
     }
 }


### PR DESCRIPTION
This only concerns the so-called 'functional' schema, i.e. mandatory properties and relationships.

Various additional tweaks to the model schema and elsewhere.