### PR TITLE
Add better I/O mappings for EAD separatedmaterial

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/exporters/ead/Ead2002Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/ead/Ead2002Exporter.java
@@ -73,6 +73,8 @@ public class Ead2002Exporter implements EadExporter {
             .put("appraisal", "appraisal")
             .put("archivalHistory", "custodhist")
             .put("physicalCharacteristics", "phystech")
+            .put("relatedUnitsOfDescription", "relatedmaterial")
+            .put("separatedUnitsOfDescription", "separatedmaterial")
             .put("notes", "odd") // controversial!
             .build();
 

--- a/ehri-io/src/main/resources/allowedNodeProperties.csv
+++ b/ehri-io/src/main/resources/allowedNodeProperties.csv
@@ -59,6 +59,7 @@ DocumentaryUnitDescription,processInfo,,,1
 DocumentaryUnitDescription,sources,,,1
 DocumentaryUnitDescription,sourceFileId,,1,
 DocumentaryUnitDescription,relatedUnitsOfDescription,,,1
+DocumentaryUnitDescription,separatedUnitsOfDescription,,,1
 DocumentaryUnitDescription,maintenanceEvent,,,1
 HistoricalAgentDescription,lastName,,,
 HistoricalAgentDescription,firstName,,,

--- a/ehri-io/src/main/resources/icaatom.properties
+++ b/ehri-io/src/main/resources/icaatom.properties
@@ -45,6 +45,10 @@ controlaccess/p/corpname/=corporateBodyAccessPoint
 controlaccess/p/geogname/=placeAccessPoint
 controlaccess/p/genreform/=genreAccessPoint
 did/unitdate/=unitDates
+relatedmaterial/=relatedUnitsOfDescription
+relatedmaterial/p/=relatedUnitsOfDescription
+separatedmaterial/=separatedUnitsOfDescription
+separatedmaterial/p/=separatedUnitsOfDescription
 #attributes
 @level=levelOfDesc
 @langcode=languagecode

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
@@ -54,6 +54,8 @@ public class Ead2002ExporterTest extends XmlExporterTest {
         assertXPath(doc, "Scope and contents note content no label |||\n\n" +
                         "Scope and contents note content |||",
                 "//ead/archdesc/scopecontent/p/text()");
+        assertXPath(doc, "Separated materials note content no label |||",
+                "//ead/archdesc/separatedmaterial[2]/p/text()");
         assertXPath(doc, "Series I",
                 "//ead/archdesc/dsc/c01/did/unitid/text()");
         assertXPath(doc, "Folder 3 |||",


### PR DESCRIPTION
This field maps on import and export to `separatedUnitsOfDescription`.