### PR TITLE
Start of better support for generic batch operations (ingest, update, delete)

### DIFF
--- a/ehri-cli/src/main/java/eu/ehri/project/commands/GetEntity.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/GetEntity.java
@@ -19,10 +19,10 @@
 
 package eu.ehri.project.commands;
 
+import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
-import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.persistence.Serializer;
 import org.apache.commons.cli.CommandLine;
 
@@ -38,7 +38,7 @@ public class GetEntity extends BaseCommand {
 
     @Override
     public String getUsage() {
-        return String.format("%s [OPTIONS] <type> <identifier>", NAME);
+        return String.format("%s [OPTIONS] <identifier>", NAME);
     }
 
     @Override
@@ -47,19 +47,15 @@ public class GetEntity extends BaseCommand {
     }
 
     @Override
-    public int execWithOptions(FramedGraph<?> graph,
-            CommandLine cmdLine) throws Exception {
-
+    public int execWithOptions(FramedGraph<?> graph, CommandLine cmdLine) throws Exception {
         GraphManager manager = GraphManagerFactory.getInstance(graph);
         Serializer serializer = new Serializer(graph);
 
-        if (cmdLine.getArgList().size() < 2)
+        if (cmdLine.getArgList().size() < 1)
             throw new RuntimeException(getUsage());
 
-        EntityClass type = EntityClass.withName(cmdLine.getArgs()[0]);
-        String id = cmdLine.getArgs()[1];
-
-        System.out.println(serializer.vertexToJson(manager.getVertex(id, type)));
+        Vertex vertex = manager.getVertex(cmdLine.getArgs()[0]);
+        System.out.println(serializer.vertexToJson(vertex));
         return 0;
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/core/GraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/GraphManager.java
@@ -144,7 +144,7 @@ public interface GraphManager {
 
     /**
      * Get a CloseableIterable of vertices with the given type, and the given
-     * key/value indexed property.
+     * key/value property.
      *
      * @param type The entity type
      * @return An iterable of vertices with the given key/value properties
@@ -176,21 +176,6 @@ public interface GraphManager {
             Map<String, ?> data) throws IntegrityError;
 
     /**
-     * Create a vertex with the given id, type, and data, specifying which
-     * property keys should be indexed.
-     *
-     * @param id   The vertex's string ID
-     * @param type The entity type
-     * @param data The data map
-     * @param keys A set of keys to be indexed
-     * @return The new vertex
-     * @throws IntegrityError
-     */
-    Vertex createVertex(String id, EntityClass type,
-            Map<String, ?> data, Iterable<String> keys)
-            throws IntegrityError;
-
-    /**
      * Create a vertex with the given id, type, and data.
      *
      * @param id   The vertex's string ID
@@ -201,20 +186,6 @@ public interface GraphManager {
      */
     Vertex updateVertex(String id, EntityClass type,
             Map<String, ?> data) throws ItemNotFound;
-
-    /**
-     * Create a vertex with the given id, type, and data, specifying which
-     * property keys should be indexed.
-     *
-     * @param id   The vertex's string ID
-     * @param type The entity type
-     * @param data The data map
-     * @param keys A set of keys to be indexed
-     * @return The updated vertex
-     * @throws ItemNotFound
-     */
-    Vertex updateVertex(String id, EntityClass type,
-            Map<String, ?> data, Iterable<String> keys) throws ItemNotFound;
 
     /**
      * Set a property on a vertex.
@@ -249,11 +220,6 @@ public interface GraphManager {
      * @param vertex The vertex to delete
      */
     void deleteVertex(Vertex vertex);
-
-    /**
-     * Rebuild the internal graph index.
-     */
-    void rebuildIndex();
 
     /*
      * Run graph-specific initialization code.

--- a/ehri-core/src/main/java/eu/ehri/project/core/GraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/GraphManager.java
@@ -97,14 +97,6 @@ public interface GraphManager {
     Vertex getVertex(String id) throws ItemNotFound;
 
     /**
-     * Get a node with the given ID and type.
-     *
-     * @param id The vertex's string ID
-     * @return The vertex
-     */
-    Vertex getVertex(String id, EntityClass type) throws ItemNotFound;
-
-    /**
      * Get a node with the given ID, and frame it with the given interface
      * class.
      *

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
@@ -35,7 +35,6 @@ import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Entity;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -172,12 +171,6 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
     @Override
     public Vertex createVertex(String id, EntityClass type,
             Map<String, ?> data) throws IntegrityError {
-        return createVertex(id, type, data, data.keySet());
-    }
-
-    @Override
-    public Vertex createVertex(String id, EntityClass type,
-            Map<String, ?> data, Iterable<String> keys) throws IntegrityError {
         Preconditions
                 .checkNotNull(id, "null vertex ID given for item creation");
         Map<String, ?> indexData = getVertexData(id, type, data);
@@ -194,18 +187,11 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
     @Override
     public Vertex updateVertex(String id, EntityClass type,
             Map<String, ?> data) throws ItemNotFound {
-        return updateVertex(id, type, data, data.keySet());
-    }
-
-    @Override
-    public Vertex updateVertex(String id, EntityClass type,
-            Map<String, ?> data, Iterable<String> keys) throws ItemNotFound {
         Preconditions.checkNotNull(id, "null vertex ID given for item update");
         Map<String, ?> indexData = getVertexData(id, type, data);
-        Collection<String> indexKeys = getVertexKeys(keys);
         try {
             Vertex node = getVertex(id);
-            replaceProperties(node, indexData, indexKeys);
+            replaceProperties(node, indexData);
             return node;
         } catch (NoSuchElementException e) {
             throw new ItemNotFound(id);
@@ -245,15 +231,10 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
     }
 
     @Override
-    public void rebuildIndex() {
-    }
-
-    @Override
     public void initialize() {
     }
 
-    private <E extends Element> void replaceProperties(E item,
-            Map<String, ?> data, Collection<String> keys) {
+    private <E extends Element> void replaceProperties(E item, Map<String, ?> data) {
         // remove 'old' properties
         for (String key : item.getPropertyKeys()) {
             if (!key.startsWith(METADATA_PREFIX)) {
@@ -262,11 +243,10 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
         }
 
         // add all 'new' properties to the relationship and index
-        addProperties(item, data, keys);
+        addProperties(item, data);
     }
 
-    private <E extends Element> void addProperties(E item,
-            Map<String, ?> data, Collection<String> keys) {
+    private <E extends Element> void addProperties(E item, Map<String, ?> data) {
         Preconditions.checkNotNull(data, "Data map cannot be null");
         for (Map.Entry<String, ?> entry : data.entrySet()) {
             if (entry.getValue() == null)
@@ -287,12 +267,5 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
         vdata.put(EntityType.ID_KEY, id);
         vdata.put(EntityType.TYPE_KEY, type.getName());
         return vdata;
-    }
-
-    private Collection<String> getVertexKeys(Iterable<String> keys) {
-        List<String> vkeys = Lists.newArrayList(keys);
-        vkeys.add(EntityType.ID_KEY);
-        vkeys.add(EntityType.TYPE_KEY);
-        return vkeys;
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
@@ -107,7 +107,7 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
     @Override
     public <E> E getEntity(String id, EntityClass type, Class<E> cls)
             throws ItemNotFound {
-        return graph.frame(getVertex(id, type), cls);
+        return graph.frame(getVertex(id), cls);
     }
 
     @Override
@@ -125,17 +125,6 @@ public class BlueprintsGraphManager<T extends Graph> implements GraphManager {
         } catch (NoSuchElementException e) {
             throw new ItemNotFound(id);
         }
-    }
-
-    @Override
-    public Vertex getVertex(String id, EntityClass type) throws ItemNotFound {
-        Preconditions
-                .checkNotNull(id, "attempt to fetch vertex with a null id");
-        for (Vertex v : graph.getVertices(EntityType.ID_KEY, id)) {
-            if (getEntityClass(v).equals(type))
-                return v;
-        }
-        throw new ItemNotFound(id);
     }
 
     @Override

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/Neo4jGraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/Neo4jGraphManager.java
@@ -86,14 +86,14 @@ public final class Neo4jGraphManager<T extends Neo4j2Graph> extends BlueprintsGr
 
     @Override
     public Vertex createVertex(String id, EntityClass type,
-            Map<String, ?> data, Iterable<String> keys) throws IntegrityError {
-        return setLabels(super.createVertex(id, type, data, keys));
+            Map<String, ?> data) throws IntegrityError {
+        return setLabels(super.createVertex(id, type, data));
     }
 
     @Override
     public Vertex updateVertex(String id, EntityClass type,
-            Map<String, ?> data, Iterable<String> keys) throws ItemNotFound {
-        return setLabels(super.updateVertex(id, type, data, keys));
+            Map<String, ?> data) throws ItemNotFound {
+        return setLabels(super.updateVertex(id, type, data));
     }
 
     @Override

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/ActionManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/ActionManager.java
@@ -486,7 +486,7 @@ public final class ActionManager {
         // *type* Stream.
         try {
             logger.trace("Creating global event root");
-            Vertex system = manager.getVertex(GLOBAL_EVENT_ROOT, EntityClass.SYSTEM);
+            Vertex system = manager.getVertex(GLOBAL_EVENT_ROOT);
             Bundle ge = Bundle.Builder.withClass(EntityClass.SYSTEM_EVENT)
                     .addDataValue(Ontology.EVENT_TYPE, type.toString())
                     .addDataValue(Ontology.EVENT_TIMESTAMP, timestamp)

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/BundleManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/BundleManager.java
@@ -180,7 +180,7 @@ public final class BundleManager {
     private Vertex createInner(Bundle bundle) {
         try {
             Vertex node = manager.createVertex(bundle.getId(), bundle.getType(),
-                    bundle.getData(), bundle.getPropertyKeys());
+                    bundle.getData());
             createDependents(node, bundle.getBundleJavaClass(), bundle.getRelations());
             return node;
         } catch (IntegrityError e) {
@@ -205,7 +205,7 @@ public final class BundleManager {
             if (!nodeBundle.equals(bundle)) {
                 logger.trace("Bundles differ\nnew:\n{}\nold:\n{}", bundle.toJson(), nodeBundle.toJson());
                 node = manager.updateVertex(bundle.getId(), bundle.getType(),
-                        bundle.getData(), bundle.getPropertyKeys());
+                        bundle.getData());
                 updateDependents(node, bundle.getBundleJavaClass(), bundle.getRelations());
                 return new Mutation<>(node, MutationState.UPDATED, nodeBundle);
             } else {

--- a/ehri-core/src/test/java/eu/ehri/project/core/GraphManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/core/GraphManagerTest.java
@@ -20,9 +20,7 @@
 package eu.ehri.project.core;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.tinkerpop.blueprints.CloseableIterable;
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
@@ -42,7 +40,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -257,39 +254,6 @@ public class GraphManagerTest {
                     .newHashMap(ImmutableMap.of(TEST_KEY, TEST_VALUE));
             Vertex vertex = manager.createVertex(TEST_ID1, TEST_TYPE, data);
             manager.setProperty(vertex, EntityType.ID_KEY, "foo");
-        }
-
-        @Ignore("Ignored because semantics of indexing changed so getting" +
-                " vertices by property value should fall back to non-indexed" +
-                " behaviour.")
-        @Test
-        public void testSelectiveIndexing() throws IntegrityError {
-            // We need to create one first, sorry
-            Map<String, ?> data = ImmutableMap.of(
-                    "name", "joe",
-                    "age", 32,
-                    "height", "5.11");
-            List<String> keys = Lists.newArrayList("name", "age");
-
-            Vertex joe = manager.createVertex(TEST_ID1, TEST_TYPE, data, keys);
-
-            // try and find joe via name and age...
-            CloseableIterable<Vertex> query1 = manager.getVertices("name",
-                    data.get("name"), TEST_TYPE);
-            assertTrue(query1.iterator().hasNext());
-            Vertex joe1 = query1.iterator().next();
-            assertEquals(joe, joe1);
-
-            CloseableIterable<Vertex> query2 = manager.getVertices("age",
-                    data.get("age"), TEST_TYPE);
-            assertTrue(query2.iterator().hasNext());
-            Vertex joe2 = query2.iterator().next();
-            assertEquals(joe, joe2);
-
-            // Query by height should fail...
-            CloseableIterable<Vertex> query3 = manager.getVertices("height",
-                    data.get("height"), TEST_TYPE);
-            assertFalse(query3.iterator().hasNext());
         }
     }
 }

--- a/ehri-core/src/test/resources/fixtures/bundle-list.json
+++ b/ehri-core/src/test/resources/fixtures/bundle-list.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "item1",
+    "type": "UnknownProperty",
+    "data": {
+      "key1": "test1",
+      "key2": "test2"
+    }
+  },
+  {
+    "id": "item2",
+    "type": "UnknownProperty",
+    "data": {
+      "key1": "test1",
+      "key2": "test2"
+    }
+  }
+]

--- a/ehri-core/src/test/resources/fixtures/bundle-patch-data.json
+++ b/ehri-core/src/test/resources/fixtures/bundle-patch-data.json
@@ -1,0 +1,47 @@
+{
+  "id": "1",
+  "type": "DocumentaryUnit",
+  "data": {
+    "identifier": "some-id"
+  },
+  "relationships": {
+    "describes": [
+      {
+        "id": "2",
+        "type": "DocumentaryUnitDescription",
+        "data": {
+        },
+        "relationships": {
+          "hasDate": [
+            {
+              "id": "3",
+              "type": "DatePeriod",
+              "data": {
+                "endDate": "1945-01-01T00:00:00Z"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "4",
+        "type": "DocumentaryUnitDescription",
+        "data": {
+          "name": "un description UPDATED"
+        },
+        "relationships": {
+          "hasDate": [
+            {
+              "id": "5",
+              "type": "DatePeriod",
+              "data": {
+                "endDate": "1945-01-01T00:00:00Z",
+                "randomArray": ["one", "two"]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/ehri-core/src/test/resources/fixtures/bundle-patch-init.json
+++ b/ehri-core/src/test/resources/fixtures/bundle-patch-init.json
@@ -1,0 +1,49 @@
+{
+  "id": "1",
+  "type": "DocumentaryUnit",
+  "data": {
+    "identifier": "some-id"
+  },
+  "relationships": {
+    "describes": [
+      {
+        "id": "2",
+        "type": "DocumentaryUnitDescription",
+        "data": {
+          "languageCode": "en",
+          "name": "a description"
+        },
+        "relationships": {
+          "hasDate": [
+            {
+              "id": "3",
+              "type": "DatePeriod",
+              "data": {
+                "startDate": "1940-01-01T00:00:00Z"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "4",
+        "type": "DocumentaryUnitDescription",
+        "data": {
+          "languageCode": "fr",
+          "name": "un description"
+        },
+        "relationships": {
+          "hasDate": [
+            {
+              "id": "5",
+              "type": "DatePeriod",
+              "data": {
+                "startDate": "1940-01-01T00:00:00Z"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/ehri-core/src/test/resources/fixtures/bundle-patch-result.json
+++ b/ehri-core/src/test/resources/fixtures/bundle-patch-result.json
@@ -1,0 +1,52 @@
+{
+  "id": "1",
+  "type": "DocumentaryUnit",
+  "data": {
+    "identifier": "some-id"
+  },
+  "relationships": {
+    "describes": [
+      {
+        "id": "2",
+        "type": "DocumentaryUnitDescription",
+        "data": {
+          "languageCode": "en",
+          "name": "a description"
+        },
+        "relationships": {
+          "hasDate": [
+            {
+              "id": "3",
+              "type": "DatePeriod",
+              "data": {
+                "startDate": "1940-01-01T00:00:00Z",
+                "endDate": "1945-01-01T00:00:00Z"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "4",
+        "type": "DocumentaryUnitDescription",
+        "data": {
+          "languageCode": "fr",
+          "name": "un description UPDATED"
+        },
+        "relationships": {
+          "hasDate": [
+            {
+              "id": "5",
+              "type": "DatePeriod",
+              "data": {
+                "startDate": "1940-01-01T00:00:00Z",
+                "endDate": "1945-01-01T00:00:00Z",
+                "randomArray": ["one", "two"]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/MapImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/MapImporter.java
@@ -229,9 +229,6 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         try {
             Bundle unit = new Bundle(EntityClass.MAINTENANCE_EVENT, event);
             //only if some source is given (especially with a creation) should a ME be created
-            for (String e : unit.getPropertyKeys()) {
-                logger.debug(e);
-            }
             if (unit.getDataValue("source") != null) {
                 Mutation<MaintenanceEvent> mutation = persister.createOrUpdate(unit, MaintenanceEvent.class);
                 return mutation.getNode();

--- a/ehri-io/src/main/java/eu/ehri/project/importers/json/BatchOperations.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/json/BatchOperations.java
@@ -1,0 +1,240 @@
+package eu.ehri.project.importers.json;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import com.google.common.base.Optional;
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.frames.FramedGraph;
+import eu.ehri.project.acl.SystemScope;
+import eu.ehri.project.core.GraphManager;
+import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.definitions.EventTypes;
+import eu.ehri.project.exceptions.DeserializationError;
+import eu.ehri.project.exceptions.ItemNotFound;
+import eu.ehri.project.exceptions.SerializationError;
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Actioner;
+import eu.ehri.project.models.base.Entity;
+import eu.ehri.project.models.base.PermissionScope;
+import eu.ehri.project.persistence.ActionManager;
+import eu.ehri.project.persistence.Bundle;
+import eu.ehri.project.persistence.BundleManager;
+import eu.ehri.project.persistence.Mutation;
+import eu.ehri.project.persistence.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.List;
+
+
+/**
+ * Batch importer for JSON data in Bundle format.
+ */
+public class BatchOperations {
+    private static final Logger logger = LoggerFactory.getLogger(BatchOperations.class);
+    private final FramedGraph<?> graph;
+    private final ActionManager actionManager;
+    private final BundleManager dao;
+    private final Serializer serializer;
+    private final GraphManager manager;
+    private final PermissionScope scope;
+    private final boolean version;
+    private final boolean tolerant;
+
+    public BatchOperations(FramedGraph<?> graph, PermissionScope scope, boolean version, boolean tolerant) {
+        this.graph = graph;
+        this.manager = GraphManagerFactory.getInstance(graph);
+        this.scope = scope;
+        this.actionManager = new ActionManager(graph, scope);
+        this.dao = new BundleManager(graph, scope.idPath());
+        this.serializer = new Serializer.Builder(graph).dependentOnly().build();
+        this.version = version;
+        this.tolerant = tolerant;
+    }
+
+    public BatchOperations(FramedGraph<?> graph) {
+        this(graph, SystemScope.getInstance(), true, false);
+    }
+
+    /**
+     * Toggle tolerant mode, which will prevent the entire batch
+     * failing if a single item fails to validate.
+     *
+     * @param tolerant true or false
+     * @return a new batch operation manager
+     */
+    public BatchOperations setTolerant(boolean tolerant) {
+        return new BatchOperations(graph, scope, version, tolerant);
+    }
+
+    /**
+     * Toggle versioning for item updates.
+     *
+     * @param versioning true or false
+     * @return a new batch operation manager
+     */
+    public BatchOperations setVersioning(boolean versioning) {
+        return new BatchOperations(graph, scope, versioning, tolerant);
+    }
+
+    /**
+     * Set the permission scope.
+     *
+     * @param scope a permission scope frame
+     * @return a new batch operation manager
+     */
+    public BatchOperations setScope(PermissionScope scope) {
+        return new BatchOperations(graph, scope, version, tolerant);
+    }
+
+    /**
+     * Create or update a batch of items.
+     *
+     * @param inputStream an input stream containing a JSON list of
+     *                    bundles corresponding to the items to update
+     *                    or create.
+     * @param actioner    the current user
+     * @param logMessage  a log message
+     * @return an import log
+     * @throws DeserializationError
+     * @throws ItemNotFound
+     * @throws ValidationError
+     */
+    public ImportLog batchImport(InputStream inputStream, Actioner actioner, Optional<String> logMessage)
+            throws DeserializationError, ItemNotFound, ValidationError {
+        ActionManager.EventContext ctx = actionManager.newEventContext(actioner,
+                EventTypes.modification, logMessage);
+        ImportLog log = new ImportLog(ctx);
+        try (CloseableIterable<Bundle> bundleIter = Bundle.bundleStream(inputStream)) {
+            for (Bundle bundle : bundleIter) {
+                try {
+                    Mutation<Accessible> update = dao.createOrUpdate(bundle, Accessible.class);
+                    switch (update.getState()) {
+                        case UPDATED:
+                            log.addUpdated();
+                            ctx.addSubjects(update.getNode());
+                            if (version) {
+                                ctx.createVersion(update.getNode(), update.getPrior().get());
+                            }
+                            break;
+                        case CREATED:
+                            log.addCreated();
+                            ctx.addSubjects(update.getNode());
+                        default:
+                            log.addUnchanged();
+                    }
+                } catch (ValidationError e) {
+                    if (!tolerant) {
+                        throw e;
+                    } else {
+                        log.setErrored(bundle.getId(), e.getMessage());
+                        logger.warn("Validation error patching {}: {}", bundle.getId(), e);
+                    }
+                }
+            }
+            if (log.hasDoneWork()) {
+                ctx.commit();
+            }
+            return log;
+        } catch (RuntimeJsonMappingException e) {
+            throw new DeserializationError("Error reading JSON stream:", e);
+        }
+    }
+
+    /**
+     * Update a batch of items.
+     *
+     * @param inputStream an input stream containing a JSON list of
+     *                    bundles corresponding to the items to update.
+     * @param actioner    the current user
+     * @param logMessage  a log message
+     * @return an import log
+     * @throws DeserializationError
+     * @throws ItemNotFound
+     * @throws ValidationError
+     */
+    public ImportLog batchUpdate(InputStream inputStream, Actioner actioner, Optional<String> logMessage)
+            throws DeserializationError, ItemNotFound, ValidationError {
+        ActionManager.EventContext ctx = actionManager.newEventContext(actioner,
+                EventTypes.modification, logMessage);
+        ImportLog log = new ImportLog(ctx);
+        try (CloseableIterable<Bundle> bundleIter = Bundle.bundleStream(inputStream)) {
+            for (Bundle bundle : bundleIter) {
+                Entity entity = manager.getEntity(bundle.getId(), bundle.getType().getJavaClass());
+                Bundle oldBundle = serializer.entityToBundle(entity);
+                Bundle newBundle = oldBundle.mergeDataWith(bundle);
+                try {
+                    Mutation<Accessible> update = dao.update(newBundle, Accessible.class);
+                    switch (update.getState()) {
+                        case UPDATED:
+                            log.addUpdated();
+                            ctx.addSubjects(update.getNode());
+                            if (version) {
+                                ctx.createVersion(entity, oldBundle);
+                            }
+                            break;
+                        case UNCHANGED:
+                            log.addUnchanged();
+                            break;
+                        default:
+                            throw new RuntimeException("Unexpected status in batch update: " + update.getState());
+                    }
+                } catch (ValidationError e) {
+                    if (!tolerant) {
+                        throw e;
+                    } else {
+                        log.setErrored(entity.getId(), e.getMessage());
+                        logger.warn("Validation error patching {}: {}", entity.getId(), e);
+                    }
+                }
+            }
+            if (log.hasDoneWork()) {
+                ctx.commit();
+            }
+            return log;
+        } catch (SerializationError serializationError) {
+            throw new RuntimeException(serializationError);
+        } catch (RuntimeJsonMappingException e) {
+            throw new DeserializationError("Error reading JSON stream:", e);
+        }
+    }
+
+    /**
+     * Delete a batch of items by ID.
+     *
+     * @param ids        a list of item IDs
+     * @param actioner   the current user
+     * @param logMessage a log message
+     * @return the number of items deleted
+     * @throws ItemNotFound
+     */
+    public int batchDelete(List<String> ids, Actioner actioner, String logMessage)
+            throws ItemNotFound {
+        if (!ids.isEmpty()) {
+            int done = 0;
+            try {
+                ActionManager.EventContext ctx = actionManager.newEventContext(actioner,
+                        EventTypes.deletion, Optional.of(logMessage));
+                for (String id : ids) {
+                    Entity entity = manager.getEntity(id, Entity.class);
+                    ctx = ctx.addSubjects(entity.as(Accessible.class));
+                    if (version) {
+                        ctx = ctx.createVersion(entity);
+                    }
+                }
+                ctx.commit();
+                for (String id : ids) {
+                    dao.delete(serializer.entityToBundle(manager.getEntity(id, Entity.class)));
+                    done++;
+                }
+                return done;
+            } catch (SerializationError serializationError) {
+                throw new RuntimeException(serializationError);
+            }
+        } else {
+            return 0;
+        }
+    }
+}

--- a/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
@@ -181,7 +181,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
     public void testBatchDeleteWithVersioning() throws Exception {
         int nodesBefore = getNodeCount(graph);
         int deleted = new BatchOperations(graph).batchDelete(Lists.newArrayList("a1"),
-                validUser.as(Actioner.class), "Test delete");
+                validUser.as(Actioner.class), Optional.of("Test delete"));
         assertEquals(1, deleted);
         // By default, total nodes should have increased by 2, since we
         // deleted 2 nodes (item and description) and created 4:
@@ -198,7 +198,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         int deleted = new BatchOperations(graph)
                 .setVersioning(false)
                 .batchDelete(Lists.newArrayList("a1"),
-                        validUser.as(Actioner.class), "Test delete");
+                        validUser.as(Actioner.class), Optional.of("Test delete"));
         assertEquals(1, deleted);
         // By default, total nodes should have increased by 1, since we
         // deleted 2 nodes (item and description) and created 3:

--- a/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
@@ -1,0 +1,210 @@
+package eu.ehri.project.importers.json;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import eu.ehri.project.exceptions.DeserializationError;
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.AbstractImporterTest;
+import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.DocumentaryUnitDescription;
+import eu.ehri.project.models.base.Actioner;
+import eu.ehri.project.models.base.PermissionScope;
+import eu.ehri.project.models.events.SystemEvent;
+import eu.ehri.project.persistence.ErrorSet;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BatchOperationsTest extends AbstractImporterTest {
+
+    @Test
+    public void testBatchImport() throws Exception {
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-test.json");
+        String logMsg = "Test import";
+        PermissionScope scope = manager.getEntity("r1", PermissionScope.class);
+
+        ImportLog log = new BatchOperations(graph)
+                .setScope(scope)
+                .batchImport(payloadStream, validUser.as(Actioner.class), Optional.of(logMsg));
+        assertTrue(log.hasDoneWork());
+        assertEquals(1, log.getCreated());
+        DocumentaryUnit newItem = manager.getEntity("nl-r1-test", DocumentaryUnit.class);
+        SystemEvent latestEvent = actionManager.getLatestGlobalEvent();
+        assertEquals(newItem, latestEvent.getFirstSubject());
+
+        // Test idempotency - running the same batch twice should not affect
+        // the state of the graph.
+        int nodesBefore = getNodeCount(graph);
+        int edgesBefore = getEdgeCount(graph);
+        payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-test.json");
+        ImportLog log2 = new BatchOperations(graph).setScope(scope).batchImport(payloadStream,
+                validUser.as(Actioner.class), Optional.of(logMsg));
+        assertFalse(log2.hasDoneWork());
+        int nodesAfter = getNodeCount(graph);
+        int edgesAfter = getEdgeCount(graph);
+        assertEquals(nodesBefore, nodesAfter);
+        assertEquals(edgesBefore, edgesAfter);
+    }
+
+    @Test
+    public void testBatchImportWithValidationError() throws Exception {
+        int nodesBefore = getNodeCount(graph);
+        int edgesBefore = getEdgeCount(graph);
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-test-validation-error.json");
+        try {
+            new BatchOperations(graph).batchImport(payloadStream,
+                    validUser.as(Actioner.class), Optional.of("Test create"));
+            fail("Import with validation error succeeded when it should have failed");
+        } catch (ValidationError e) {
+            assertEquals(1, e.getErrorSet().getErrorValue("identifier").size());
+        }
+
+        int nodesAfter = getNodeCount(graph);
+        int edgesAfter = getEdgeCount(graph);
+        assertEquals(nodesBefore, nodesAfter);
+        assertEquals(edgesBefore, edgesAfter);
+    }
+
+    @Test
+    public void testBatchUpdate() throws Exception {
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-patch-test.json");
+        String logMsg = "Test partial update";
+        int nodesBeforePatch = getNodeCount(graph);
+        ImportLog log = new BatchOperations(graph).batchUpdate(payloadStream,
+                validUser.as(Actioner.class), Optional.of(logMsg));
+        assertTrue(log.hasDoneWork());
+        assertEquals(1, log.getUpdated());
+        assertEquals(1, log.getUnchanged());
+        DocumentaryUnit doc = manager.getEntity("c1", DocumentaryUnit.class);
+        DocumentaryUnitDescription desc = manager.getEntity("cd1", DocumentaryUnitDescription.class);
+        assertEquals("Documentary Unit 1 CHANGED", desc.getName());
+        SystemEvent latestEvent = actionManager.getLatestGlobalEvent();
+        assertEquals(logMsg, latestEvent.getLogMessage());
+        assertEquals(1, Iterables.size(latestEvent.getSubjects()));
+        assertEquals(doc, latestEvent.getFirstSubject());
+        // Newly created nodes will be:
+        //  - 1 event link
+        //  - 1 action link
+        //  - 1 event
+        //  - 1 version
+        assertEquals(nodesBeforePatch + 4, getNodeCount(graph));
+
+        // Test idempotency - running the same batch twice should not affect
+        // the state of the graph.
+        int nodesBefore = getNodeCount(graph);
+        int edgesBefore = getEdgeCount(graph);
+        payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-patch-test.json");
+        ImportLog log2 = new BatchOperations(graph).batchUpdate(payloadStream,
+                validUser.as(Actioner.class), Optional.of(logMsg));
+        assertFalse(log2.hasDoneWork());
+        int nodesAfter = getNodeCount(graph);
+        int edgesAfter = getEdgeCount(graph);
+        assertEquals(nodesBefore, nodesAfter);
+        assertEquals(edgesBefore, edgesAfter);
+    }
+
+    @Test
+    public void testBatchUpdateWithEmptyStream() throws Exception {
+        InputStream emptyStream = new ByteArrayInputStream("[]".getBytes());
+        int nodesBefore = getNodeCount(graph);
+        ImportLog log = new BatchOperations(graph).batchUpdate(emptyStream,
+                validUser.as(Actioner.class), Optional.of("Test partial update"));
+        assertFalse(log.hasDoneWork());
+        int nodesAfter = getNodeCount(graph);
+        assertEquals(nodesBefore, nodesAfter);
+    }
+
+    @Test
+    public void testBatchUpdateWithValidationError() throws Exception {
+        int nodesBefore = getNodeCount(graph);
+        int edgesBefore = getEdgeCount(graph);
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-patch-test-validation-error.json");
+        try {
+            new BatchOperations(graph).batchUpdate(payloadStream,
+                    validUser.as(Actioner.class), Optional.of("Test partial update"));
+            fail("Import with validation error succeeded when it should have failed");
+        } catch (ValidationError e) {
+            Collection<ErrorSet> describes = e.getErrorSet().getRelations("describes");
+            assertEquals(1, Lists.newArrayList(describes).get(0).getErrorValue("name").size());
+        }
+
+        int nodesAfter = getNodeCount(graph);
+        int edgesAfter = getEdgeCount(graph);
+        assertEquals(nodesBefore, nodesAfter);
+        assertEquals(edgesBefore, edgesAfter);
+    }
+
+    @Test
+    public void testBatchUpdateWithValidationErrorTolerant() throws Exception {
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-patch-test-validation-error.json");
+        ImportLog log = new BatchOperations(graph).setTolerant(true).batchUpdate(payloadStream,
+                validUser.as(Actioner.class), Optional.of("Test partial update"));
+        assertTrue(log.hasDoneWork());
+        assertEquals(1, log.getUpdated());
+        assertEquals(1, log.getErrored());
+        assertTrue(log.getErrors().containsKey("c2"));
+    }
+
+    @Test
+    public void testBatchUpdateWithDeserializationError() throws Exception {
+        int nodesBefore = getNodeCount(graph);
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-patch-test-deserialization-error.json");
+        try {
+            new BatchOperations(graph).batchUpdate(payloadStream,
+                    validUser.as(Actioner.class), Optional.of("Test partial update"));
+            fail("Import with deserialization error succeeded when it should have failed");
+        } catch (DeserializationError e) {
+            // Okay...
+        }
+        int nodesAfter = getNodeCount(graph);
+        assertEquals(nodesBefore, nodesAfter);
+    }
+
+    @Test
+    public void testBatchDeleteWithVersioning() throws Exception {
+        int nodesBefore = getNodeCount(graph);
+        int deleted = new BatchOperations(graph).batchDelete(Lists.newArrayList("a1"),
+                validUser.as(Actioner.class), "Test delete");
+        assertEquals(1, deleted);
+        // By default, total nodes should have increased by 2, since we
+        // deleted 2 nodes (item and description) and created 4:
+        //  - 1 version node
+        //  - 1 event link
+        //  - 1 action link
+        //  - 1 event
+        assertEquals(nodesBefore + 2, getNodeCount(graph));
+    }
+
+    @Test
+    public void testBatchDeleteWithoutVersioning() throws Exception {
+        int nodesBefore = getNodeCount(graph);
+        int deleted = new BatchOperations(graph)
+                .setVersioning(false)
+                .batchDelete(Lists.newArrayList("a1"),
+                        validUser.as(Actioner.class), "Test delete");
+        assertEquals(1, deleted);
+        // By default, total nodes should have increased by 1, since we
+        // deleted 2 nodes (item and description) and created 3:
+        //  - 1 event link
+        //  - 1 action link
+        //  - 1 event
+        assertEquals(nodesBefore + 1, getNodeCount(graph));
+    }
+}

--- a/ehri-io/src/test/resources/import-patch-test-deserialization-error.json
+++ b/ehri-io/src/test/resources/import-patch-test-deserialization-error.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "c1",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd1",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Documentary Unit 1 CHANGED"
+          }
+        }
+      ]
+    }
+  },
+  "this is broken"
+]

--- a/ehri-io/src/test/resources/import-patch-test-validation-error.json
+++ b/ehri-io/src/test/resources/import-patch-test-validation-error.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "c1",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd1",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Documentary Unit 1 CHANGED"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "c2",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd2",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": ""
+          }
+        }
+      ]
+    }
+  }
+]

--- a/ehri-io/src/test/resources/import-patch-test.json
+++ b/ehri-io/src/test/resources/import-patch-test.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "c1",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd1",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Documentary Unit 1 CHANGED"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "c2",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd2",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Documentary Unit 2"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/ehri-io/src/test/resources/import-test-validation-error.json
+++ b/ehri-io/src/test/resources/import-test-validation-error.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Won't work without identifier",
+            "languageCode": "eng"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/ehri-io/src/test/resources/import-test.json
+++ b/ehri-io/src/test/resources/import-test.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "DocumentaryUnit",
+    "data": {
+      "identifier": "test"
+    },
+    "relationships": {
+      "describes": [
+        {
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "New Documentary Unit",
+            "languageCode": "eng"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -160,8 +160,7 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
             UserProfile user = getCurrentUser();
             Vocabulary vocabulary = views.detail(id, user);
-            CrudViews<Concept> conceptViews = new CrudViews<>(
-                    graph, Concept.class, vocabulary);
+            CrudViews<Concept> conceptViews = new CrudViews<>(graph, Concept.class, vocabulary);
             ActionManager actionManager = new ActionManager(graph, vocabulary);
             Iterable<Concept> concepts = vocabulary.getConcepts();
             if (concepts.iterator().hasNext()) {
@@ -169,6 +168,10 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
                         .newEventContext(user, EventTypes.deletion, getLogMessage());
                 for (Concept concept : concepts) {
                     context.addSubjects(concept);
+                    context.createVersion(concept);
+                }
+                context.commit();
+                for (Concept concept : concepts) {
                     conceptViews.delete(concept.getId(), user);
                 }
             }

--- a/ehri-ws/src/main/java/eu/ehri/extension/base/AbstractRestResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/base/AbstractRestResource.java
@@ -33,7 +33,7 @@ import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.frames.FramedGraphFactory;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerModule;
-import eu.ehri.extension.errors.BadRequester;
+import eu.ehri.extension.errors.MissingOrInvalidUser;
 import eu.ehri.project.acl.AnonymousAccessor;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
@@ -262,7 +262,7 @@ public abstract class AbstractRestResource implements TxCheckedResource {
             try {
                 return manager.getEntity(id.get(), Accessor.class);
             } catch (ItemNotFound e) {
-                throw new BadRequester(id.get());
+                throw new MissingOrInvalidUser(id.get());
             }
         }
     }
@@ -277,7 +277,7 @@ public abstract class AbstractRestResource implements TxCheckedResource {
         Accessor profile = getRequesterUserProfile();
         if (profile.isAdmin() || profile.isAnonymous()
                 || !profile.getType().equals(Entities.USER_PROFILE)) {
-            throw new BadRequester("Invalid user: " + profile.getId());
+            throw new MissingOrInvalidUser(profile.getId());
         }
         return graph.frame(profile.asVertex(), UserProfile.class);
     }

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/MissingOrInvalidUser.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/MissingOrInvalidUser.java
@@ -19,11 +19,11 @@
 
 package eu.ehri.extension.errors;
 
-public class BadRequester extends RuntimeException {
+public class MissingOrInvalidUser extends RuntimeException {
 
     private static final long serialVersionUID = 2608176871477505511L;
 
-    public BadRequester(String requester) {
+    public MissingOrInvalidUser(String requester) {
         super(String.format("Requester missing or badly formed: '%s'", requester));
     }
 }

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/AccessDeniedMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/AccessDeniedMapper.java
@@ -22,6 +22,7 @@ package eu.ehri.extension.errors.mappers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.ehri.project.exceptions.AccessDenied;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -52,6 +53,7 @@ public class AccessDeniedMapper implements ExceptionMapper<AccessDenied> {
         };
         try {
             return Response.status(Status.UNAUTHORIZED)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
                     .entity(new ObjectMapper().writeValueAsBytes(out)).build();
         } catch (Exception e1) {
             throw new RuntimeException(e1);

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/DeserializationErrorMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/DeserializationErrorMapper.java
@@ -23,6 +23,7 @@ import com.google.common.base.Charsets;
 import eu.ehri.extension.errors.WebDeserializationError;
 import eu.ehri.project.exceptions.DeserializationError;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -50,6 +51,7 @@ public class DeserializationErrorMapper implements
     public Response toResponse(DeserializationError e) {
         return Response
                 .status(Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_JSON_TYPE)
                 .entity(WebDeserializationError.errorToJson(e)
                         .getBytes(Charsets.UTF_8)).build();
     }

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/ItemNotFoundMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/ItemNotFoundMapper.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import eu.ehri.project.exceptions.ItemNotFound;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -55,6 +56,7 @@ public class ItemNotFoundMapper implements ExceptionMapper<ItemNotFound> {
         };
         try {
             return Response.status(Status.NOT_FOUND)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
                     .entity(mapper.writeValueAsString(out)
                             .getBytes(Charsets.UTF_8)).build();
         } catch (Exception e1) {

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/MissingOrInvalidUserErrorMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/MissingOrInvalidUserErrorMapper.java
@@ -20,53 +20,27 @@
 package eu.ehri.extension.errors.mappers;
 
 import com.google.common.base.Charsets;
-import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.extension.errors.MissingOrInvalidUser;
 
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-
 /**
- * Serialize a tree of validation errors to JSON. Like bundles,
- * ValidationErrors are a recursive structure with a 'relations'
- * map that contains lists of the errors found in each top-level
- * item's children. The end result should look like:
- * <p>
- * {
- * "errors":{},
- * "relations":{
- * "describes":[
- * {}
- * ],
- * "hasDate":[
- * {
- * "errors":{
- * "startDate":["Missing mandatory field"],
- * "endDate":["Missing mandatory field"]
- * },
- * "relations":{}
- * }
- * ]
- * }
- * }
- * <p>
- * The response is sent with HTTP status Bad Request.
+ * Maps the {@link MissingOrInvalidUser} exception to the Bad Request response.
+ * This is distinct from the case where a valid user was supplied but was not
+ * authorised to perform a particular action.
  */
 @Provider
-public class ValidationErrorMapper implements ExceptionMapper<ValidationError> {
+public class MissingOrInvalidUserErrorMapper implements ExceptionMapper<MissingOrInvalidUser> {
     @Override
-    public Response toResponse(ValidationError e) {
-        try {
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON_TYPE)
-                    .entity(e.getErrorSet().toJson()
-                            .getBytes(Charsets.UTF_8)).build();
-        } catch (Exception e1) {
-            e1.printStackTrace();
-            throw new RuntimeException(e1);
-        }
+    public Response toResponse(MissingOrInvalidUser e) {
+        return Response
+                .status(Status.BAD_REQUEST)
+                .type(MediaType.TEXT_PLAIN_TYPE)
+                .entity(e.getMessage().getBytes(Charsets.UTF_8)).build();
     }
 }

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/PermissionDeniedMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/PermissionDeniedMapper.java
@@ -22,6 +22,7 @@ package eu.ehri.extension.errors.mappers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.ehri.project.exceptions.PermissionDenied;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -55,6 +56,7 @@ public class PermissionDeniedMapper implements ExceptionMapper<PermissionDenied>
         };
         try {
             return Response.status(Status.UNAUTHORIZED)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
                     .entity(mapper.writeValueAsBytes(out)).build();
         } catch (Exception e1) {
             throw new RuntimeException(e1);

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/BundleProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/BundleProvider.java
@@ -47,7 +47,6 @@ public class BundleProvider implements MessageBodyReader<Bundle> {
     public Bundle readFrom(Class<Bundle> bundleClass, Type type, Annotation[] annotations,
                            MediaType mediaType, MultivaluedMap<String,
             String> headers, InputStream stream) throws IOException, WebApplicationException {
-
         try {
             return Bundle.fromStream(stream);
         } catch (DeserializationError deserializationError) {

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/GlobalPermissionSetProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/GlobalPermissionSetProvider.java
@@ -19,10 +19,8 @@
 
 package eu.ehri.extension.providers;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.ehri.project.acl.ContentTypes;
 import eu.ehri.project.acl.GlobalPermissionSet;
 import eu.ehri.project.acl.PermissionType;
@@ -46,10 +44,7 @@ import java.util.List;
 
 @Provider
 @Consumes(MediaType.APPLICATION_JSON)
-public class GlobalPermissionSetProvider implements MessageBodyReader<GlobalPermissionSet> {
-
-    private static final JsonFactory factory = new JsonFactory();
-    private static final ObjectMapper mapper = new ObjectMapper(factory);
+public class GlobalPermissionSetProvider implements MessageBodyReader<GlobalPermissionSet>, JsonMessageBodyHandler {
 
     @Override
     public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
@@ -58,7 +53,7 @@ public class GlobalPermissionSetProvider implements MessageBodyReader<GlobalPerm
 
     @Override
     public GlobalPermissionSet readFrom(Class<GlobalPermissionSet> bundleClass, Type type, Annotation[] annotations,
-                                        MediaType mediaType, MultivaluedMap<String,
+            MediaType mediaType, MultivaluedMap<String,
             String> headers, InputStream stream) throws IOException, WebApplicationException {
 
         try {

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/ImportLogProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/ImportLogProvider.java
@@ -19,12 +19,10 @@
 
 package eu.ehri.extension.providers;
 
-import eu.ehri.extension.PermissionsResource;
-import eu.ehri.project.acl.InheritedItemPermissionSet;
+import eu.ehri.project.importers.ImportLog;
 
-import javax.ws.rs.Produces;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
@@ -35,28 +33,20 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 @Provider
-@Produces(MediaType.APPLICATION_JSON)
-public class InheritedItemPermissionSetProvider
-        implements MessageBodyWriter<InheritedItemPermissionSet>, JsonMessageBodyHandler {
-
+@Consumes(MediaType.APPLICATION_JSON)
+public class ImportLogProvider implements MessageBodyWriter<ImportLog>, JsonMessageBodyHandler {
     @Override
     public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
-        return InheritedItemPermissionSet.class.equals(aClass);
+        return aClass == ImportLog.class;
     }
 
     @Override
-    public long getSize(InheritedItemPermissionSet permissionSet, Class<?> aClass, Type type, Annotation[] annotations,
-            MediaType mediaType) {
+    public long getSize(ImportLog importLog, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
         return -1L;
     }
 
     @Override
-    public void writeTo(InheritedItemPermissionSet itemPermissionSet,
-            Class<?> aClass, Type type, Annotation[] annotations,
-            MediaType mediaType, MultivaluedMap<String, Object> headers,
-            OutputStream outputStream) throws IOException, WebApplicationException {
-        headers.putSingle(HttpHeaders.CACHE_CONTROL,
-                PermissionsResource.getCacheControl().toString());
-        mapper.writeValue(outputStream, itemPermissionSet.serialize());
+    public void writeTo(ImportLog importLog, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
+        mapper.writeValue(outputStream, importLog);
     }
 }

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/InheritedGlobalPermissionSetProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/InheritedGlobalPermissionSetProvider.java
@@ -19,8 +19,6 @@
 
 package eu.ehri.extension.providers;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.ehri.extension.PermissionsResource;
 import eu.ehri.project.acl.InheritedGlobalPermissionSet;
 
@@ -36,13 +34,10 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
-public class InheritedGlobalPermissionSetProvider implements MessageBodyWriter<InheritedGlobalPermissionSet> {
-
-    private static final JsonFactory factory = new JsonFactory();
-    private static final ObjectMapper mapper = new ObjectMapper(factory);
+public class InheritedGlobalPermissionSetProvider
+        implements MessageBodyWriter<InheritedGlobalPermissionSet>, JsonMessageBodyHandler {
 
     @Override
     public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
@@ -51,15 +46,15 @@ public class InheritedGlobalPermissionSetProvider implements MessageBodyWriter<I
 
     @Override
     public long getSize(InheritedGlobalPermissionSet globalPermissionSet, Class<?> aClass, Type type, Annotation[] annotations,
-                        MediaType mediaType) {
+            MediaType mediaType) {
         return -1L;
     }
 
     @Override
     public void writeTo(InheritedGlobalPermissionSet globalPermissionSet,
-                        Class<?> aClass, Type type, Annotation[] annotations,
-                        MediaType mediaType, MultivaluedMap<String, Object> headers,
-                        OutputStream outputStream) throws IOException, WebApplicationException {
+            Class<?> aClass, Type type, Annotation[] annotations,
+            MediaType mediaType, MultivaluedMap<String, Object> headers,
+            OutputStream outputStream) throws IOException, WebApplicationException {
         headers.putSingle(HttpHeaders.CACHE_CONTROL,
                 PermissionsResource.getCacheControl().toString());
         mapper.writeValue(outputStream, globalPermissionSet.serialize());

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/ItemPermissionSetProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/ItemPermissionSetProvider.java
@@ -19,10 +19,8 @@
 
 package eu.ehri.extension.providers;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.ehri.project.acl.ItemPermissionSet;
 import eu.ehri.project.acl.PermissionType;
 import eu.ehri.project.exceptions.DeserializationError;
@@ -44,10 +42,7 @@ import java.util.Set;
 
 @Provider
 @Consumes(MediaType.APPLICATION_JSON)
-public class ItemPermissionSetProvider implements MessageBodyReader<ItemPermissionSet> {
-
-    private static final JsonFactory factory = new JsonFactory();
-    private static final ObjectMapper mapper = new ObjectMapper(factory);
+public class ItemPermissionSetProvider implements MessageBodyReader<ItemPermissionSet>, JsonMessageBodyHandler {
 
     @Override
     public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
@@ -56,7 +51,7 @@ public class ItemPermissionSetProvider implements MessageBodyReader<ItemPermissi
 
     @Override
     public ItemPermissionSet readFrom(Class<ItemPermissionSet> bundleClass, Type type, Annotation[] annotations,
-                                      MediaType mediaType, MultivaluedMap<String,
+            MediaType mediaType, MultivaluedMap<String,
             String> headers, InputStream stream) throws IOException, WebApplicationException {
 
         try {

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/JsonMessageBodyHandler.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/JsonMessageBodyHandler.java
@@ -1,0 +1,10 @@
+package eu.ehri.extension.providers;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+interface JsonMessageBodyHandler {
+    JsonFactory factory = new JsonFactory();
+    ObjectMapper mapper = new ObjectMapper(factory);
+}

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/DocumentaryUnitRestClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/DocumentaryUnitRestClientTest.java
@@ -232,11 +232,11 @@ public class DocumentaryUnitRestClientTest extends AbstractRestClientTest {
     }
 
     @Test
-    public void testListDocumentaryUnitWithBadRequester() throws Exception {
+    public void testListDocumentaryUnitWithBadUser() throws Exception {
         ClientResponse response = jsonCallAs("invalidId",
                 entityUri(Entities.DOCUMENTARY_UNIT, TEST_JSON_IDENTIFIER, "list"))
                 .get(ClientResponse.class);
-        assertStatus(INTERNAL_SERVER_ERROR, response);
+        assertStatus(BAD_REQUEST, response);
     }
 
     @Test

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceRestClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceRestClientTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.sun.jersey.api.client.ClientResponse;
+import eu.ehri.extension.GenericResource;
 import eu.ehri.extension.ImportResource;
 import eu.ehri.project.importers.ead.IcaAtomEadHandler;
 import org.apache.commons.io.FileUtils;
@@ -46,6 +47,7 @@ import java.util.zip.ZipOutputStream;
 
 import static eu.ehri.extension.ImportResource.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -265,17 +267,17 @@ public class ImportResourceRestClientTest extends AbstractRestClientTest {
     }
 
     @Test
-    public void testJsonPatch() throws Exception {
+    public void testBatchUpdate() throws Exception {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("import-patch-test.json");
         System.out.println(payloadStream);
         String logText = "Testing patch update";
-        URI jsonUri = ehriUriBuilder(ImportResource.ENDPOINT, "json")
+        URI jsonUri = ehriUriBuilder(ImportResource.ENDPOINT, "batch")
                 .queryParam(LOG_PARAM, logText).build();
         ClientResponse response = callAs(getAdminUserProfileId(), jsonUri)
                 .header("Content-Type", "application/json")
                 .entity(payloadStream)
-                .post(ClientResponse.class);
+                .put(ClientResponse.class);
 
         String output = response.getEntity(String.class);
         System.out.println(output);
@@ -286,6 +288,27 @@ public class ImportResourceRestClientTest extends AbstractRestClientTest {
         assertEquals(1, rootNode.path("updated").asInt());
         assertEquals(1, rootNode.path("unchanged").asInt());
         assertEquals(logText, rootNode.path("message").asText());
+    }
+
+    @Test
+    public void testBatchDelete() throws Exception {
+        String user = getAdminUserProfileId();
+        assertTrue(checkExists("a2", user));
+        String logText = "Testing patch delete";
+        URI jsonUri = ehriUriBuilder(ImportResource.ENDPOINT, "batch")
+                .queryParam(LOG_PARAM, logText)
+                .queryParam(ID_PARAM, "a2")
+                .build();
+        ClientResponse response = callAs(user, jsonUri)
+                .delete(ClientResponse.class);
+        assertStatus(ClientResponse.Status.NO_CONTENT, response);
+        assertFalse(checkExists("a2", user));
+    }
+
+    private boolean checkExists(String id, String userId) {
+        URI uri = ehriUriBuilder(GenericResource.ENDPOINT, id).build();
+        return callAs(userId, uri).get(ClientResponse.class).getStatus()
+                == ClientResponse.Status.OK.getStatusCode();
     }
 
     private UriBuilder getImportUrl(String endPoint, String scopeId, String log, boolean tolerant) {

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceRestClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceRestClientTest.java
@@ -264,6 +264,30 @@ public class ImportResourceRestClientTest extends AbstractRestClientTest {
         assertEquals(logText, rootNode.path("message").asText());
     }
 
+    @Test
+    public void testJsonPatch() throws Exception {
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("import-patch-test.json");
+        System.out.println(payloadStream);
+        String logText = "Testing patch update";
+        URI jsonUri = ehriUriBuilder(ImportResource.ENDPOINT, "json")
+                .queryParam(LOG_PARAM, logText).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), jsonUri)
+                .header("Content-Type", "application/json")
+                .entity(payloadStream)
+                .post(ClientResponse.class);
+
+        String output = response.getEntity(String.class);
+        System.out.println(output);
+        assertStatus(ClientResponse.Status.OK, response);
+
+        JsonNode rootNode = jsonMapper.readTree(output);
+        assertEquals(0, rootNode.path("created").asInt());
+        assertEquals(1, rootNode.path("updated").asInt());
+        assertEquals(1, rootNode.path("unchanged").asInt());
+        assertEquals(logText, rootNode.path("message").asText());
+    }
+
     private UriBuilder getImportUrl(String endPoint, String scopeId, String log, boolean tolerant) {
         return ehriUriBuilder(ImportResource.ENDPOINT, endPoint)
                 .queryParam(LOG_PARAM, log)

--- a/ehri-ws/src/test/resources/import-patch-test.json
+++ b/ehri-ws/src/test/resources/import-patch-test.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "c1",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd1",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Documentary Unit 1 CHANGED"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "c2",
+    "type": "DocumentaryUnit",
+    "data": {},
+    "relationships": {
+      "describes": [
+        {
+          "id": "cd2",
+          "type": "DocumentaryUnitDescription",
+          "data": {
+            "name": "Documentary Unit 2"
+          }
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
The main change to pre-existing code is that the action manager now supports creating versions for multiple subject items. Additional changes:

 - refactored JSON serialization of bundle objects
 - added support for tree-wise property updates in bundles, allowing dependent items in a tree to be updated as PATCH operations
 - removed unnecessary graph manager methods
 - added a provider for the import log class

The batch operations class currently supports import, update, and delete, but only the latter two are currently exposed by the WS.