### PR TITLE
More cleanups

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -174,22 +174,4 @@
             <version>0.12.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>Neo4jMaven2releaserepository</id>
-            <name>Neo4j Maven 2 release repository</name>
-            <url>http://m2.neo4j.org/releases/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-        <repository>
-            <id>Sonatype-public</id>
-            <name>SnakeYAML repository</name>
-            <url>http://oss.sonatype.org/content/groups/public/</url>
-        </repository>
-    </repositories>
 </project>

--- a/ehri-core/src/main/java/eu/ehri/project/models/AccessPoint.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/AccessPoint.java
@@ -26,7 +26,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.base.Accessible;
-import eu.ehri.project.models.base.Annotator;
+import eu.ehri.project.models.base.Annotatable;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.Named;
 
@@ -35,7 +35,7 @@ import eu.ehri.project.models.base.Named;
  * but without the target-end of the relationship being determined.
  */
 @EntityType(EntityClass.ACCESS_POINT)
-public interface AccessPoint extends Accessible, Named, Annotator {
+public interface AccessPoint extends Accessible, Named {
 
     /**
      * Fetch the description to which this UR belongs.

--- a/ehri-core/src/main/java/eu/ehri/project/models/Annotation.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Annotation.java
@@ -27,7 +27,6 @@ import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Fetch;
 import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.base.Annotatable;
-import eu.ehri.project.models.base.Annotator;
 import eu.ehri.project.models.base.Promotable;
 
 /**
@@ -52,7 +51,7 @@ public interface Annotation extends Promotable {
      */
     @Fetch(value = Ontology.ANNOTATOR_HAS_ANNOTATION, numLevels = 0)
     @Adjacency(label = Ontology.ANNOTATOR_HAS_ANNOTATION, direction = Direction.IN)
-    Annotator getAnnotator();
+    UserProfile getAnnotator();
 
     /**
      * Set the annotator of this annotation.
@@ -60,7 +59,7 @@ public interface Annotation extends Promotable {
      * @param annotator an annotator frame
      */
     @Adjacency(label = Ontology.ANNOTATOR_HAS_ANNOTATION, direction = Direction.IN)
-    void setAnnotator(Annotator annotator);
+    void setAnnotator(UserProfile annotator);
 
     /**
      * Fetch all targets of this annotation, including sub-parts

--- a/ehri-core/src/main/java/eu/ehri/project/models/UserProfile.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/UserProfile.java
@@ -33,7 +33,6 @@ import eu.ehri.project.models.annotations.Meta;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Actioner;
-import eu.ehri.project.models.base.Annotator;
 import eu.ehri.project.models.base.Watchable;
 
 import static eu.ehri.project.definitions.Ontology.ACCESSOR_BELONGS_TO_GROUP;
@@ -45,8 +44,7 @@ import static eu.ehri.project.models.utils.JavaHandlerUtils.*;
  * A frame class representing a user within the database.
  */
 @EntityType(EntityClass.USER_PROFILE)
-public interface UserProfile extends Accessor, Accessible,
-        Annotator, Actioner {
+public interface UserProfile extends Accessor, Accessible, Actioner {
 
     String FOLLOWER_COUNT = "followers";
     String FOLLOWING_COUNT = "following";
@@ -145,7 +143,6 @@ public interface UserProfile extends Accessor, Accessible,
      * @return an iterable of annotation frames
      */
     @Adjacency(label = Ontology.ANNOTATOR_HAS_ANNOTATION)
-    @Override
     Iterable<Annotation> getAnnotations();
 
     /**

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/AbstractUnit.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/AbstractUnit.java
@@ -20,8 +20,8 @@
 package eu.ehri.project.models.base;
 
 /**
- * An abstract entity that has the features that documentary units need.
+ * An abstract entity representing either a documentary (physical) unit
+ * or a virtual unit.
  */
-public interface AbstractUnit extends Described,
-        ItemHolder, Watchable {
+public interface AbstractUnit extends Described, ItemHolder, Watchable {
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Accessible.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Accessible.java
@@ -39,6 +39,11 @@ import static eu.ehri.project.models.utils.JavaHandlerUtils.hasEdge;
  */
 public interface Accessible extends PermissionGrantTarget, Versioned, Annotatable {
 
+    /**
+     * Fetch accessors to which this item is restricted.
+     *
+     * @return an iterable of accessor frames
+     */
     @Fetch(value = Ontology.IS_ACCESSIBLE_TO, ifBelowLevel = 1)
     @Adjacency(label = Ontology.IS_ACCESSIBLE_TO)
     Iterable<Accessor> getAccessors();
@@ -52,15 +57,36 @@ public interface Accessible extends PermissionGrantTarget, Versioned, Annotatabl
     @JavaHandler
     void addAccessor(Accessor accessor);
 
+    /**
+     * Remove an accessor from having access to this item.
+     *
+     * @param accessor an accessor frame
+     */
     @Adjacency(label = Ontology.IS_ACCESSIBLE_TO)
     void removeAccessor(Accessor accessor);
 
+    /**
+     * Fetch the permission scope to which this item belongs, if any.
+     *
+     * @return a permission scope frame, or null
+     */
     @Adjacency(label = Ontology.HAS_PERMISSION_SCOPE)
     PermissionScope getPermissionScope();
 
+    /**
+     * Set this item's permission scope.
+     *
+     * @param scope a permission scope frame
+     */
     @JavaHandler
     void setPermissionScope(PermissionScope scope);
 
+    /**
+     * Get the full hierarchy of permission scopes to which this
+     * item belongs.
+     *
+     * @return an iterable of permission scope frames
+     */
     @JavaHandler
     Iterable<PermissionScope> getPermissionScopes();
 
@@ -72,10 +98,20 @@ public interface Accessible extends PermissionGrantTarget, Versioned, Annotatabl
     @JavaHandler
     Iterable<SystemEvent> getHistory();
 
+    /**
+     * Fetch the most recent event that affected this item.
+     *
+     * @return a system event frame, or null
+     */
     @Fetch(value = Ontology.ENTITY_HAS_LIFECYCLE_EVENT, ifLevel = 0)
     @JavaHandler
     SystemEvent getLatestEvent();
 
+    /**
+     * Determine if this item has access restrictions.
+     *
+     * @return true, if the item is restricted, otherwise false
+     */
     @JavaHandler
     boolean hasAccessRestriction();
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Annotator.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Annotator.java
@@ -24,11 +24,14 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.Annotation;
 
 /**
- * An entity that can annotate {@link Annotatable}s.
- *
-
+ * An entity that can annotate {@link Annotatable} items.
  */
 public interface Annotator extends Entity {
+    /**
+     * Fetch annotations belonging to this item.
+     *
+     * @return an iterable of annotation frames
+     */
     @Adjacency(label = Ontology.ANNOTATOR_HAS_ANNOTATION)
     Iterable<Annotation> getAnnotations();
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Described.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Described.java
@@ -27,20 +27,30 @@ import eu.ehri.project.models.annotations.Fetch;
 
 /**
  * An entity that can have descriptions.
- *
-
  */
 public interface Described extends PermissionScope, Linkable {
 
+    /**
+     * Add a description to this item.
+     *
+     * @param description a description frame
+     */
     @Adjacency(label = Ontology.DESCRIPTION_FOR_ENTITY, direction = Direction.IN)
     void addDescription(Description description);
 
-    @Adjacency(label = Ontology.DESCRIPTION_FOR_ENTITY, direction = Direction.IN)
-    void setDescriptions(Iterable<Description> descriptions);
-
+    /**
+     * Remove a description from this item.
+     *
+     * @param description a description frame
+     */
     @Adjacency(label = Ontology.DESCRIPTION_FOR_ENTITY, direction = Direction.IN)
     void removeDescription(Description description);
 
+    /**
+     * Fetch this item's descriptions.
+     *
+     * @return an iterable of description frames
+     */
     @Fetch(Ontology.DESCRIPTION_FOR_ENTITY)
     @Dependent
     @Adjacency(label = Ontology.DESCRIPTION_FOR_ENTITY, direction = Direction.IN)

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Linkable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Linkable.java
@@ -26,13 +26,21 @@ import eu.ehri.project.models.Link;
 
 /**
  * An entity that can hold incoming links.
- *
-
  */
 public interface Linkable extends Accessible {
+    /**
+     * Fetch links attached to this item.
+     *
+     * @return an iterable of link frames
+     */
     @Adjacency(label = Ontology.LINK_HAS_TARGET, direction = Direction.IN)
     Iterable<Link> getLinks();
 
+    /**
+     * Add a link to this item.
+     *
+     * @param link a link frame
+     */
     @Adjacency(label = Ontology.LINK_HAS_TARGET, direction = Direction.IN)
     void addLink(Link link);
 }

--- a/ehri-core/src/main/java/eu/ehri/project/views/AnnotationViews.java
+++ b/ehri-core/src/main/java/eu/ehri/project/views/AnnotationViews.java
@@ -33,11 +33,11 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.models.Annotation;
+import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.Annotatable;
-import eu.ehri.project.models.base.Annotator;
 import eu.ehri.project.models.base.Entity;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.persistence.ActionManager;
@@ -96,7 +96,7 @@ public final class AnnotationViews implements Scoped<AnnotationViews> {
      * @throws ValidationError
      * @throws ItemNotFound
      */
-    public Annotation createFor(String id, String did, Bundle bundle, Accessor user, Collection<Accessor> accessibleTo)
+    public Annotation create(String id, String did, Bundle bundle, UserProfile user, Collection<Accessor> accessibleTo)
             throws PermissionDenied, AccessDenied, ValidationError, ItemNotFound {
         Accessible entity = manager.getEntity(id, Accessible.class);
         Annotatable dep = manager.getEntity(did, Annotatable.class);
@@ -113,7 +113,7 @@ public final class AnnotationViews implements Scoped<AnnotationViews> {
         if (!entity.equals(dep)) {
             dep.addAnnotationPart(annotation);
         }
-        annotation.setAnnotator(graph.frame(user.asVertex(), Annotator.class));
+        annotation.setAnnotator(user);
         acl.setAccessors(annotation, accessibleTo);
         acl.withScope(SystemScope.INSTANCE)
                 .grantPermission(annotation, PermissionType.OWNER, user);

--- a/ehri-core/src/main/java/eu/ehri/project/views/Query.java
+++ b/ehri-core/src/main/java/eu/ehri/project/views/Query.java
@@ -21,14 +21,10 @@ package eu.ehri.project.views;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.tinkerpop.blueprints.CloseableIterable;
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.gremlin.java.GremlinPipeline;
@@ -50,14 +46,12 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 
 /**
  * Handles querying Accessible Entities, with ACL semantics.
- * <p>
+ * <p/>
  * TODO: Possibly refactor more of the ACL logic into AclManager.
  *
  * @param <E>
@@ -68,17 +62,14 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
     private static final int DEFAULT_LIMIT = 20;
     private static final long NO_COUNT = -1L;
 
-    
+
     private static final Logger logger = LoggerFactory.getLogger(Query.class);
 
     private final int offset;
     private final int limit;
     private final SortedMap<String, Sort> sort;
-    private final SortedMap<QueryUtils.TraversalPath, Sort> traversalSort;
     private final Optional<Pair<String, Sort>> defaultSort;
     private final SortedMap<String, Pair<FilterPredicate, String>> filters;
-    private final ImmutableMap<Pair<String, Direction>, Integer> depthFilters;
-    private final List<GremlinPipeline<Vertex, Vertex>> traversalFilters;
     private final boolean stream;
 
     private final FramedGraph<?> graph;
@@ -95,7 +86,6 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
 
     /**
      * Filter predicates
-     *
      */
     public enum FilterPredicate {
         EQUALS, IEQUALS, STARTSWITH, ENDSWITH, CONTAINS, ICONTAINS, MATCHES, GT, GTE, LT, LTE
@@ -110,11 +100,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
             int offset,
             int limit,
             SortedMap<String, Sort> sort,
-            SortedMap<QueryUtils.TraversalPath, Sort> traversalSort,
             Optional<Pair<String, Sort>> defSort,
             SortedMap<String, Pair<FilterPredicate, String>> filters,
-            Map<Pair<String, Direction>, Integer> depthFilters,
-            List<GremlinPipeline<Vertex, Vertex>> traversalFilters,
             boolean stream) {
         this.graph = graph;
         this.cls = cls;
@@ -122,13 +109,10 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
         this.offset = offset;
         this.limit = limit;
         this.sort = ImmutableSortedMap.copyOf(sort);
-        this.traversalSort = ImmutableSortedMap.copyOf(traversalSort);
         this.defaultSort = defSort;
         this.filters = ImmutableSortedMap
                 .copyOf(filters);
         this.stream = stream;
-        this.depthFilters = ImmutableMap.copyOf(depthFilters);
-        this.traversalFilters = ImmutableList.copyOf(traversalFilters);
         manager = GraphManagerFactory.getInstance(graph);
     }
 
@@ -138,12 +122,9 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
     public Query(FramedGraph<?> graph, Class<E> cls) {
         this(graph, cls, SystemScope.getInstance(),
                 DEFAULT_OFFSET, DEFAULT_LIMIT,
-                ImmutableSortedMap.<String, Sort>of(), ImmutableSortedMap
-                .<QueryUtils.TraversalPath, Sort>of(), Optional
-                .<Pair<String, Sort>>absent(), ImmutableSortedMap
-                .<String, Pair<FilterPredicate, String>>of(), Maps
-                .<Pair<String, Direction>, Integer>newHashMap(),
-                ImmutableList.<GremlinPipeline<Vertex, Vertex>>of(), false);
+                ImmutableSortedMap.<String, Sort>of(), Optional
+                        .<Pair<String, Sort>>absent(), ImmutableSortedMap
+                        .<String, Pair<FilterPredicate, String>>of(), false);
     }
 
     /**
@@ -151,8 +132,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
      */
     public Query<E> copy(Query<E> other) {
         return new Query<>(other.graph, other.cls, other.scope, other.offset,
-                other.limit, other.sort, other.traversalSort, other.defaultSort, other.filters,
-                other.depthFilters, other.traversalFilters, other.stream);
+                other.limit, other.sort, other.defaultSort, other.filters,
+                other.stream);
     }
 
 
@@ -262,8 +243,7 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
      * Return a Page instance containing a total of total items, and an iterable
      * for the given page/count.
      */
-    public <T extends Entity> Page<T> page(Iterable<T> vertices,
-            Accessor user, Class<T> cls) {
+    public <T extends Entity> Page<T> page(Iterable<T> vertices, Accessor user, Class<T> cls) {
         PipeFunction<Vertex, Boolean> aclFilterFunction = AclManager
                 .getAclFilterFunction(user);
 
@@ -273,11 +253,11 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
 
         if (stream) {
             return new Page<>(graph.frameVertices(
-                    setPipelineRange(setOrder(applyFilters(pipeline))), cls), offset, limit, NO_COUNT);
+                    setPipelineRange(setOrder(setFilters(pipeline))), cls), offset, limit, NO_COUNT);
         } else {
             // FIXME: We have to read the vertices into memory here since we
             // can't re-use the iterator for counting and streaming.
-            ArrayList<Vertex> userVerts = Lists.newArrayList(applyFilters(pipeline).iterator());
+            ArrayList<Vertex> userVerts = Lists.newArrayList(setFilters(pipeline).iterator());
             Iterable<T> iterable = graph.frameVertices(
                     setPipelineRange(setOrder(new GremlinPipeline<Vertex, Vertex>(
                             userVerts))), cls);
@@ -297,12 +277,12 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
                 PipeFunction<Vertex, Boolean> aclFilterFunction = AclManager.getAclFilterFunction(user);
                 long numItems = stream
                         ? NO_COUNT
-                        : applyFilters(new GremlinPipeline<Vertex, Vertex>(countQ)
+                        : setFilters(new GremlinPipeline<Vertex, Vertex>(countQ)
                         .filter(aclFilterFunction)).count();
 
                 return new Page<>(
                         graph.frameVertices(
-                                setPipelineRange(setOrder(applyFilters(new GremlinPipeline<Vertex, Vertex>(
+                                setPipelineRange(setOrder(setFilters(new GremlinPipeline<Vertex, Vertex>(
                                         indexQ).filter(aclFilterFunction)))),
                                 cls), offset, limit, numItems);
             }
@@ -310,15 +290,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
     }
 
     /**
-     * Apply filtering actions to a Gremlin pipeline.
-     */
-    private <S> GremlinPipeline<S, Vertex> applyFilters(GremlinPipeline<S, Vertex> pipe) {
-        return setFilters(setDepthFilters(setTraversalFilters(pipe)));
-    }
-
-    /**
      * Count items.
-     * <p>
+     * <p/>
      * NB: Count doesn't 'account' for ACL privileges!
      */
     public long count() {
@@ -327,18 +300,17 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
 
     /**
      * Count items accessible to a given user.
-     * <p>
+     * <p/>
      * NB: Count doesn't 'account' for ACL privileges!
      */
     public <T> long count(Iterable<T> vertices) {
         GremlinPipeline<T, Vertex> filter = new GremlinPipeline<>(vertices);
-
-        return applyFilters(filter).count();
+        return setFilters(filter).count();
     }
 
     /**
      * Count all items of a given type.
-     * <p>
+     * <p/>
      * NB: Count doesn't 'account' for ACL privileges!
      */
     public long count(EntityClass type) {
@@ -352,7 +324,7 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
      */
     public Query<E> setOffset(int offset) {
         return new Query<>(graph, cls, scope, offset,
-                limit, sort, traversalSort, defaultSort, filters, depthFilters, traversalFilters, stream);
+                limit, sort, defaultSort, filters, stream);
     }
 
     /**
@@ -362,8 +334,7 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
      */
     public Query<E> setLimit(int limit) {
         return new Query<>(graph, cls, scope, offset,
-                limit, sort, traversalSort, defaultSort, filters,
-                depthFilters, traversalFilters, stream);
+                limit, sort, defaultSort, filters, stream);
     }
 
     /**
@@ -375,8 +346,7 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
      */
     public Query<E> setStream(boolean stream) {
         return new Query<>(graph, cls, scope, offset,
-                limit, sort, traversalSort, defaultSort, filters,
-                depthFilters, traversalFilters, stream);
+                limit, sort, defaultSort, filters, stream);
     }
 
     /**
@@ -384,9 +354,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
      */
     public Query<E> defaultOrderBy(String field, Sort order) {
 
-        return new Query<>(graph, cls, scope, offset, limit, sort, traversalSort,
-                Optional.of(new Pair<>(field, order)), filters,
-                depthFilters, traversalFilters, stream);
+        return new Query<>(graph, cls, scope, offset, limit, sort,
+                Optional.of(new Pair<>(field, order)), filters, stream);
     }
 
     /**
@@ -395,22 +364,13 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
     public Query<E> orderBy(String field, Sort order) {
         SortedMap<String, Sort> tmp = new ImmutableSortedMap.Builder<String, Sort>(
                 Ordering.natural()).putAll(sort).put(field, order).build();
-        return new Query<>(graph, cls, scope, offset, limit, tmp, traversalSort, defaultSort,
-                filters, depthFilters, traversalFilters, stream);
+        return new Query<>(graph, cls, scope, offset, limit, tmp, defaultSort,
+                filters, stream);
     }
-
-    public Query<E> orderByTraversal(QueryUtils.TraversalPath tp, Sort order) {
-        ImmutableSortedMap.Builder<QueryUtils.TraversalPath, Sort> tmp = new ImmutableSortedMap.Builder<QueryUtils.TraversalPath, Sort>(
-                Ordering.arbitrary()).putAll(traversalSort);
-        tmp.put(tp, order);
-        return new Query<>(graph, cls, scope, offset, limit, sort, tmp.build(), defaultSort,
-                filters, depthFilters, traversalFilters, stream);
-    }
-
 
     /**
      * Add a set of string order clauses. Clauses must be of the form:
-     * <p>
+     * <p/>
      * property__DIRECTION
      *
      * @param orderSpecs list of orderSpecs
@@ -419,14 +379,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
         SortedMap<String, Sort> tmp = QueryUtils.parseOrderSpecs(orderSpecs);
         Query<E> query = this;
         for (Entry<String, Sort> entry : tmp.entrySet()) {
-            Optional<QueryUtils.TraversalPath> tp = QueryUtils.getTraversalPath(entry.getKey());
-            if (tp.isPresent()) {
-                logger.debug("Adding traversal order: {}", entry.getKey());
-                query = query.orderByTraversal(tp.get(), entry.getValue());
-            } else {
-                logger.debug("Adding property order: {}", entry.getKey());
-                query = query.orderBy(entry.getKey(), entry.getValue());
-            }
+            logger.debug("Adding property order: {}", entry.getKey());
+            query = query.orderBy(entry.getKey(), entry.getValue());
         }
         return query;
     }
@@ -442,10 +396,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
                 offset,
                 limit,
                 sort,
-                traversalSort,
                 defaultSort,
                 ImmutableSortedMap.<String, Pair<FilterPredicate, String>>of(),
-                depthFilters, traversalFilters,
                 stream);
     }
 
@@ -460,29 +412,15 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
                 offset,
                 limit,
                 ImmutableSortedMap.<String, Sort>of(),
-                traversalSort,
                 defaultSort,
                 filters,
-                depthFilters, traversalFilters,
                 stream);
-    }
-
-    /**
-     * Filter out items that are over a certain depth in the given
-     * relationship chain.
-     */
-    public Query<E> depthFilter(String label, Direction direction, Integer depth) {
-        Map<Pair<String, Direction>, Integer> tmp = Maps.newHashMap(depthFilters);
-        tmp.put(new Pair<>(label, direction), depth);
-        return new Query<>(graph, cls, scope, offset, limit, sort,
-                traversalSort, defaultSort, filters, tmp, traversalFilters, stream);
     }
 
     /**
      * Add a filter clause.
      */
-    public Query<E> filter(String property, FilterPredicate predicate,
-            String value) {
+    public Query<E> filter(String property, FilterPredicate predicate, String value) {
         ImmutableSortedMap.Builder<String, Pair<FilterPredicate, String>> builder
                 = new ImmutableSortedMap.Builder<>(
                 Ordering.natural());
@@ -494,45 +432,24 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
         builder.put(property, new Pair<>(predicate, value));
 
         return new Query<>(graph, cls, scope, offset, limit, sort,
-                traversalSort, defaultSort, builder.build(), depthFilters, traversalFilters, stream);
-    }
-
-    /**
-     * Add a filter clause.
-     */
-    public Query<E> filterTraversal(QueryUtils.TraversalPath path, FilterPredicate predicate,
-            String value) {
-        ArrayList<GremlinPipeline<Vertex, Vertex>> tmp = Lists.newArrayList(traversalFilters);
-        tmp.add(getFilterTraversalPipeline(path, new Pair<>(predicate, value)));
-        return new Query<>(graph, cls, scope, offset, limit, sort,
-                traversalSort, defaultSort, filters, depthFilters, tmp, stream);
+                defaultSort, builder.build(), stream);
     }
 
     /**
      * Add a set of unparsed filter clauses. Clauses must be of the format:
      * property__PREDICATE:value
-     * <p>
+     * <p/>
      * If PREDICATE is omitted, EQUALS is the default.
      *
      * @param filters list of filters
      * @return a new query object
      */
     public Query<E> filter(Collection<String> filters) {
-        // FIXME: This is really gross, but we want to allow the arguments
-        // to .filter() to be a mix of property filters and traversal path
-        // filters, because they'll usually just come straight from some
-        // query params.
         SortedMap<String, Pair<FilterPredicate, String>> tmp = QueryUtils.parseFilters(filters);
         Query<E> query = this;
         for (Entry<String, Pair<FilterPredicate, String>> ft : tmp.entrySet()) {
-            Optional<QueryUtils.TraversalPath> tpath = QueryUtils.getTraversalPath(ft.getKey());
-            if (tpath.isPresent()) {
-                logger.debug("Adding traversal filter: {}", tpath.get());
-                query = query.filterTraversal(tpath.get(), ft.getValue().getA(), ft.getValue().getB());
-            } else {
-                logger.debug("Adding property filter: {}", ft.getKey());
-                query = query.filter(ft.getKey(), ft.getValue().getA(), ft.getValue().getB());
-            }
+            logger.debug("Adding property filter: {}", ft.getKey());
+            query = query.filter(ft.getKey(), ft.getValue().getA(), ft.getValue().getB());
         }
         return query;
     }
@@ -557,7 +474,6 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
 
     private <EE> GremlinPipeline<EE, Vertex> setOrder(
             GremlinPipeline<EE, Vertex> pipe) {
-        pipe = setTraversalOrdering(pipe);
         if (sort.isEmpty()) {
             if (defaultSort.isPresent()) {
                 return pipe
@@ -571,14 +487,6 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
         return pipe.order(getOrderFunction(sort));
     }
 
-    private <EE> GremlinPipeline<EE, Vertex> setTraversalOrdering(
-            GremlinPipeline<EE, Vertex> pipe) {
-        for (Entry<QueryUtils.TraversalPath, Sort> entry : traversalSort.entrySet()) {
-            pipe = pipe.order(getTraversalOrderFunction(entry.getKey(), entry.getValue()));
-        }
-        return pipe;
-    }
-
     private <EE> GremlinPipeline<EE, Vertex> setFilters(
             GremlinPipeline<EE, Vertex> pipe) {
         if (filters.isEmpty())
@@ -586,26 +494,11 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
         return pipe.filter(getFilterFunction());
     }
 
-    private <EE> GremlinPipeline<EE, Vertex> setTraversalFilters(
-            GremlinPipeline<EE, Vertex> pipe) {
-        if (traversalFilters.isEmpty())
-            return pipe;
-        return pipe.filter(getTraversalFilterFunction());
-    }
-
-    private <EE> GremlinPipeline<EE, Vertex> setDepthFilters(
-            GremlinPipeline<EE, Vertex> pipe) {
-        if (depthFilters.isEmpty())
-            return pipe;
-        return pipe.filter(getDepthFilterFunction());
-    }
-
     /**
      * Get a PipeFunction which sorted vertices by the ordered list
      * of sort parameters.
      */
-    private PipeFunction<Pair<Vertex, Vertex>, Integer> getOrderFunction(
-            final SortedMap<String, Sort> sort) {
+    private PipeFunction<Pair<Vertex, Vertex>, Integer> getOrderFunction(final SortedMap<String, Sort> sort) {
         final Ordering<Comparable<?>> order = Ordering.natural().nullsLast();
         return new PipeFunction<Pair<Vertex, Vertex>, Integer>() {
             public Integer compute(Pair<Vertex, Vertex> pair) {
@@ -618,41 +511,6 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
                             (String) b.getProperty(entry.getKey()), order);
                 }
                 return chain.result();
-            }
-        };
-    }
-
-    /**
-     * Create a filter that limits the selected nodes to with a particular depth
-     * of a relationship chain. For example, if a set of nodes form a
-     * hierarchical relationship such as:
-     * <p>
-     * child -[childOf]-&gt; parent -[childOf]-&gt; grandparent
-     * <p>
-     * Then a depthFilter of childOf -&gt; 0 would filter out all except the
-     * grandparent node.
-     * <p>
-     * TODO: Figure out how to do this will Gremlin's loop() construct.
-     */
-    private PipeFunction<Vertex, Boolean> getDepthFilterFunction() {
-        return new PipeFunction<Vertex, Boolean>() {
-            public Boolean compute(Vertex vertex) {
-                for (Entry<Pair<String, Direction>, Integer> entry : depthFilters.entrySet()) {
-                    int depthCount = 0;
-                    Vertex tmp = vertex;
-                    String label = entry.getKey().getA();
-                    Direction direction = entry.getKey().getB();
-                    while (tmp.getEdges(direction, label)
-                            .iterator().hasNext()) {
-                        tmp = tmp.getVertices(direction, label)
-                                .iterator().next();
-                        depthCount++;
-                        if (depthCount > entry.getValue()) {
-                            return false;
-                        }
-                    }
-                }
-                return true;
             }
         };
     }
@@ -675,101 +533,6 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
             }
         };
     }
-
-    private PipeFunction<Vertex, Boolean> getTraversalFilterFunction() {
-        // FIXME: Make this less horribly inefficient!
-        return new PipeFunction<Vertex, Boolean>() {
-            public Boolean compute(Vertex vertex) {
-                for (GremlinPipeline<Vertex, Vertex> pipeline : traversalFilters) {
-                    pipeline.reset();
-                    if (!pipeline.start(vertex).hasNext()) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-        };
-    }
-
-    private PipeFunction<Pair<Vertex, Vertex>, Integer> getTraversalOrderFunction(
-            QueryUtils.TraversalPath tp, final Sort sort) {
-        // FIXME: Make this less horribly inefficient!
-        final GremlinPipeline<Vertex, String> pipe = getOrderTraversalPipeline(tp);
-        final Map<Vertex, String> cache = Maps.newHashMap();
-        final Ordering<Comparable<?>> order = Ordering.natural().nullsLast();
-        return new PipeFunction<Pair<Vertex, Vertex>, Integer>() {
-            public Integer compute(Pair<Vertex, Vertex> pair) {
-                String a = cache.get(pair.getA());
-                String b = cache.get(pair.getB());
-                if (!cache.containsKey(pair.getA())) {
-                    pipe.reset();
-                    if (pipe.start(pair.getA()).hasNext()) {
-                        a = pipe.next();
-                        cache.put(pair.getA(), a);
-                    }
-                }
-                if (!cache.containsKey(pair.getB())) {
-                    pipe.reset();
-                    if (pipe.start(pair.getB()).hasNext()) {
-                        b = pipe.next();
-                        cache.put(pair.getB(), b);
-                    }
-                }
-                return sort == Sort.ASC ? order.compare(a, b) : order.compare(b, a);
-            }
-        };
-    }
-
-    private GremlinPipeline<Vertex, String> getOrderTraversalPipeline(
-            final QueryUtils.TraversalPath traversalPath) {
-        GremlinPipeline<Vertex, Vertex> p = addTraversals(traversalPath.getTraversals(), false,
-                new GremlinPipeline<Vertex, Vertex>());
-        return p.transform(new PipeFunction<Vertex, String>() {
-            public String compute(Vertex vertex) {
-                return vertex.getProperty(traversalPath.getProperty());
-            }
-        });
-    }
-
-
-    private GremlinPipeline<Vertex, Vertex> getFilterTraversalPipeline(
-            final QueryUtils.TraversalPath traversalPath,
-            final Pair<FilterPredicate, String> filter) {
-        GremlinPipeline<Vertex, Vertex> p = addTraversals(traversalPath.getTraversals(), false,
-                new GremlinPipeline<Vertex, Vertex>());
-        return p.filter(new PipeFunction<Vertex, Boolean>() {
-            public Boolean compute(Vertex vertex) {
-                String p = vertex.getProperty(traversalPath.getProperty());
-                return p != null && matches(p, filter.getB(), filter.getA());
-            }
-        });
-    }
-
-    /**
-     * Add traversals to a pipeline given a set of String/Direction pairs.
-     */
-    private static <S> GremlinPipeline<S, Vertex> addTraversals(List<Pair<String, Direction>> paths,
-            Boolean reverse, GremlinPipeline<S, Vertex> pipe) {
-        List<Pair<String, Direction>> orderedPaths = reverse ? Lists.reverse(paths) : paths;
-        for (Pair<String, Direction> tp : orderedPaths) {
-            Direction direction = reverse ? tp.getB().opposite() : tp.getB();
-            String relation = tp.getA();
-            switch (direction) {
-                case IN:
-                    logger.debug("Adding {} relation: {}", relation, direction);
-                    pipe = pipe.in(relation);
-                    break;
-                case OUT:
-                    logger.debug("Adding {} relation: {}", relation, direction);
-                    pipe = pipe.out(relation);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unexpected direction in traversal pipe function: " + tp.getB());
-            }
-        }
-        return pipe;
-    }
-
 
     // FIXME: This has several limitations so far.
     // - only handles properties cast as strings
@@ -813,10 +576,8 @@ public final class Query<E extends Accessible> implements Scoped<Query> {
                 offset,
                 limit,
                 sort,
-                traversalSort,
                 defaultSort,
                 filters,
-                depthFilters, traversalFilters,
                 stream);
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/views/QueryUtils.java
+++ b/ehri-core/src/main/java/eu/ehri/project/views/QueryUtils.java
@@ -19,14 +19,10 @@
 
 package eu.ehri.project.views;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.pipes.util.structures.Pair;
-import org.neo4j.helpers.collection.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,18 +46,17 @@ public class QueryUtils {
      * @param filterList A list of filter spec strings
      * @return A map of filter specs
      */
-    static SortedMap<String, Pair<Query.FilterPredicate, String>> parseFilters(
-            Collection<String> filterList) {
-        ImmutableSortedMap.Builder<String, Pair<Query.FilterPredicate, String>> builder = new ImmutableSortedMap.Builder<>(
-                Ordering.natural());
+    static SortedMap<String, Pair<Query.FilterPredicate, String>> parseFilters(Collection<String> filterList) {
+        ImmutableSortedMap.Builder<String, Pair<Query.FilterPredicate, String>> builder =
+                new ImmutableSortedMap.Builder<>(Ordering.natural());
         Splitter psplit = Splitter.on("__");
         Splitter vsplit = Splitter.on(":");
         for (String filter : filterList) {
-            List<String> kv = Iterables.toList(vsplit.split(filter));
+            List<String> kv = vsplit.splitToList(filter);
             if (kv.size() == 2) {
                 String ppred = kv.get(0);
                 String value = kv.get(1);
-                List<String> pp = Iterables.toList(psplit.split(ppred));
+                List<String> pp = psplit.splitToList(ppred);
                 if (pp.size() == 1) {
                     builder.put(pp.get(0), new Pair<>(
                             Query.FilterPredicate.EQUALS, value));
@@ -81,11 +76,11 @@ public class QueryUtils {
      * @return A map of order specs
      */
     static SortedMap<String, Query.Sort> parseOrderSpecs(Collection<String> orderSpecs) {
-        ImmutableSortedMap.Builder<String, Query.Sort> builder = new ImmutableSortedMap.Builder<>(
-                Ordering.natural());
+        ImmutableSortedMap.Builder<String, Query.Sort> builder =
+                new ImmutableSortedMap.Builder<>(Ordering.natural());
         Splitter psplit = Splitter.on("__");
         for (String spec : orderSpecs) {
-            List<String> od = Iterables.toList(psplit.split(spec));
+            List<String> od = psplit.splitToList(spec);
             if (od.size() == 1) {
                 builder.put(od.get(0), Query.Sort.ASC);
             } else if (od.size() > 1) {
@@ -93,80 +88,5 @@ public class QueryUtils {
             }
         }
         return builder.build();
-    }
-
-    /**
-     * Class that represents a traversal path to a particular
-     * property of some relations.
-     */
-    public static class TraversalPath {
-        private final String property;
-        private final List<Pair<String,Direction>> traversals;
-
-        public TraversalPath(String property, List<Pair<String,Direction>> traversals) {
-            this.property = property;
-            this.traversals = traversals;
-        }
-
-        public String getProperty() {
-            return property;
-        }
-
-        public List<Pair<String, Direction>> getTraversals() {
-            return traversals;
-        }
-
-        @Override public String toString() {
-            // TODO: Fix this...
-            return traversals + " : " + property;
-        }
-    }
-
-    /**
-     * Attempt to parse a traversal pattern from a input string. The
-     * string should look like this:
-     *
-     *  -&gt;relation1-&gt;relation2.propertyName
-     *
-     * @param input A traversal path spec
-     * @return A traversal path
-     */
-    public static Optional<TraversalPath> getTraversalPath(String input) {
-
-        String[] splitProp = input.split("\\.");
-        if (splitProp.length != 2) {
-            logger.warn("Ignoring invalid traversal path without property delimiter: {}", input);
-            return Optional.absent();
-        }
-        String pathSpec = splitProp[0];
-        String property = splitProp[1];
-
-        // Arrrgh, lookarounds and splitting on zero-width matches, inspired
-        // by http://stackoverflow.com/questions/275768/is-there-a-way-to-split-strings-with-string-split-and-include-the-delimiters
-        String[] parse = pathSpec.split("(?<=\\w+)(?=->)|(?<=->)(?=\\w+)|(?<=\\w+)(?=<-)|(?<=<-)");
-
-        // if it has an odd number of values it must end in
-        // a direction delimiter, so it's invalid.
-        // Only if there's an odd number of elements are we okay.
-        if (parse.length % 2 != 0) {
-            logger.warn("Ignoring invalid traversal path pattern: {}", input);
-            return Optional.absent();
-        }
-
-        List<Pair<String,Direction>> traversals = Lists.newArrayListWithCapacity(parse.length / 2);
-        for (int i = 0; i < parse.length; i += 2) {
-            String dir = parse[i];
-            String rel = parse[i+1];
-            if (rel.equals("->") || rel.equals("<-") ) {
-                logger.warn("Invalid traversal path starts with delimiter: {}", input);
-                return Optional.absent();
-            }
-            if (dir.equals("->")) {
-                traversals.add(new Pair<>(rel, Direction.OUT));
-            } else {
-                traversals.add(new Pair<>(rel, Direction.IN));
-            }
-        }
-        return Optional.of(new TraversalPath(property, traversals));
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/models/AnnotationTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/AnnotationTest.java
@@ -26,6 +26,7 @@ import eu.ehri.project.test.ModelTestBase;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class AnnotationTest extends ModelTestBase {
@@ -58,9 +59,16 @@ public class AnnotationTest extends ModelTestBase {
         Annotatable ann1 = manager.getEntity("ann1",
                 Annotatable.class);
         Annotation ann2 = manager.getEntity("ann2", Annotation.class);
-
         assertEquals(ann2.getTargets().iterator().next(), ann1);
+        assertEquals(TEST_ANNOTATION_ANNOTATION_BODY, ann2.getBody());
         assertEquals(ann1.getAnnotations().iterator().next().getBody(),
                 ann2.getBody());
+    }
+
+    @Test
+    public void testGetAnnotator() throws Exception {
+        UserProfile mike = manager.getEntity("mike", UserProfile.class);
+        Annotation ann1 = manager.getEntity("ann1", Annotation.class);
+        assertEquals(mike, ann1.getAnnotator());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/views/AnnotationViewsTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/views/AnnotationViewsTest.java
@@ -59,7 +59,7 @@ public class AnnotationViewsTest extends AbstractFixtureTest {
         Bundle ann = new Bundle(EntityClass.ANNOTATION)
                 .withDataValue(Ontology.ANNOTATION_NOTES_BODY, "test");
         Annotation annotation = av
-                .createFor("c4", "cd4", ann, user, Lists.<Accessor>newArrayList());
+                .create("c4", "cd4", ann, user, Lists.<Accessor>newArrayList());
         assertEquals("test", annotation.getBody());
     }
 
@@ -69,7 +69,7 @@ public class AnnotationViewsTest extends AbstractFixtureTest {
         Bundle ann = new Bundle(EntityClass.ANNOTATION)
                 .withDataValue(Ontology.ANNOTATION_NOTES_BODY, "test");
         Annotation annotation = av
-                .createFor("c1", "cd1", ann, user, Lists.<Accessor>newArrayList());
+                .create("c1", "cd1", ann, user, Lists.<Accessor>newArrayList());
         assertEquals("test", annotation.getBody());
     }
 
@@ -79,7 +79,7 @@ public class AnnotationViewsTest extends AbstractFixtureTest {
         Bundle ann = new Bundle(EntityClass.ANNOTATION)
                 .withDataValue(Ontology.ANNOTATION_NOTES_BODY, "test");
         Annotation annotation = av
-                .createFor("c4", "cd1", ann, user, Lists.<Accessor>newArrayList());
+                .create("c4", "cd1", ann, user, Lists.<Accessor>newArrayList());
         assertEquals("test", annotation.getBody());
     }
 
@@ -89,7 +89,7 @@ public class AnnotationViewsTest extends AbstractFixtureTest {
         Bundle ann = new Bundle(EntityClass.ANNOTATION)
                 .withDataValue(Ontology.ANNOTATION_NOTES_BODY, "test");
         Annotation annotation = av
-                .createFor("c4", "cd4", ann, user, Lists.<Accessor>newArrayList());
+                .create("c4", "cd4", ann, user, Lists.<Accessor>newArrayList());
         assertEquals("test", annotation.getBody());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/views/LinkViewsTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/views/LinkViewsTest.java
@@ -29,6 +29,7 @@ import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.Link;
 import eu.ehri.project.models.AccessPoint;
+import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.Linkable;
 import eu.ehri.project.persistence.ActionManager;
@@ -71,8 +72,8 @@ public class LinkViewsTest extends AbstractFixtureTest {
         String linkDesc = "Test Link";
         String linkType = "subjectAccess";
         Bundle linkBundle = getLinkBundle(linkDesc, linkType);
-        Link link = linkViews.createLink("c1", "a1", Lists.newArrayList("ur1"),
-                linkBundle, validUser);
+        Link link = linkViews.create("c1", "a1", Lists.newArrayList("ur1"),
+                linkBundle, validUser, Lists.<Accessor>newArrayList());
         assertEquals(linkDesc, link.getDescription());
         assertEquals(2L, Iterables.size(link.getLinkTargets()));
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
@@ -86,8 +87,9 @@ public class LinkViewsTest extends AbstractFixtureTest {
 
     @Test(expected = PermissionDenied.class)
     public void testCreateLinkWithoutPermission() throws Exception {
-        linkViews.createLink("c1", "a1", Lists.newArrayList("ur1"),
-                getLinkBundle("won't work!", "too bad!"), invalidUser);
+        linkViews.create("c1", "a1", Lists.newArrayList("ur1"),
+                getLinkBundle("won't work!", "too bad!"), invalidUser,
+                Lists.<Accessor>newArrayList());
     }
 
     @Test
@@ -99,7 +101,7 @@ public class LinkViewsTest extends AbstractFixtureTest {
         String linkType = "subjectAccess";
         Bundle linkBundle = getLinkBundle(linkDesc, linkType);
         Link link = linkViews.createAccessPointLink("c1", "a1", "cd1", linkDesc, linkType,
-                linkBundle, validUser);
+                linkBundle, validUser, Lists.<Accessor>newArrayList(validUser, invalidUser));
         assertEquals(linkDesc, link.getDescription());
         assertEquals(2L, Iterables.size(link.getLinkTargets()));
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
@@ -110,6 +112,7 @@ public class LinkViewsTest extends AbstractFixtureTest {
         assertEquals(rel.getRelationshipType(), linkType);
         Description d = rel.getDescription();
         assertEquals(desc, d);
+        assertTrue(link.hasAccessRestriction());
         assertTrue(Lists.newArrayList(actionManager
                 .getLatestGlobalEvent().getSubjects()).contains(link));
     }

--- a/ehri-core/src/test/java/eu/ehri/project/views/QueryTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/views/QueryTest.java
@@ -19,16 +19,12 @@
 
 package eu.ehri.project.views;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.acl.AclManager;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
-import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.test.AbstractFixtureTest;
 import eu.ehri.project.views.Query.Page;
@@ -156,27 +152,6 @@ public class QueryTest extends AbstractFixtureTest {
     }
 
     @Test
-    public void testListWithDepthFilter() throws Exception {
-        Query<DocumentaryUnit> query = new Query<>(graph,
-                DocumentaryUnit.class);
-
-        // Query for only top-level documentary units.
-        // The result should be c1 and c4
-        List<DocumentaryUnit> list = toList(query.depthFilter(
-                Ontology.DOC_IS_CHILD_OF, Direction.OUT, 0).page(
-                EntityClass.DOCUMENTARY_UNIT, validUser));
-        assertFalse(list.isEmpty());
-        assertEquals(3, list.size());
-
-        // The same query with a depth filter of 1 should get 3 items
-        list = toList(query.depthFilter(Ontology.DOC_IS_CHILD_OF,
-                Direction.OUT, 1).page(EntityClass.DOCUMENTARY_UNIT, validUser));
-        assertFalse(list.isEmpty());
-        assertEquals(4, list.size());
-
-    }
-
-    @Test
     public void testListWithPredicateFilter() throws Exception {
         Query<DocumentaryUnit> query = new Query<>(graph,
                 DocumentaryUnit.class);
@@ -248,46 +223,6 @@ public class QueryTest extends AbstractFixtureTest {
                 .page(EntityClass.DOCUMENTARY_UNIT, validUser)).size());
 
     }
-
-    @Test
-    public void testListWithTraversalFilter() {
-        Query<DocumentaryUnit> query1 = new Query<>(graph,
-                DocumentaryUnit.class);
-        List<String> filters1 = ImmutableList.of(
-          "<-describes.identifier:c1-desc"
-        );
-        Iterable<DocumentaryUnit> list1 = query1
-                .filter(filters1).page(validUser);
-        assertEquals(1, Iterables.size(list1));
-
-        Query<Repository> query2 = new Query<>(graph,
-                Repository.class);
-        List<String> filters2 = ImmutableList.of(
-                "<-describes->hasAddress.municipality:Brussels"
-        );
-        Iterable<Repository> list2 = query2
-                .filter(filters2).page(validUser);
-        assertEquals(1, Iterables.size(list2));
-
-    }
-
-    @Test
-    public void testListWithTraversalOrder() {
-        Query<Repository> query1 = new Query<>(graph, Repository.class);
-        Iterable<Repository> out1 = query1
-                .orderBy(ImmutableList.of("<-describes.identifier"))
-                .page(validUser);
-        List<Repository> list1 = Lists.newLinkedList(out1);
-
-        Query<Repository> query2 = new Query<>(graph, Repository.class);
-        Iterable<Repository> out2 = query2
-                .orderBy(ImmutableList.of("<-describes.identifier__DESC"))
-                .page(validUser);
-        List<Repository> list2 = Lists.newLinkedList(out2);
-
-        assertEquals(list1, Lists.reverse(list2));
-    }
-
 
     @Test
     public void testListWithSort() throws Exception {

--- a/ehri-core/src/test/java/eu/ehri/project/views/QueryUtilsTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/views/QueryUtilsTest.java
@@ -19,26 +19,34 @@
 
 package eu.ehri.project.views;
 
-import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.tinkerpop.pipes.util.structures.Pair;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
+import java.util.SortedMap;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class QueryUtilsTest {
+    @Test
+    public void testParseFilters() throws Exception {
+        SortedMap<String, Pair<Query.FilterPredicate, String>> filters
+                = QueryUtils.parseFilters(Lists.newArrayList("identifier__GT:c1"));
+        assertTrue(filters.containsKey("identifier"));
+        Pair<Query.FilterPredicate, String> pair = filters.get("identifier");
+        assertEquals(Query.FilterPredicate.GT, pair.getA());
+        assertEquals("c1", pair.getB());
+    }
 
     @Test
-    public void testGetTraversalPath() throws Exception {
-        String notAPath = "imNotAPath";
-        Optional<QueryUtils.TraversalPath> traversalPath = QueryUtils.getTraversalPath(notAPath);
-        assertFalse(traversalPath.isPresent());
-
-        String validPath = "->foo<-bar.baz";
-        traversalPath = QueryUtils.getTraversalPath(validPath);
-        assertTrue(traversalPath.isPresent());
-
-        String badPath = "foo->bar.baz";
-        traversalPath = QueryUtils.getTraversalPath(badPath);
-        assertFalse(traversalPath.isPresent());
+    public void testParseOrderSpecs() throws Exception {
+        SortedMap<String, Query.Sort> orders = QueryUtils
+                .parseOrderSpecs(Lists.newArrayList("identifier__DESC", "name"));
+        assertTrue(orders.containsKey("identifier"));
+        Query.Sort sort = orders.get("identifier");
+        assertEquals(Query.Sort.DESC, sort);
+        Query.Sort nameSort = orders.get("name");
+        assertEquals(Query.Sort.ASC, nameSort);
     }
 }

--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -447,6 +447,7 @@
     body: Test Annotation
     isPromotable: !!bool true
   relationships:
+    hasAnnotator: mike
     hasAnnotationTarget: c1
     
 - id: ann2

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -121,11 +121,4 @@
             <version>1.10</version>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
 </project>

--- a/ehri-ws-sparql/pom.xml
+++ b/ehri-ws-sparql/pom.xml
@@ -176,22 +176,6 @@
 
     <repositories>
         <repository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>neo4j-snapshot-repository</id>
-            <name>Neo4j Maven 2 snapshot repository</name>
-            <url>http://m2.neo4j.org/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-        <repository>
             <id>openrdf</id>
             <name>openrdf</name>
             <url>http://repo.aduna-software.org/maven2/releases/</url>

--- a/ehri-ws/pom.xml
+++ b/ehri-ws/pom.xml
@@ -199,32 +199,10 @@
             <version>0.12.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <!-- Needed to put this in here explicitly for the neo4j snapshots -->
-    <repositories>
-        <repository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>neo4j-snapshot-repository</id>
-            <name>Neo4j Maven 2 snapshot repository</name>
-            <url>http://m2.neo4j.org/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
-
     <pluginRepositories>
         <pluginRepository>
             <id>opencast-public</id>
             <url>http://repository.opencastproject.org/nexus/content/repositories/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
 </project>

--- a/ehri-ws/src/main/java/eu/ehri/extension/AnnotationResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AnnotationResource.java
@@ -26,17 +26,30 @@ import eu.ehri.extension.base.ListResource;
 import eu.ehri.extension.base.UpdateResource;
 import eu.ehri.project.core.Tx;
 import eu.ehri.project.definitions.Entities;
-import eu.ehri.project.exceptions.*;
+import eu.ehri.project.exceptions.AccessDenied;
+import eu.ehri.project.exceptions.DeserializationError;
+import eu.ehri.project.exceptions.ItemNotFound;
+import eu.ehri.project.exceptions.PermissionDenied;
+import eu.ehri.project.exceptions.SerializationError;
+import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.models.Annotation;
+import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.Accessible;
-import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.AnnotationViews;
 import eu.ehri.project.views.Query;
 import eu.ehri.project.views.impl.CrudViews;
 import org.neo4j.graphdb.GraphDatabaseService;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -90,12 +103,12 @@ public class AnnotationResource
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
     @Path("{id:.+}")
     public Response createAnnotationFor(@PathParam("id") String id,
-                                        Bundle bundle, @QueryParam(ACCESSOR_PARAM) List<String> accessors)
+            Bundle bundle, @QueryParam(ACCESSOR_PARAM) List<String> accessors)
             throws PermissionDenied, AccessDenied, ValidationError, DeserializationError,
             ItemNotFound, SerializationError {
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Annotation ann = annotationViews.createFor(id, id,
+            UserProfile user = getCurrentUser();
+            Annotation ann = annotationViews.create(id, id,
                     bundle, user, getAccessors(accessors, user));
             Response response = creationResponse(ann);
             tx.success();
@@ -128,8 +141,8 @@ public class AnnotationResource
             throws PermissionDenied, AccessDenied, ValidationError, DeserializationError,
             ItemNotFound, SerializationError {
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Annotation ann = annotationViews.createFor(id, did,
+            UserProfile user = getCurrentUser();
+            Annotation ann = annotationViews.create(id, did,
                     bundle, user, getAccessors(accessors, user));
             Response response = creationResponse(ann);
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
@@ -32,6 +32,7 @@ import eu.ehri.project.exceptions.*;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;
 import eu.ehri.project.models.AccessPoint;
+import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.*;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.views.DescriptionViews;
@@ -114,15 +115,12 @@ public class LinkResource extends AbstractAccessibleResource<Link>
             @PathParam("sourceId") String sourceId, Bundle bundle,
             @QueryParam(BODY_PARAM) List<String> bodies,
             @QueryParam(ACCESSOR_PARAM) List<String> accessors)
-            throws PermissionDenied, ValidationError, DeserializationError,
-            ItemNotFound, SerializationError {
-
+                throws PermissionDenied, ValidationError,
+                    DeserializationError, ItemNotFound, SerializationError {
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
-            Accessor user = getRequesterUserProfile();
-            Link link = linkViews.createLink(targetId,
-                    sourceId, bodies, bundle, user);
-            aclManager.setAccessors(link,
-                    getAccessors(accessors, user));
+            UserProfile user = getCurrentUser();
+            Link link = linkViews.create(targetId,
+                    sourceId, bodies, bundle, user, getAccessors(accessors, user));
             Response response = creationResponse(link);
             tx.success();
             return response;


### PR DESCRIPTION
 - rationalise models, removing `Annotator` base class
 - remove 'advanced' `Query` functionality, which was unused, fragile, and confusing