### PR TITLE
Strip out all bundle XML support.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -39,7 +39,6 @@ import eu.ehri.project.models.idgen.IdGenerator;
 import eu.ehri.project.models.utils.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -53,7 +52,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Class that represents a graph entity and subtree relations
  * prior to being materialised as vertices and edges.
- *
+ * <p/>
  * Note: unlike a vertex, a bundle can contain null values
  * in its data map, though these values will not be externally
  * visible. Null values <i>are</i> however used in merge operations,
@@ -684,24 +683,6 @@ public final class Bundle {
         } catch (SerializationError e) {
             return "Invalid Bundle: " + e.getMessage();
         }
-    }
-
-    /**
-     * Serialize a bundle to a JSON string.
-     *
-     * @return document An XML document
-     */
-    public Document toXml() {
-        return DataConverter.bundleToXml(this);
-    }
-
-    /**
-     * Serialize to an XML String.
-     *
-     * @return An XML string
-     */
-    public String toXmlString() {
-        return DataConverter.bundleToXmlString(this);
     }
 
     /**

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Serializer.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Serializer.java
@@ -35,7 +35,6 @@ import eu.ehri.project.models.base.Entity;
 import eu.ehri.project.models.utils.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
 
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
@@ -279,42 +278,6 @@ public final class Serializer {
     public String vertexToJson(Vertex item)
             throws SerializationError {
         return DataConverter.bundleToJson(vertexToBundle(item));
-    }
-
-    /**
-     * Serialise a vertex frame to XML.
-     *
-     * @param item The item vertex
-     * @return An XML document
-     * @throws SerializationError
-     */
-    public Document vertexToXml(Vertex item)
-            throws SerializationError {
-        return DataConverter.bundleToXml(vertexToBundle(item));
-    }
-
-    /**
-     * Serialise a vertex frame to XML string.
-     *
-     * @param item The item vertex
-     * @return An XML document string
-     * @throws SerializationError
-     */
-    public String vertexToXmlString(Vertex item)
-            throws SerializationError {
-        return DataConverter.bundleToXmlString(vertexToBundle(item));
-    }
-
-    /**
-     * Serialise a vertex frame to XML string.
-     *
-     * @param item The framed item
-     * @return An XML document string
-     * @throws SerializationError
-     */
-    public <T extends Entity> String entityToXmlString(T item)
-            throws SerializationError {
-        return DataConverter.bundleToXmlString(entityToBundle(item));
     }
 
     /**

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/DataConverterTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/DataConverterTest.java
@@ -21,14 +21,9 @@ package eu.ehri.project.persistence;
 
 import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.CloseableIterable;
-import eu.ehri.project.models.DocumentaryUnit;
-import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Test;
 import org.neo4j.helpers.collection.Iterables;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -37,35 +32,12 @@ import java.util.List;
 import static eu.ehri.project.persistence.DataConverter.isEmptySequence;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Test for Bundle data conversion functions.
  */
 public class DataConverterTest extends AbstractFixtureTest {
-
-    @Test
-    public void testBundleToXml() throws Exception {
-        DocumentaryUnit c1 = manager.getEntity("c1", DocumentaryUnit.class);
-        Bundle bundle = new Serializer(graph).entityToBundle(c1)
-                .withDataValue("testarray", new String[]{"one", "two", "three"})
-                .withDataValue("itemWithLt", "I should be escape because of: <>");
-
-        Document document = bundle.toXml();
-        assertTrue(document.hasChildNodes());
-        NodeList root = document.getChildNodes();
-        assertEquals(1, root.getLength());
-        Node rootItem = root.item(0);
-        assertNotNull(rootItem.getAttributes().getNamedItem(Bundle.ID_KEY));
-        assertNotNull(rootItem.getAttributes().getNamedItem(Bundle.TYPE_KEY));
-        assertEquals("c1", rootItem.getAttributes().getNamedItem(Bundle.ID_KEY).getNodeValue());
-        assertEquals(EntityClass.DOCUMENTARY_UNIT.getName(),
-                rootItem.getAttributes().getNamedItem(Bundle.TYPE_KEY).getNodeValue());
-        assertTrue(rootItem.hasChildNodes());
-        // TODO: Check properties and relationships are serialized properly
-        System.out.println(bundle.toXmlString());
-    }
 
     @Test
     public void testBundleStream() throws Exception {

--- a/ehri-ws/src/main/java/eu/ehri/extension/AdminResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AdminResource.java
@@ -124,7 +124,7 @@ public class AdminResource extends AbstractRestResource {
      * @throws Exception
      */
     @POST
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("create-default-user-profile")
     public Response createDefaultUserProfile(String jsonData,

--- a/ehri-ws/src/main/java/eu/ehri/extension/AnnotationResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AnnotationResource.java
@@ -71,7 +71,7 @@ public class AnnotationResource extends AbstractAccessibleResource<Annotation>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -79,7 +79,7 @@ public class AnnotationResource extends AbstractAccessibleResource<Annotation>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
@@ -101,7 +101,7 @@ public class AnnotationResource extends AbstractAccessibleResource<Annotation>
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response createAnnotation(
             @QueryParam(TARGET_PARAM) String id,
             @QueryParam(BODY_PARAM) String did,

--- a/ehri-ws/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
@@ -53,7 +53,7 @@ public class AuthoritativeSetResource extends
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -61,14 +61,14 @@ public class AuthoritativeSetResource extends
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     @Override
     public Response listChildren(
@@ -88,7 +88,7 @@ public class AuthoritativeSetResource extends
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response create(Bundle bundle,
                            @QueryParam(ACCESSOR_PARAM) List<String> accessors)
@@ -102,7 +102,7 @@ public class AuthoritativeSetResource extends
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -149,7 +149,7 @@ public class AuthoritativeSetResource extends
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.HISTORICAL_AGENT)
     @Override
     public Response createChild(@PathParam("id") String id,

--- a/ehri-ws/src/main/java/eu/ehri/extension/ContentTypeResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ContentTypeResource.java
@@ -50,7 +50,7 @@ public class ContentTypeResource extends AbstractAccessibleResource<ContentType>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -58,7 +58,7 @@ public class ContentTypeResource extends AbstractAccessibleResource<ContentType>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();

--- a/ehri-ws/src/main/java/eu/ehri/extension/CountryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CountryResource.java
@@ -52,7 +52,7 @@ public class CountryResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -60,14 +60,14 @@ public class CountryResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     @Override
     public Response listChildren(@PathParam("id") String id,
@@ -86,7 +86,7 @@ public class CountryResource
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response create(Bundle bundle,
                            @QueryParam(ACCESSOR_PARAM) List<String> accessors)
@@ -100,7 +100,7 @@ public class CountryResource
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -137,7 +137,7 @@ public class CountryResource
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.REPOSITORY)
     @Override
     public Response createChild(@PathParam("id") String id,

--- a/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
@@ -51,7 +51,7 @@ public class CvocConceptResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -59,7 +59,7 @@ public class CvocConceptResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
@@ -67,7 +67,7 @@ public class CvocConceptResource
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -92,7 +92,7 @@ public class CvocConceptResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     @Override
     public Response listChildren(@PathParam("id") String id,
@@ -111,7 +111,7 @@ public class CvocConceptResource
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.CVOC_CONCEPT)
     @Override
     public Response createChild(@PathParam("id") String id,
@@ -195,7 +195,7 @@ public class CvocConceptResource
      * @throws AccessDenied
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/broader/list")
     public Response getCvocBroaderConcepts(@PathParam("id") String id)
             throws ItemNotFound, AccessDenied {
@@ -217,7 +217,7 @@ public class CvocConceptResource
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/related/list")
     public Response getCvocRelatedConcepts(@PathParam("id") String id) throws ItemNotFound {
         Tx tx = graph.getBaseGraph().beginTx();
@@ -240,7 +240,7 @@ public class CvocConceptResource
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/relatedBy/list")
     public Response getCvocRelatedByConcepts(@PathParam("id") String id) throws ItemNotFound {
         Tx tx = graph.getBaseGraph().beginTx();

--- a/ehri-ws/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
@@ -74,7 +74,7 @@ public class DocumentaryUnitResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -82,14 +82,14 @@ public class DocumentaryUnitResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     @Override
     public Response listChildren(
@@ -110,7 +110,7 @@ public class DocumentaryUnitResource
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id,
@@ -136,7 +136,7 @@ public class DocumentaryUnitResource
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.DOCUMENTARY_UNIT)
     @Override
     public Response createChild(@PathParam("id") String id,

--- a/ehri-ws/src/main/java/eu/ehri/extension/GenericResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/GenericResource.java
@@ -117,7 +117,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response list(@QueryParam("id") List<String> ids,
             @QueryParam("gid") List<Long> gids) throws ItemNotFound {
 
@@ -161,7 +161,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws PermissionDenied
      */
     @POST
-    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public Response listFromJson(String json)
             throws ItemNotFound, PermissionDenied, DeserializationError, IOException {
@@ -177,7 +177,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     public Response get(@PathParam("id") String id) throws ItemNotFound, AccessDenied {
         try (final Tx tx = graph.getBaseGraph().beginTx()) {
@@ -191,7 +191,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
                 throw new AccessDenied(currentUser.getId(), id);
             }
 
-            Response response = single(item);
+            Response response = single(graph.frame(item, Accessible.class));
             tx.success();
             return response;
         }
@@ -206,6 +206,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + ACCESS)
     public Response visibility(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, SerializationError {
@@ -231,6 +232,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + ACCESS)
     public Response setVisibility(@PathParam("id") String id,
             @QueryParam(ACCESSOR_PARAM) List<String> accessorIds)
@@ -255,6 +257,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + PROMOTE)
     public Response addPromotion(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound {
@@ -262,8 +265,9 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             Promotable item = manager.getEntity(id, Promotable.class);
             UserProfile currentUser = getCurrentUser();
             pv.upVote(item, currentUser);
+            Response response = single(item);
             tx.success();
-            return single(item);
+            return response;
         } catch (PromotionViews.NotPromotableError e) {
             return Response.status(Response.Status.BAD_REQUEST.getStatusCode())
                     .entity(e.getMessage()).build();
@@ -279,6 +283,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + PROMOTE)
     public Response removePromotion(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
@@ -286,8 +291,9 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             Promotable item = manager.getEntity(id, Promotable.class);
             UserProfile currentUser = getCurrentUser();
             pv.removeUpVote(item, currentUser);
+            Response response = single(item);
             tx.success();
-            return single(item);
+            return response;
         }
     }
 
@@ -300,6 +306,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + DEMOTE)
     public Response addDemotion(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound {
@@ -307,8 +314,9 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             Promotable item = manager.getEntity(id, Promotable.class);
             UserProfile currentUser = getCurrentUser();
             pv.downVote(item, currentUser);
+            Response response = single(item);
             tx.success();
-            return single(item);
+            return response;
         } catch (PromotionViews.NotPromotableError e) {
             return Response.status(Response.Status.BAD_REQUEST.getStatusCode())
                     .entity(e.getMessage()).build();
@@ -324,6 +332,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + DEMOTE)
     public Response removeDemotion(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
@@ -331,8 +340,9 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             Promotable item = manager.getEntity(id, Promotable.class);
             UserProfile currentUser = getCurrentUser();
             pv.removeDownVote(item, currentUser);
+            Response response = single(item);
             tx.success();
-            return single(item);
+            return response;
         }
     }
 
@@ -374,7 +384,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + ANNOTATIONS)
     public Response annotations(
             @PathParam("id") String id) throws ItemNotFound {
@@ -397,7 +407,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + LINKS)
     public Response links(@PathParam("id") String id) throws ItemNotFound {
         Tx tx = graph.getBaseGraph().beginTx();
@@ -419,7 +429,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + PERMISSION_GRANTS)
     public Response permissionGrants(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound {
@@ -442,7 +452,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + SCOPE_PERMISSION_GRANTS)
     public Response permissionGrantsAsScope(@PathParam("id") String id)
             throws ItemNotFound {
@@ -471,7 +481,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + DESCRIPTIONS)
     public Response createDescription(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ValidationError,
@@ -503,7 +513,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + DESCRIPTIONS)
     public Response updateDescription(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ValidationError,
@@ -535,7 +545,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + DESCRIPTIONS + "/{did:[^/]+}")
     public Response updateDescriptionWithId(@PathParam("id") String id,
             @PathParam("did") String did, Bundle bundle)
@@ -583,7 +593,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + DESCRIPTIONS + "/{did:[^/]+}/" + ACCESS_POINTS)
     public Response createAccessPoint(@PathParam("id") String id,
             @PathParam("did") String did, Bundle bundle)

--- a/ehri-ws/src/main/java/eu/ehri/extension/GroupResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/GroupResource.java
@@ -72,7 +72,7 @@ public class GroupResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -80,7 +80,7 @@ public class GroupResource
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
@@ -88,7 +88,7 @@ public class GroupResource
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response createGroup(Bundle bundle,
             @QueryParam(ACCESSOR_PARAM) List<String> accessors,
             @QueryParam(MEMBER_PARAM) List<String> members)
@@ -116,7 +116,7 @@ public class GroupResource
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -165,7 +165,7 @@ public class GroupResource
      * UserProfiles and sub-Groups (direct descendants)
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     public Response listChildren(
             @PathParam("id") String id,

--- a/ehri-ws/src/main/java/eu/ehri/extension/HistoricalAgentResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/HistoricalAgentResource.java
@@ -72,7 +72,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -81,7 +81,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
@@ -89,7 +89,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response create(Bundle bundle,
             @QueryParam(ACCESSOR_PARAM) List<String> accessors)
@@ -103,7 +103,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -103,7 +103,6 @@ public class ImportResource extends AbstractRestResource {
         super(database);
     }
 
-
     /**
      * Import a SKOS file, of varying formats, as specified by the &quot;language&quot;
      * column of the file extensions table <a href="https://jena.apache.org/documentation/io/">here</a>.

--- a/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
@@ -70,7 +70,7 @@ public class LinkResource extends AbstractAccessibleResource<Link>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -78,7 +78,7 @@ public class LinkResource extends AbstractAccessibleResource<Link>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response list() {
         return listItems();
     }
@@ -111,7 +111,7 @@ public class LinkResource extends AbstractAccessibleResource<Link>
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response create(
             Bundle bundle,
             @QueryParam(SOURCE_PARAM) String source,

--- a/ehri-ws/src/main/java/eu/ehri/extension/PermissionGrantResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/PermissionGrantResource.java
@@ -58,7 +58,7 @@ public class PermissionGrantResource extends AbstractRestResource implements Del
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {

--- a/ehri-ws/src/main/java/eu/ehri/extension/PermissionsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/PermissionsResource.java
@@ -254,7 +254,7 @@ public class PermissionsResource extends AbstractRestResource {
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userOrGroup:[^/]+}/" + GenericResource.PERMISSION_GRANTS)
     public Response listPermissionGrants(@PathParam("userOrGroup") String id) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();

--- a/ehri-ws/src/main/java/eu/ehri/extension/RepositoryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/RepositoryResource.java
@@ -74,7 +74,7 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -82,14 +82,14 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     @Override
     public Response listChildren(
@@ -111,7 +111,7 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -148,7 +148,7 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.DOCUMENTARY_UNIT)
     @Override
     public Response createChild(@PathParam("id") String id,

--- a/ehri-ws/src/main/java/eu/ehri/extension/SystemEventResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/SystemEventResource.java
@@ -92,7 +92,7 @@ public class SystemEventResource extends AbstractAccessibleResource<SystemEvent>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -131,7 +131,7 @@ public class SystemEventResource extends AbstractAccessibleResource<SystemEvent>
      * @throws ItemNotFound
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/subjects")
     public Response pageSubjectsForEvent(@PathParam("id") String id)
             throws ItemNotFound, AccessDenied {

--- a/ehri-ws/src/main/java/eu/ehri/extension/UserProfileResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/UserProfileResource.java
@@ -85,7 +85,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -93,7 +93,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
@@ -101,7 +101,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response createUserProfile(Bundle bundle,
             @QueryParam(GROUP_PARAM) List<String> groupIds,
             @QueryParam(ACCESSOR_PARAM) List<String> accessors) throws PermissionDenied,
@@ -130,7 +130,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -155,7 +155,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + FOLLOWERS)
     public Response listFollowers(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -171,7 +171,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + FOLLOWING)
     public Response listFollowing(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -187,7 +187,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + IS_FOLLOWING + "/{otherId:[^/]+}")
     public boolean isFollowing(
             @PathParam("userId") String userId,
@@ -204,7 +204,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + IS_FOLLOWER + "/{otherId:[^/]+}")
     public boolean isFollower(
             @PathParam("userId") String userId,
@@ -252,7 +252,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + BLOCKED)
     public Response listBlocked(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -268,7 +268,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + IS_BLOCKING + "/{otherId:[^/]+}")
     public boolean isBlocking(
             @PathParam("userId") String userId,
@@ -316,7 +316,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + WATCHING)
     public Response listWatching(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -380,7 +380,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + GenericResource.ANNOTATIONS)
     public Response listAnnotations(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -396,7 +396,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + GenericResource.LINKS)
     public Response pageLinks(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();
@@ -412,7 +412,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + Entities.VIRTUAL_UNIT)
     public Response pageVirtualUnits(@PathParam("userId") String userId) throws ItemNotFound {
         final Tx tx = graph.getBaseGraph().beginTx();

--- a/ehri-ws/src/main/java/eu/ehri/extension/VirtualUnitResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VirtualUnitResource.java
@@ -66,7 +66,7 @@ public final class VirtualUnitResource extends
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -74,14 +74,14 @@ public final class VirtualUnitResource extends
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     public Response listChildVirtualUnits(
             @PathParam("id") String id,
@@ -100,7 +100,7 @@ public final class VirtualUnitResource extends
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + INCLUDED)
     public Response listIncludedVirtualUnits(
             @PathParam("id") String id) throws ItemNotFound {
@@ -164,7 +164,7 @@ public final class VirtualUnitResource extends
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     public Response createTopLevelVirtualUnit(Bundle bundle,
                                               @QueryParam(ACCESSOR_PARAM) List<String> accessors,
                                               @QueryParam(ID_PARAM) List<String> includedIds)
@@ -191,7 +191,7 @@ public final class VirtualUnitResource extends
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -217,7 +217,7 @@ public final class VirtualUnitResource extends
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.VIRTUAL_UNIT)
     public Response createChildVirtualUnit(@PathParam("id") String id,
                                            Bundle bundle, @QueryParam(ACCESSOR_PARAM) List<String> accessors,

--- a/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -80,7 +80,7 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
@@ -88,14 +88,14 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response list() {
         return listItems();
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/list")
     @Override
     public Response listChildren(
@@ -115,7 +115,7 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response create(Bundle bundle,
             @QueryParam(ACCESSOR_PARAM) List<String> accessors)
@@ -129,7 +129,7 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}")
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
@@ -183,7 +183,7 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_XML})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/" + Entities.CVOC_CONCEPT)
     @Override
     public Response createChild(@PathParam("id") String id,


### PR DESCRIPTION
This alternative serialization format has not been used, and has always been a second-class citizen. Removing it simplifies the serialization code.