### PR TITLE
Add option to EAD ingest tools to make overwriting/updating explicit...

### DIFF
--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -85,6 +85,10 @@ public abstract class ImportCommand extends BaseCommand {
                 .desc("Don't error if a file is not valid.")
                 .build());
         options.addOption(Option.builder()
+                .longOpt("allow-updates")
+                .desc("Allow the ingest process to update existing items.")
+                .build());
+        options.addOption(Option.builder()
                 .longOpt("log")
                 .hasArg()
                 .type(String.class)
@@ -144,10 +148,11 @@ public abstract class ImportCommand extends BaseCommand {
             // because the import managers do transactional stuff that they
             // probably should not do.
             ImportLog log = new SaxImportManager(graph, scope, user,
+                    cmdLine.hasOption("tolerant"),
+                    cmdLine.hasOption("allow-updates"),
                     importer, handler,
                     optionalProperties,
                     Lists.<ImportCallback>newArrayList())
-                    .setTolerant(cmdLine.hasOption("tolerant"))
                     .importFiles(filePaths, logMessage);
             log.printReport();
 

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
@@ -68,6 +68,10 @@ public abstract class ImportCsvCommand extends BaseCommand {
                 .desc("Don't error if a file is not valid.")
                 .build());
         options.addOption(Option.builder()
+                .longOpt("allow-updates")
+                .desc("Allow the ingest process to update existing items.")
+                .build());
+        options.addOption(Option.builder()
                 .longOpt("log")
                 .hasArg()
                 .type(String.class)
@@ -86,6 +90,7 @@ public abstract class ImportCsvCommand extends BaseCommand {
         }
 
         boolean tolerant = cmdLine.hasOption("tolerant");
+        boolean allowUpdates = cmdLine.hasOption("allow-updates");
 
         if (cmdLine.getArgList().size() < 1)
             throw new RuntimeException(getUsage());
@@ -106,8 +111,8 @@ public abstract class ImportCsvCommand extends BaseCommand {
             UserProfile user = manager.getEntity(cmdLine.getOptionValue("user"),
                     UserProfile.class);
 
-            ImportLog log = new CsvImportManager(graph, scope, user, importer)
-                    .setTolerant(tolerant).importFiles(filePaths, logMessage);
+            ImportLog log = new CsvImportManager(graph, scope, user, tolerant, allowUpdates, importer)
+                    .importFiles(filePaths, logMessage);
 
             log.printReport();
             if (log.getErrored() > 0) {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/SaxXmlHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/SaxXmlHandler.java
@@ -310,23 +310,24 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
     }
 
     /**
-     * did/unitid/@ehrilabel$ehri_main_identifier=objectIdentifier
+     * did/unitid/{@literal @}ehrilabel$ehri_main_identifier=objectIdentifier
      *
-     * @param path           did/unitid/
-     * @param attribute      @ehrilabel
-     * @param attributevalue $ehri_main_identifier
+     * @param path      did/unitid/
+     * @param attribute {@literal @}ehrilabel
+     * @param value     $ehri_main_identifier
      * @return the corresponding value to this path from the properties file. The search is inside out, so if
      * both eadheader/ and ead/eadheader/ are specified, it will return the value for the first.
      * <p/>
      * If this path has no corresponding value in the properties file, it will return the entire path name, with _
      * replacing the /
      */
-    private String getImportantPath(Stack<String> path, String attribute, String attributevalue) {
+    private String getImportantPath(Stack<String> path, String attribute, String value) {
         String all = "";
         for (int i = path.size(); i > 0; i--) {
             all = path.get(i - 1) + "/" + all;
-            if (properties.getProperty(all + attribute + attributevalue) != null) {
-                return properties.getProperty(all + attribute + attributevalue);
+            String key = properties.getProperty(all + attribute + value);
+            if (key != null) {
+                return key;
             }
         }
         return UNKNOWN + all.replace("/", "_");
@@ -335,18 +336,21 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
     /**
      * If this path has no corresponding value in the properties file, it will return false
      * <p/>
-     * did/unitid/@ehrilabel$ehri_main_identifier=objectIdentifier
+     * did/unitid/{@literal @}ehrilabel$ehri_main_identifier=objectIdentifier
      *
-     * @param path           did/unitid/
-     * @param attribute      {@literal @}ehrilabel
-     * @param attributevalue $ehri_main_identifier
+     * @param path      did/unitid/
+     * @param attribute {@literal @}ehrilabel
+     * @param value     $ehri_main_identifier
      * @return returns true if this path is a key in the properties file.
      */
-    private boolean isKeyInPropertyFile(Stack<String> path, String attribute, String attributevalue) {
+    private boolean isKeyInPropertyFile(Stack<String> path, String attribute, String value) {
+        logger.trace("Checking for key in property file: {}, {}, {}", path, attribute, value);
         String all = "";
         for (int i = path.size(); i > 0; i--) {
             all = path.get(i - 1) + "/" + all;
-            if (properties.getProperty(all + attribute + attributevalue) != null) {
+            String key = all + attribute + value;
+            if (properties.getProperty(key) != null) {
+                logger.trace(" FOUND Path key: {}", key);
                 return true;
             }
         }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
@@ -266,7 +266,7 @@ public class EadHandler extends SaxXmlHandler {
                         }
                     }
                 } catch (ValidationError ex) {
-                    logger.error("caught validation error: {}", ex);
+                    logger.error("caught validation error", ex);
                 } finally {
                     depth--;
                     scopeIds.pop();

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
@@ -48,7 +48,6 @@ import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.persistence.BundleManager;
 import eu.ehri.project.persistence.Mutation;
 import eu.ehri.project.persistence.Serializer;
-import eu.ehri.project.views.LinkViews;
 import eu.ehri.project.views.impl.CrudViews;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +117,7 @@ public class EadImporter extends EaImporter {
         }
 
         for (Map<String, Object> dpb : extractMaintenanceEvent(itemData)) {
-            logger.info("maintenance event found");
+            logger.debug("maintenance event found {}", dpb);
             //dates in maintenanceEvents are no DatePeriods, they are not something to search on
             descBundle = descBundle.withRelation(Ontology.HAS_MAINTENANCE_EVENT,
                     new Bundle(EntityClass.MAINTENANCE_EVENT, dpb));
@@ -170,7 +169,7 @@ public class EadImporter extends EaImporter {
             }
         }
         handleCallbacks(mutation);
-        logger.debug("============== {} state: {}", frame.getIdentifier(), mutation.getState());
+        logger.debug("============== {} state: {}", frame.getId(), mutation.getState());
         if (mutation.created()) {
             solveUndeterminedRelationships(frame, descBundle);
         }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/IcaAtomEadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/IcaAtomEadHandler.java
@@ -56,7 +56,8 @@ public class IcaAtomEadHandler extends EadHandler {
         return new org.xml.sax.InputSource(new java.io.StringReader(""));
     }
 
-    public IcaAtomEadHandler(AbstractImporter<Map<String, Object>> importer, XmlImportProperties properties) {
+    public IcaAtomEadHandler(AbstractImporter<Map<String, Object>> importer,
+            XmlImportProperties properties) {
         super(importer, properties);
         children[depth] = Lists.newArrayList();
     }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/exceptions/ModeViolation.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/exceptions/ModeViolation.java
@@ -23,7 +23,7 @@ package eu.ehri.project.importers.exceptions;
  * Input data violates an import/export mode by altering data in
  * a way that was no foreseen.
  */
-public class ModeViolationException extends RuntimeException {
+public class ModeViolation extends RuntimeException {
     private static final long serialVersionUID = -5295648478089620968L;
 
     /**
@@ -31,7 +31,7 @@ public class ModeViolationException extends RuntimeException {
      *
      * @param message a description of the error
      */
-    public ModeViolationException(String message) {
+    public ModeViolation(String message) {
         super(message);
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/exceptions/ModeViolationException.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/exceptions/ModeViolationException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.importers.exceptions;
+
+/**
+ * Input data violates an import/export mode by altering data in
+ * a way that was no foreseen.
+ */
+public class ModeViolationException extends RuntimeException {
+    private static final long serialVersionUID = -5295648478089620968L;
+
+    /**
+     * Constructor.
+     *
+     * @param message a description of the error
+     */
+    public ModeViolationException(String message) {
+        super(message);
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.importers.managers;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.definitions.EventTypes;
 import eu.ehri.project.exceptions.ValidationError;
@@ -76,6 +77,7 @@ public abstract class AbstractImportManager implements ImportManager {
             boolean tolerant,
             boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass) {
+        Preconditions.checkNotNull(scope, "Scope cannot be null");
         this.framedGraph = graph;
         this.permissionScope = scope;
         this.actioner = actioner;

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -49,7 +49,8 @@ public abstract class AbstractImportManager implements ImportManager {
     protected final FramedGraph<?> framedGraph;
     protected final PermissionScope permissionScope;
     protected final Actioner actioner;
-    private boolean tolerant;
+    protected final boolean tolerant;
+    protected final boolean allowUpdates;
 
     // Ugly stateful variables for tracking import state
     // and reporting errors usefully...
@@ -60,29 +61,27 @@ public abstract class AbstractImportManager implements ImportManager {
     /**
      * Constructor.
      *
-     * @param graph    the framed graph
-     * @param scope    the permission scope
-     * @param actioner the actioner
+     * @param graph         the framed graph
+     * @param scope         the permission scope
+     * @param actioner      the actioner
+     * @param tolerant      allow individual items to fail validation without
+     *                      failing an entire batch
+     * @param allowUpdates  allow this import manager to update data items as well
+     *                      as create them
+     * @param importerClass the class of the item importer object
      */
     public AbstractImportManager(
             FramedGraph<?> graph,
-            PermissionScope scope, Actioner actioner, Class<? extends AbstractImporter> importerClass) {
+            PermissionScope scope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates,
+            Class<? extends AbstractImporter> importerClass) {
         this.framedGraph = graph;
         this.permissionScope = scope;
         this.actioner = actioner;
-        this.importerClass = importerClass;
-    }
-
-    /**
-     * Tell the importer to simply skip invalid items rather than throwing an
-     * exception.
-     *
-     * @param tolerant true means it won't validateData the xml file
-     */
-    public AbstractImportManager setTolerant(boolean tolerant) {
-        logger.info("Setting importer to tolerant: " + tolerant);
         this.tolerant = tolerant;
-        return this;
+        this.allowUpdates = allowUpdates;
+        this.importerClass = importerClass;
     }
 
     /**
@@ -127,7 +126,6 @@ public abstract class AbstractImportManager implements ImportManager {
     @Override
     public ImportLog importFiles(List<String> paths, String logMessage)
             throws IOException, ValidationError, InputParseError {
-
         try {
 
             Optional<String> msg = getLogMessage(logMessage);
@@ -213,7 +211,6 @@ public abstract class AbstractImportManager implements ImportManager {
     protected abstract void importFile(InputStream ios,
             ActionManager.EventContext eventContext, ImportLog log)
             throws IOException, ValidationError, InputParseError;
-
 
     // Helpers
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -30,6 +30,7 @@ import eu.ehri.project.importers.AbstractImporter;
 import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.exceptions.InputParseError;
+import eu.ehri.project.importers.exceptions.ModeViolationException;
 import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
@@ -56,8 +57,10 @@ public class CsvImportManager extends AbstractImportManager {
     private static final Logger logger = LoggerFactory.getLogger(CsvImportManager.class);
 
     public CsvImportManager(FramedGraph<?> framedGraph,
-            PermissionScope permissionScope, Actioner actioner, Class<? extends AbstractImporter> importerClass) {
-        super(framedGraph, permissionScope, actioner, importerClass);
+            PermissionScope permissionScope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates, Class<? extends AbstractImporter> importerClass) {
+        super(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass);
     }
 
     /**
@@ -88,6 +91,11 @@ public class CsvImportManager extends AbstractImportManager {
                             log.addCreated();
                             break;
                         case UPDATED:
+                            if (!allowUpdates) {
+                                throw new ModeViolationException(String.format(
+                                        "Item '%s' was updated but import manager does not allow updates",
+                                        mutation.getNode().getId()));
+                            }
                             logger.info("Item updated: {}", mutation.getNode().getId());
                             eventContext.addSubjects(mutation.getNode());
                             log.addUpdated();

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -30,7 +30,7 @@ import eu.ehri.project.importers.AbstractImporter;
 import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.exceptions.ModeViolationException;
+import eu.ehri.project.importers.exceptions.ModeViolation;
 import eu.ehri.project.importers.util.Helpers;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
@@ -92,7 +92,7 @@ public class CsvImportManager extends AbstractImportManager {
                             break;
                         case UPDATED:
                             if (!allowUpdates) {
-                                throw new ModeViolationException(String.format(
+                                throw new ModeViolation(String.format(
                                         "Item '%s' was updated but import manager does not allow updates",
                                         mutation.getNode().getId()));
                             }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/ImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/ImportManager.java
@@ -80,9 +80,9 @@ public interface ImportManager {
      * @param inputStream the archive input stream
      * @param logMessage  an optional log message to describe the import
      * @return an ImportLog for the given stream
-     * @throws IOException     when reading or writing fails
-     * @throws InputParseError when parsing the stream data fails
-     * @throws ValidationError when the content of the file is invalid
+     * @throws IOException            when reading or writing fails
+     * @throws InputParseError        when parsing the stream data fails
+     * @throws ValidationError        when the content of the file is invalid
      */
     ImportLog importFiles(ArchiveInputStream inputStream, String logMessage)
             throws IOException, InputParseError, ValidationError;

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -69,7 +69,8 @@ public class SaxImportManager extends AbstractImportManager {
      * @param actioner the actioner
      */
     public SaxImportManager(FramedGraph<?> graph,
-            PermissionScope scope, Actioner actioner,
+            PermissionScope scope,
+            Actioner actioner,
             boolean tolerant,
             boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
@@ -121,17 +122,14 @@ public class SaxImportManager extends AbstractImportManager {
 
     /**
      * Constructor.
-     *
-     * @param graph    the framed graph
+     *  @param graph    the framed graph
      * @param scope    a permission scope
      * @param actioner the actioner
      */
     public SaxImportManager(FramedGraph<?> graph,
             PermissionScope scope, Actioner actioner,
-            boolean tolerant,
-            boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
-        this(graph, scope, actioner, tolerant, allowUpdates, importerClass, handlerClass, Lists
+        this(graph, scope, actioner, false, false, importerClass, handlerClass, Lists
                 .<ImportCallback>newArrayList());
     }
 
@@ -220,7 +218,7 @@ public class SaxImportManager extends AbstractImportManager {
 
     public SaxImportManager withProperties(String properties) {
         if (properties == null) {
-            return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass,
+            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass,
                     handlerClass);
         } else {
             XmlImportProperties xmlImportProperties = new XmlImportProperties(properties);
@@ -236,6 +234,11 @@ public class SaxImportManager extends AbstractImportManager {
 
     public SaxImportManager allowUpdates(boolean allowUpdates) {
         return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant,
+                allowUpdates, importerClass, handlerClass, properties, extraCallbacks);
+    }
+
+    public SaxImportManager withScope(PermissionScope scope) {
+        return new SaxImportManager(framedGraph, scope, actioner, tolerant,
                 allowUpdates, importerClass, handlerClass, properties, extraCallbacks);
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -29,6 +29,7 @@ import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.SaxXmlHandler;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.exceptions.InvalidXmlDocument;
+import eu.ehri.project.importers.exceptions.ModeViolationException;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
@@ -37,7 +38,6 @@ import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.persistence.Mutation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -45,9 +45,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -72,10 +70,12 @@ public class SaxImportManager extends AbstractImportManager {
      */
     public SaxImportManager(FramedGraph<?> graph,
             PermissionScope scope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             Optional<XmlImportProperties> properties,
             List<ImportCallback> callbacks) {
-        super(graph, scope, actioner, importerClass);
+        super(graph, scope, actioner, tolerant, allowUpdates, importerClass);
         this.handlerClass = handlerClass;
         this.properties = properties;
         this.extraCallbacks = Lists.newArrayList(callbacks);
@@ -92,9 +92,13 @@ public class SaxImportManager extends AbstractImportManager {
      */
     public SaxImportManager(FramedGraph<?> graph,
             PermissionScope scope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             List<ImportCallback> callbacks) {
-        this(graph, scope, actioner, importerClass, handlerClass, Optional.<XmlImportProperties>absent(), callbacks);
+        this(graph, scope, actioner, tolerant, allowUpdates, importerClass, handlerClass, Optional
+                        .<XmlImportProperties>absent(),
+                callbacks);
     }
 
     /**
@@ -106,9 +110,12 @@ public class SaxImportManager extends AbstractImportManager {
      */
     public SaxImportManager(FramedGraph<?> graph,
             PermissionScope scope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             XmlImportProperties properties) {
-        this(graph, scope, actioner, importerClass, handlerClass, Optional.fromNullable(properties),
+        this(graph, scope, actioner, tolerant, allowUpdates, importerClass, handlerClass, Optional.fromNullable
+                        (properties),
                 Lists.<ImportCallback>newArrayList());
     }
 
@@ -121,8 +128,11 @@ public class SaxImportManager extends AbstractImportManager {
      */
     public SaxImportManager(FramedGraph<?> graph,
             PermissionScope scope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates,
             Class<? extends AbstractImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
-        this(graph, scope, actioner, importerClass, handlerClass, Lists.<ImportCallback>newArrayList());
+        this(graph, scope, actioner, tolerant, allowUpdates, importerClass, handlerClass, Lists
+                .<ImportCallback>newArrayList());
     }
 
     /**
@@ -139,7 +149,6 @@ public class SaxImportManager extends AbstractImportManager {
     @Override
     protected void importFile(InputStream ios, final ActionManager.EventContext eventContext,
             final ImportLog log) throws IOException, ValidationError, InputParseError {
-
         try {
             AbstractImporter<Map<String, Object>> importer = importerClass
                     .getConstructor(FramedGraph.class, PermissionScope.class,
@@ -160,6 +169,11 @@ public class SaxImportManager extends AbstractImportManager {
                             log.addCreated();
                             break;
                         case UPDATED:
+                            if (!allowUpdates) {
+                                throw new ModeViolationException(String.format(
+                                        "Item '%s' was updated but import manager does not allow updates",
+                                            mutation.getNode().getId()));
+                            }
                             logger.info("Item updated: {}", mutation.getNode().getId());
                             eventContext.addSubjects(mutation.getNode());
                             log.addUpdated();
@@ -193,23 +207,35 @@ public class SaxImportManager extends AbstractImportManager {
             logger.error("{}: {}", e.getMessage(), e);
             throw new RuntimeException(e);
         } catch (SAXException e) {
-            logger.error("SAXException: " + e.getMessage());
-            throw new InputParseError(e);
+            if (e.getCause().getClass().equals(ValidationError.class)) {
+                if (isTolerant()) {
+                    logger.error("Validation error:", e.getCause());
+                }
+            } else {
+                logger.error("SAXException: " + e.getMessage());
+                throw new InputParseError(e);
+            }
         }
-    }
-
-    public SaxImportManager withProperties(XmlImportProperties properties) {
-        return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass,
-                Optional.of(properties), extraCallbacks);
     }
 
     public SaxImportManager withProperties(String properties) {
         if (properties == null) {
-            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass);
+            return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass,
+                    handlerClass);
         } else {
             XmlImportProperties xmlImportProperties = new XmlImportProperties(properties);
-            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass,
-                    Optional.of(xmlImportProperties), extraCallbacks);
+            return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass,
+                    handlerClass, Optional.of(xmlImportProperties), extraCallbacks);
         }
+    }
+
+    public SaxImportManager setTolerant(boolean tolerant) {
+        return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant,
+                allowUpdates, importerClass, handlerClass, properties, extraCallbacks);
+    }
+
+    public SaxImportManager allowUpdates(boolean allowUpdates) {
+        return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant,
+                allowUpdates, importerClass, handlerClass, properties, extraCallbacks);
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -29,7 +29,7 @@ import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.SaxXmlHandler;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.exceptions.InvalidXmlDocument;
-import eu.ehri.project.importers.exceptions.ModeViolationException;
+import eu.ehri.project.importers.exceptions.ModeViolation;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
@@ -168,7 +168,7 @@ public class SaxImportManager extends AbstractImportManager {
                             break;
                         case UPDATED:
                             if (!allowUpdates) {
-                                throw new ModeViolationException(String.format(
+                                throw new ModeViolation(String.format(
                                         "Item '%s' was updated but import manager does not allow updates",
                                             mutation.getNode().getId()));
                             }
@@ -218,8 +218,8 @@ public class SaxImportManager extends AbstractImportManager {
 
     public SaxImportManager withProperties(String properties) {
         if (properties == null) {
-            return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass,
-                    handlerClass);
+            return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant, allowUpdates,
+                    importerClass, handlerClass, Optional.<XmlImportProperties>absent(), extraCallbacks);
         } else {
             XmlImportProperties xmlImportProperties = new XmlImportProperties(properties);
             return new SaxImportManager(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass,

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
@@ -46,7 +46,7 @@ public class Eac2010ExporterTest extends XmlExporterTest {
         AuthoritativeSet auths = manager.getEntity("auths", AuthoritativeSet.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("abwehr.xml");
         String logMessage = "Test EAC import/export";
-        new SaxImportManager(graph, auths, validUser, false, false,
+        new SaxImportManager(graph, auths, validUser,
                 EacImporter.class, EacHandler.class)
                 .importFile(ios, logMessage);
         HistoricalAgent repo = graph.frame(getVertexByIdentifier(graph, "381"), HistoricalAgent.class);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
@@ -45,10 +45,10 @@ public class Eac2010ExporterTest extends XmlExporterTest {
     public void testImportExport1() throws Exception {
         AuthoritativeSet auths = manager.getEntity("auths", AuthoritativeSet.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("abwehr.xml");
-        SaxImportManager importManager = new SaxImportManager(graph, auths, validUser, EacImporter.class, EacHandler
-                .class);
         String logMessage = "Test EAC import/export";
-        importManager.importFile(ios, logMessage);
+        new SaxImportManager(graph, auths, validUser, false, false,
+                EacImporter.class, EacHandler.class)
+                .importFile(ios, logMessage);
         HistoricalAgent repo = graph.frame(getVertexByIdentifier(graph, "381"), HistoricalAgent.class);
         String xml = testExport(repo, "eng");
         Document doc = parseDocument(xml);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
@@ -3,7 +3,6 @@ package eu.ehri.project.exporters.ead;
 import eu.ehri.project.exporters.test.XmlExporterTest;
 import eu.ehri.project.importers.ead.IcaAtomEadHandler;
 import eu.ehri.project.importers.ead.IcaAtomEadImporter;
-import eu.ehri.project.importers.managers.ImportManager;
 import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
@@ -56,7 +55,7 @@ public class Ead2002ExporterTest extends XmlExporterTest {
                 "//ead/archdesc/scopecontent/p/text()");
         assertXPath(doc, "Separated materials note content no label |||",
                 "//ead/archdesc/separatedmaterial[2]/p/text()");
-        assertXPath(doc, "Series I",
+        assertXPath(doc, "Series I |||",
                 "//ead/archdesc/dsc/c01/did/unitid/text()");
         assertXPath(doc, "Folder 3 |||",
                 "//ead/archdesc/dsc/c01[3]/c02[2]/did/unitid/text()");
@@ -111,9 +110,10 @@ public class Ead2002ExporterTest extends XmlExporterTest {
     private String testImportExport(Repository repository, String resourceName,
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
-        ImportManager importManager = new SaxImportManager(graph, repository, validUser,
-                false, true, IcaAtomEadImporter.class, IcaAtomEadHandler.class);
-        importManager.importFile(ios, "Testing import/export");
+        new SaxImportManager(graph, repository, validUser,
+                IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+                //.allowUpdates(true)
+                .importFile(ios, "Testing import/export");
 
         DocumentaryUnit fonds = graph.frame(
                 getVertexByIdentifier(graph, topLevelIdentifier), DocumentaryUnit.class);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
@@ -112,7 +112,7 @@ public class Ead2002ExporterTest extends XmlExporterTest {
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
         ImportManager importManager = new SaxImportManager(graph, repository, validUser,
-                IcaAtomEadImporter.class, IcaAtomEadHandler.class);
+                false, true, IcaAtomEadImporter.class, IcaAtomEadHandler.class);
         importManager.importFile(ios, "Testing import/export");
 
         DocumentaryUnit fonds = graph.frame(

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
@@ -28,7 +28,7 @@ public class Eag2012ExporterTest extends XmlExporterTest {
         Country nl = manager.getEntity("nl", Country.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("eag-2896.xml");
         SaxImportManager importManager = new SaxImportManager(graph, nl, validUser,
-                false, false, EagImporter.class, EagHandler.class);
+                EagImporter.class, EagHandler.class);
         importManager.importFile(ios, "Text EAG import/export");
         Repository repo = graph.frame(getVertexByIdentifier(graph, "NL-002896"), Repository.class);
         testExport(repo, "eng");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
@@ -27,8 +27,8 @@ public class Eag2012ExporterTest extends XmlExporterTest {
     public void testImportExport1() throws Exception {
         Country nl = manager.getEntity("nl", Country.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("eag-2896.xml");
-        SaxImportManager importManager = new SaxImportManager(graph, nl, validUser, EagImporter.class, EagHandler
-                .class);
+        SaxImportManager importManager = new SaxImportManager(graph, nl, validUser,
+                false, false, EagImporter.class, EagHandler.class);
         importManager.importFile(ios, "Text EAG import/export");
         Repository repo = graph.frame(getVertexByIdentifier(graph, "NL-002896"), Repository.class);
         testExport(repo, "eng");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/test/XmlExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/test/XmlExporterTest.java
@@ -2,7 +2,6 @@ package eu.ehri.project.exporters.test;
 
 import com.google.common.io.Resources;
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Before;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;

--- a/ehri-io/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/AbstractImporterTest.java
@@ -23,16 +23,14 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
-
 import eu.ehri.project.definitions.Ontology;
-import eu.ehri.project.importers.managers.AbstractImportManager;
+import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.cvoc.Concept;
 import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.test.AbstractFixtureTest;
-
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -46,23 +44,31 @@ public class AbstractImporterTest extends AbstractFixtureTest {
     private static final Logger logger = LoggerFactory.getLogger(AbstractImporterTest.class);
 
     /**
-     * Shared import manager
-     */
-    protected AbstractImportManager importManager;
-
-    /**
      * Action Manager
      */
     protected ActionManager actionManager;
 
     /**
-     * Test repository, initialised in test setup using TEST_REPO identifier.
+     * Test repository, initialised in test setup using TEST_USER identifier.
      */
     protected Repository repository;
     /**
      * Test repository identifier. Depends on fixtures
      */
     protected final String TEST_REPO = "r1";
+
+    /**
+     * Convenience method for creating a Sax import manager.
+     */
+    protected SaxImportManager saxImportManager(Class<? extends AbstractImporter> importerClass, Class<? extends
+            SaxXmlHandler> handlerClass) {
+        return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass);
+    }
+
+    protected SaxImportManager saxImportManager(Class<? extends AbstractImporter> importerClass, Class<? extends
+            SaxXmlHandler> handlerClass, String propertiesResource) {
+        return saxImportManager(importerClass, handlerClass).withProperties(propertiesResource);
+    }
 
     /**
      * Calls setUp in superclass and initialises the repository
@@ -77,14 +83,14 @@ public class AbstractImporterTest extends AbstractFixtureTest {
 
     /**
      * Resets the shared import manager after a Test.
-     * @throws Exception 
+     *
+     * @throws Exception
      */
     @After
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
         logger.debug("Cleaning up after test: reset importManager");
-        importManager = null;
     }
 
     protected void printGraph(FramedGraph<?> graph) {
@@ -147,11 +153,12 @@ public class AbstractImporterTest extends AbstractFixtureTest {
 
     /**
      * Get a Vertex from the FramedGraph using its unit ID.
-     * @see {@link eu.ehri.project.definitions.Ontology#IDENTIFIER_KEY}
-     * @param graph the graph to search
+     *
+     * @param graph      the graph to search
      * @param identifier the Vertex's 'human readable' identifier
      * @return the first Vertex with the given identifier
      * @throws NoSuchElementException when there are no vertices with this identifier
+     * @see {@link eu.ehri.project.definitions.Ontology#IDENTIFIER_KEY}
      */
     protected Vertex getVertexByIdentifier(FramedGraph<?> graph, String identifier) {
         Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY, identifier);
@@ -160,11 +167,12 @@ public class AbstractImporterTest extends AbstractFixtureTest {
 
     /**
      * Get a Vertex from the FramedGraph using its graph ID.
-     * @see {@link eu.ehri.project.models.annotations.EntityType#ID_KEY}
+     *
      * @param graph the graph to search
-     * @param id the Vertex's generated, slugified identifier
+     * @param id    the Vertex's generated, slugified identifier
      * @return the first Vertex with the given identifier
      * @throws NoSuchElementException when there are no vertices with this identifier
+     * @see {@link eu.ehri.project.models.annotations.EntityType#ID_KEY}
      */
     protected Vertex getVertexById(FramedGraph<?> graph, String id) {
         Iterable<Vertex> docs = graph.getVertices(EntityType.ID_KEY, id);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthItemImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthItemImporterTest.java
@@ -58,7 +58,7 @@ public class CsvAuthItemImporterTest extends AbstractImporterTest {
 
         List<VertexProxy> graphState1 = getGraphState(graph);
         ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser,
-                CsvAuthoritativeItemImporter.class).importFile(ios, logMessage);
+                false, false, CsvAuthoritativeItemImporter.class).importFile(ios, logMessage);
         assertEquals(9, log.getCreated());
         printGraph(graph);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
@@ -63,8 +63,8 @@ public class CsvConceptImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser, CsvConceptImporter.class).importFile(ios, logMessage);
-        System.out.println(Iterables.toList(authoritativeSet.getAuthoritativeItems()));
+        ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser, true, false, CsvConceptImporter.class)
+                .importFile(ios, logMessage);
         /*
          * 18 Concept
          * 18 ConceptDesc

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
@@ -63,7 +63,7 @@ public class CsvConceptImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser, true, false, CsvConceptImporter.class)
+        new CsvImportManager(graph, authoritativeSet, validUser, true, false, CsvConceptImporter.class)
                 .importFile(ios, logMessage);
         /*
          * 18 Concept

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
@@ -50,7 +50,7 @@ public class CsvDossinImporterTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, ps, validUser, EadImporter.class).importFile(ios, logMessage);
+        new CsvImportManager(graph, ps, validUser, false, false, EadImporter.class).importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
@@ -55,7 +55,8 @@ public class PersonalitiesImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, authoritativeSet, validUser, PersonalitiesImporter.class).importFile(ios, logMessage);
+        new CsvImportManager(graph, authoritativeSet, validUser, false, false,
+                PersonalitiesImporter.class).importFile(ios, logMessage);
         SystemEvent ev = actionManager.getLatestGlobalEvent();
 
         /*

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/UkrainianUnitImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/UkrainianUnitImporterTest.java
@@ -63,7 +63,8 @@ public class UkrainianUnitImporterTest extends AbstractImporterTest {
         assertTrue(p.containsProperty("project_judaica"));
         
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new CsvImportManager(graph, repo, validUser, UkrainianUnitImporter.class)
+        ImportLog log = new CsvImportManager(graph, repo, validUser, false, false,
+                    UkrainianUnitImporter.class)
                 .importFile(ios, logMessage);
         assertTrue(log.hasDoneWork());
 
@@ -76,7 +77,5 @@ public class UkrainianUnitImporterTest extends AbstractImporterTest {
          */
         assertEquals(count + 76, getNodeCount(graph));
         printGraph(graph);
-//        assertEquals(voccount + 8, toList(authoritativeSet.getAuthoritativeItems()).size());
-       
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/Wp2PersonalitiesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/Wp2PersonalitiesImporterTest.java
@@ -53,7 +53,9 @@ public class Wp2PersonalitiesImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, authoritativeSet, validUser, PersonalitiesImporter.class).importFile(ios, logMessage);
+        new CsvImportManager(graph, authoritativeSet, validUser,
+                false, false, PersonalitiesImporter.class)
+                .importFile(ios, logMessage);
 
         /*
          * 16 HistAgent

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractSkosTest extends AbstractFixtureTest {
             for (String key : v.getPropertyKeys()) {
                 String value = "";
                 if (v.getProperty(key) instanceof String[]) {
-                    String[] list = (String[]) v.getProperty(key);
+                    String[] list = v.getProperty(key);
                     for (String o : list) {
                         value += "[" + o + "] ";
                     }
@@ -75,5 +75,4 @@ public abstract class AbstractSkosTest extends AbstractFixtureTest {
             }
         }
     }
-
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
@@ -23,7 +23,6 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.models.Link;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Linkable;
@@ -64,19 +63,18 @@ public class JoodsRaadTest extends AbstractImporterTest {
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
-        ImportLog log = importer.importFile(ios, logMessage);
-//        log.printReport();
+        importer.importFile(ios, logMessage);
+
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);
         diff.printDebug(System.out);
 
 
-//        printGraph(graph);
         /*  How many new nodes will have been created? We should have
          * 5 more Concepts
        	 * 9 more ConceptDescription
-	 * 6 more import Event links 
+     	 * 6 more import Event links
          * 1 more import Event
          */
         assertEquals(count + 21, getNodeCount(graph));
@@ -110,9 +108,9 @@ public class JoodsRaadTest extends AbstractImporterTest {
 
         Vocabulary cvoc1 = manager.getEntity("cvoc1", Vocabulary.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream(EHRI_SKOS_TERM);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, cvoc1);
-        importer.setTolerant(true);
-        ImportLog log = importer.importFile(ios, logMessage);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, cvoc1)
+                .setTolerant(true);
+        importer.importFile(ios, logMessage);
 
 
         int count = getNodeCount(graph);
@@ -134,7 +132,6 @@ public class JoodsRaadTest extends AbstractImporterTest {
         diff.printDebug(System.out);
 
 
-//        printGraph(graph);
         /*  How many new nodes will have been created? We should have
          * 1 more Concepts
        	 * 1 more ConceptDescription

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/SkosImporterAdminDistrictTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/SkosImporterAdminDistrictTest.java
@@ -42,7 +42,7 @@ public class SkosImporterAdminDistrictTest extends AbstractImporterTest {
     @Test
     public void testImportItemsT() throws Exception {
         UserProfile user = validUser; //graph.frame(graph.getVertex(validUserId), UserProfile.class);
-        Repository agent = manager.getEntity(TEST_REPO, Repository.class); //graph.frame(helper.getTestVertex(TEST_REPO), Repository.class);
+        Repository agent = manager.getEntity(TEST_REPO, Repository.class); //graph.frame(helper.getTestVertex(TEST_USER), Repository.class);
 
         final String logMessage = "Importing a single skos: " + SINGLE_SKOS;
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/EacImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/EacImporterTest.java
@@ -25,7 +25,6 @@ import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.HistoricalAgentDescription;
 import eu.ehri.project.models.base.Accessible;
@@ -58,8 +57,8 @@ public class EacImporterTest extends AbstractImporterTest {
 
         // Before...
         List<VertexProxy> graphState1 = GraphTestBase.getGraphState(graph);
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false,
-                    EacImporter.class, EacHandler.class)
+        saxImportManager(EacImporter.class, EacHandler.class)
+                .withScope(SystemScope.getInstance())
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = GraphTestBase.getGraphState(graph);
@@ -98,8 +97,8 @@ public class EacImporterTest extends AbstractImporterTest {
         List<VertexProxy> before = GraphTestBase.getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(eacFile);
-        ImportLog log = new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false,
-                    EacImporter.class, EacHandler.class)
+        ImportLog log = saxImportManager(EacImporter.class, EacHandler.class)
+                .withScope(SystemScope.getInstance())
                 .importFile(ios, logMessage);
 
         List<VertexProxy> after = GraphTestBase.getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/EacImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/EacImporterTest.java
@@ -58,8 +58,9 @@ public class EacImporterTest extends AbstractImporterTest {
 
         // Before...
         List<VertexProxy> graphState1 = GraphTestBase.getGraphState(graph);
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
+        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false,
+                    EacImporter.class, EacHandler.class)
+                .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = GraphTestBase.getGraphState(graph);
         GraphDiff diff = GraphTestBase.diffGraph(graphState1, graphState2);
@@ -97,8 +98,9 @@ public class EacImporterTest extends AbstractImporterTest {
         List<VertexProxy> before = GraphTestBase.getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(eacFile);
-        ImportLog log = new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false,
+                    EacImporter.class, EacHandler.class)
+                .importFile(ios, logMessage);
 
         List<VertexProxy> after = GraphTestBase.getGraphState(graph);
         GraphTestBase.diffGraph(before, after).printDebug(System.err);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
@@ -26,8 +26,6 @@ import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
@@ -61,16 +59,16 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
 
     @Test
     public void newPersonalitiesWithoutCreatedBy() throws Exception {
-        final String SINGLE_EAC = "PersonalitiesV2withoutCreatedBy.xml";
-        final String logMessage = "Importing EAC " + SINGLE_EAC;
-        InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAC);
+        final String file = "PersonalitiesV2withoutCreatedBy.xml";
+        final String logMessage = "Importing EAC " + file;
+        InputStream ios = ClassLoader.getSystemResourceAsStream(file);
         int count = getNodeCount(graph);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false, EacImporter.class,
-                EacHandler.class, new XmlImportProperties(PROPERTIES))
+        saxImportManager(EacImporter.class, EacHandler.class, PROPERTIES)
+                .withScope(SystemScope.getInstance())
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -110,8 +108,8 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false, EacImporter.class,
-                EacHandler.class, new XmlImportProperties(PROPERTIES))
+        saxImportManager(EacImporter.class, EacHandler.class, PROPERTIES)
+                .withScope(SystemScope.getInstance())
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -162,8 +160,8 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false, EacImporter.class,
-                EacHandler.class, new XmlImportProperties(PROPERTIES))
+        saxImportManager(EacImporter.class, EacHandler.class, PROPERTIES)
+                .withScope(SystemScope.getInstance())
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
@@ -69,8 +69,8 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class, new XmlImportProperties(PROPERTIES)).setTolerant(Boolean.TRUE)
+        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false, EacImporter.class,
+                EacHandler.class, new XmlImportProperties(PROPERTIES))
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -110,8 +110,8 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class, new XmlImportProperties(PROPERTIES)).setTolerant(Boolean.TRUE)
+        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false, EacImporter.class,
+                EacHandler.class, new XmlImportProperties(PROPERTIES))
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -162,8 +162,8 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, SystemScope.getInstance(), validUser, EacImporter.class,
-                EacHandler.class, new XmlImportProperties(PROPERTIES)).setTolerant(Boolean.TRUE)
+        new SaxImportManager(graph, SystemScope.getInstance(), validUser, true, false, EacImporter.class,
+                EacHandler.class, new XmlImportProperties(PROPERTIES))
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveSplitTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveSplitTest.java
@@ -25,8 +25,6 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
@@ -45,14 +43,12 @@ import static org.junit.Assert.assertTrue;
 
 public class BundesarchiveSplitTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "BA_split.xml";
     protected final String ARCHDESC = "NS 1";
 
     @Test
     public void bundesarchiveTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of the Split Bundesarchive EAD";
 
         int origCount = getNodeCount(graph);
@@ -60,8 +56,7 @@ public class BundesarchiveSplitTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("bundesarchive.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "bundesarchive.properties")
                 .importFile(ios, logMessage);
 
         // After...
@@ -92,8 +87,8 @@ public class BundesarchiveSplitTest extends AbstractImporterTest {
         assertTrue(archUnit.getPropertyKeys().contains(Ontology.OTHER_IDENTIFIERS));
 
         assertNull(archUnit.getParent());
-        assertEquals(agent, archUnit.getRepository());
-        assertEquals(agent, archUnit.getPermissionScope());
+        assertEquals(repository, archUnit.getRepository());
+        assertEquals(repository, archUnit.getPermissionScope());
 
         //test titles
         for (DocumentaryUnitDescription d : archUnit.getDocumentDescriptions()) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveSplitTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveSplitTest.java
@@ -60,9 +60,9 @@ public class BundesarchiveSplitTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser,
-                EadImporter.class, EadHandler.class,
-                new XmlImportProperties("bundesarchive.properties")).importFile(ios, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("bundesarchive.properties"))
+                .importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveVcTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveVcTest.java
@@ -24,11 +24,8 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.VirtualUnit;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -40,25 +37,21 @@ import static org.junit.Assert.assertEquals;
 
 public class BundesarchiveVcTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "BA_split.xml";
     protected final String VCFILE = "BA_vc.xml";
     protected final String ARCHDESC = "NS 1";
-    int origCount = 0;
 
     @Test
     public void bundesarchiveTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of the Split Bundesarchive EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("bundesarchive.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "bundesarchive.properties")
                 .importFile(ios, logMessage);
 
         // After...
@@ -84,8 +77,7 @@ public class BundesarchiveVcTest extends AbstractImporterTest {
                 DocumentaryUnit.class);
 
         InputStream iosvc = ClassLoader.getSystemResourceAsStream(VCFILE);
-        new SaxImportManager(graph, agent, validUser, false, false, VirtualEadImporter.class,
-                VirtualEadHandler.class, new XmlImportProperties("vc.properties"))
+        saxImportManager(VirtualEadImporter.class, VirtualEadHandler.class, "vc.properties")
                 .importFile(iosvc, logMessage);
         printGraph(graph);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveVcTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveVcTest.java
@@ -57,7 +57,7 @@ public class BundesarchiveVcTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser,
+        new SaxImportManager(graph, agent, validUser, false, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("bundesarchive.properties"))
                 .importFile(ios, logMessage);
 
@@ -84,7 +84,7 @@ public class BundesarchiveVcTest extends AbstractImporterTest {
                 DocumentaryUnit.class);
 
         InputStream iosvc = ClassLoader.getSystemResourceAsStream(VCFILE);
-        new SaxImportManager(graph, agent, validUser, VirtualEadImporter.class,
+        new SaxImportManager(graph, agent, validUser, false, false, VirtualEadImporter.class,
                 VirtualEadHandler.class, new XmlImportProperties("vc.properties"))
                 .importFile(iosvc, logMessage);
         printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAATest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAATest.java
@@ -68,7 +68,7 @@ public class CegesomaAATest extends AbstractImporterTest {
         origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class,
+        new SaxImportManager(graph, agent, validUser, true, false, EadImporter.class,
                 EadHandler.class, new XmlImportProperties("cegesomaAA.properties"))
                 .importFile(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAATest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAATest.java
@@ -24,14 +24,11 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.MaintenanceEvent;
 import eu.ehri.project.models.MaintenanceEventType;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,26 +47,22 @@ import static org.junit.Assert.assertTrue;
  */
 public class CegesomaAATest extends AbstractImporterTest {
     private static final Logger logger = LoggerFactory.getLogger(CegesomaAATest.class);
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "CegesomaAA.pxml";
     protected final String ARCHDESC = "AA 1134",
             C01 = "1234",
             C02_01 = "AA 1134 / 32",
             C02_02 = "AA 1134 / 34";
     DocumentaryUnit archdesc, c1, c2_1, c2_2;
-    int origCount = 0;
 
     @Test
     public void cegesomaTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example Cegesoma EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, true, false, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("cegesomaAA.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "cegesomaAA.properties")
                 .importFile(ios, logMessage);
 
         // How many new nodes will have been created? We should have
@@ -128,8 +121,7 @@ public class CegesomaAATest extends AbstractImporterTest {
             assertEquals("Documenten betreffende l'Union nationale de la Résistance", dd.getName());
             assertEquals("nld", dd.getLanguageOfDescription());
             assertEquals("SOMA_CEGES_72695#NLD", dd.getProperty("sourceFileId"));
-//            TODO
-//            assertEquals(1, toList(dd.getMaintenanceEvents()).size());
+            assertEquals(1, toList(dd.getMaintenanceEvents()).size());
         }
 
         // There should be one DocumentDescription for the (second) <c02>

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaABTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaABTest.java
@@ -26,15 +26,12 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.Link;
 import eu.ehri.project.models.MaintenanceEvent;
 import eu.ehri.project.models.MaintenanceEventType;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -43,7 +40,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test the import of a Cegesoma AB EAD file.
@@ -51,22 +47,18 @@ import static org.junit.Assert.fail;
  */
 public class CegesomaABTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "CegesomaAB.xml";
     protected final String ARCHDESC = "AB 2029";
-    int origCount = 0;
 
     @Test
     public void cegesomaTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example Cegesoma EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("cegesomaAB.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "cegesomaAB.properties")
                 .importFile(ios, logMessage);
 
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaABTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaABTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test the import of a Cegesoma AB EAD file.
@@ -64,7 +65,7 @@ public class CegesomaABTest extends AbstractImporterTest {
         origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class,
+        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class,
                 EadHandler.class, new XmlImportProperties("cegesomaAB.properties"))
                 .importFile(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAraTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAraTest.java
@@ -64,8 +64,9 @@ public class CegesomaAraTest extends AbstractImporterTest {
         origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("cegesomaAA.properties"))
+        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, false, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("cegesomaAA.properties"));
+        importManager
                 .importFile(ios, logMessage);
 
         printGraph(graph);
@@ -106,8 +107,8 @@ public class CegesomaAraTest extends AbstractImporterTest {
         assertTrue(archdesc.<List<String>>getProperty(Ontology.OTHER_IDENTIFIERS).contains("AA 627"));
 
         InputStream ios_ara = ClassLoader.getSystemResourceAsStream(ARA_XMLFILE);
-        importManager = new SaxImportManager(graph, repository, validUser, AraEadImporter.class, EadHandler.class, new XmlImportProperties("ara.properties"))
-                .setTolerant(Boolean.TRUE);
+        importManager = new SaxImportManager(graph, repository, validUser, true, true,
+                AraEadImporter.class, EadHandler .class, new XmlImportProperties("ara.properties"));
 
         importManager.importFile(ios_ara, logMessage);
         for (String key : archdesc.getPropertyKeys()) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAraTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAraTest.java
@@ -45,7 +45,6 @@ import static org.junit.Assert.assertTrue;
 public class CegesomaAraTest extends AbstractImporterTest {
 
     private static final Logger logger = LoggerFactory.getLogger(CegesomaAraTest.class);
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "CegesomaAA.pxml";
     protected final String ARA_XMLFILE = "araEad.xml";
     protected final String ARCHDESC = "AA 1134",
@@ -53,7 +52,6 @@ public class CegesomaAraTest extends AbstractImporterTest {
             C02_01 = "AA 1134 / 32",
             C02_02 = "AA 1134 / 34";
     DocumentaryUnit archdesc, c1, c2_1, c2_2;
-    int origCount = 0;
 
     @Test
     public void cegesomaTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
@@ -61,11 +59,10 @@ public class CegesomaAraTest extends AbstractImporterTest {
         PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example Cegesoma EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("cegesomaAA.properties"));
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, "cegesomaAA.properties");
         importManager
                 .importFile(ios, logMessage);
 
@@ -107,10 +104,9 @@ public class CegesomaAraTest extends AbstractImporterTest {
         assertTrue(archdesc.<List<String>>getProperty(Ontology.OTHER_IDENTIFIERS).contains("AA 627"));
 
         InputStream ios_ara = ClassLoader.getSystemResourceAsStream(ARA_XMLFILE);
-        importManager = new SaxImportManager(graph, repository, validUser, true, true,
-                AraEadImporter.class, EadHandler .class, new XmlImportProperties("ara.properties"));
-
-        importManager.importFile(ios_ara, logMessage);
+        saxImportManager(AraEadImporter.class, EadHandler.class, "ara.properties")
+            .allowUpdates(true)
+            .importFile(ios_ara, logMessage);
         for (String key : archdesc.getPropertyKeys()) {
             logger.debug(key + " " + archdesc.getProperty(key));
         }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaCATest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaCATest.java
@@ -59,7 +59,7 @@ public class CegesomaCATest extends AbstractImporterTest {
 
         origCount = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE_NL);
-        ImportLog log = new SaxImportManager(graph, agent, validUser,
+        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false,
                 EadImporter.class, EadHandler.class,
                 new XmlImportProperties("cegesomaCA.properties")).importFile(ios, logMessage);
         assertTrue(log.hasDoneWork());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaCATest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaCATest.java
@@ -24,12 +24,9 @@ import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -46,22 +43,16 @@ import static org.junit.Assert.assertTrue;
  */
 public class CegesomaCATest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE_NL = "CS-foto-188845-nl.xml";
     protected final String ARCHDESC = "CA FE 1437";
-    int origCount;
 
     @Test
     public void cegesomaTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
-
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example Cegesoma EAD";
-
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE_NL);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, EadHandler.class,
-                new XmlImportProperties("cegesomaCA.properties")).importFile(ios, logMessage);
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, "cegesomaCA.properties")
+                .importFile(ios, logMessage);
         assertTrue(log.hasDoneWork());
         printGraph(graph);
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/DansEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/DansEadImporterTest.java
@@ -20,8 +20,6 @@
 package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import org.junit.Test;
@@ -38,8 +36,7 @@ public class DansEadImporterTest extends AbstractImporterTest {
     protected final String SINGLE_EAD = "dans_convertedead_part.xml";
 
     // Depends on fixtures
-    protected final String TEST_REPO = "r1",
-            ARCHDESC = "easy-collection:2",
+    protected final String ARCHDESC = "easy-collection:2",
             C1 = "urn:nbn:nl:ui:13-4i8-gpf",
             C2 = "urn:nbn:nl:ui:13-qa8-3r5";
 
@@ -52,8 +49,7 @@ public class DansEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("dansead.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "dansead.properties")
                 .importFile(ios, logMessage);
 
         // Before...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/DansEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/DansEadImporterTest.java
@@ -52,13 +52,12 @@ public class DansEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser,
+        new SaxImportManager(graph, repository, validUser, true, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("dansead.properties"))
-                .setTolerant(Boolean.TRUE);
+                .importFile(ios, logMessage);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
-        importManager.importFile(ios, logMessage);
         printGraph(graph);
 
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/FinlandXmlImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/FinlandXmlImporterTest.java
@@ -21,7 +21,6 @@ package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import org.junit.Test;
@@ -49,12 +48,10 @@ public class FinlandXmlImporterTest extends AbstractImporterTest {
         final String logMessage = "Importing a single EAD";
 
         int count = getNodeCount(graph);
-        System.out.println(count);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("finlandead.properties"));
-        importManager
-                .importFile(ios, logMessage);
+        SaxImportManager importManager = saxImportManager(
+                EadImporter.class, EadHandler.class, "finlandead.properties");
+        importManager.importFile(ios, logMessage);
 
         // After...
         int countAfter = getNodeCount(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/FinlandXmlImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/FinlandXmlImporterTest.java
@@ -51,10 +51,10 @@ public class FinlandXmlImporterTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         System.out.println(count);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("finlandead.properties"))
-                .setTolerant(Boolean.TRUE);
-        // Before...
-        importManager.importFile(ios, logMessage);
+        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("finlandead.properties"));
+        importManager
+                .importFile(ios, logMessage);
 
         // After...
         int countAfter = getNodeCount(graph);
@@ -88,7 +88,7 @@ public class FinlandXmlImporterTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
         //import the english version:
         ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_ENG);
-        importManager.importFile(ios, logMessage);
+        importManager.allowUpdates(true).importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);
@@ -132,7 +132,7 @@ public class FinlandXmlImporterTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1a = getGraphState(graph);
         ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_ENG);
-        importManager.importFile(ios, logMessage);
+        importManager.allowUpdates(true).importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2a = getGraphState(graph);
         GraphDiff diffa = diffGraph(graphState1a, graphState2a);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/GenericEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/GenericEadImporterTest.java
@@ -44,13 +44,12 @@ public class GenericEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser,
+        new SaxImportManager(graph, repository, validUser, true, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("ara.properties"))
-                .setTolerant(Boolean.TRUE);
+                .importFile(ios, logMessage);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
-        importManager.importFile(ios, logMessage);
         printGraph(graph);
 
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/GenericEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/GenericEadImporterTest.java
@@ -20,9 +20,6 @@
 package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -33,9 +30,6 @@ public class GenericEadImporterTest extends AbstractImporterTest {
 
     protected final String SINGLE_EAD = "genericEad.xml";
 
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-
     @Test
     public void testImportItemsT() throws Exception {
 
@@ -44,8 +38,7 @@ public class GenericEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("ara.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "ara.properties")
                 .importFile(ios, logMessage);
 
         // Before...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadImporterTest.java
@@ -24,7 +24,6 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.managers.ImportManager;
-import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Accessible;
@@ -44,8 +43,7 @@ import static org.junit.Assert.assertTrue;
 public class IcaAtomEadImporterTest extends AbstractImporterTest {
     private static final Logger logger = LoggerFactory.getLogger(IcaAtomEadImporterTest.class);
     protected final String SINGLE_EAD = "hierarchical-ead.xml";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
+
     // Depends on hierarchical-ead.xml
     protected final String FONDS_LEVEL = "Ctop level fonds";
     protected final String SUBFONDS_LEVEL = "C00001";
@@ -61,10 +59,9 @@ public class IcaAtomEadImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportManager importManager = new SaxImportManager(graph, agent, validUser, true, false,
-                IcaAtomEadImporter.class, IcaAtomEadHandler.class);
+        ImportManager importManager = saxImportManager(IcaAtomEadImporter.class, IcaAtomEadHandler.class);
         ImportLog log = importManager.importFile(ios, logMessage);
-//        printGraph(graph);
+
 
         // How many new nodes will have been created? We should have
         // - 5 more DocumentaryUnits

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadImporterTest.java
@@ -61,8 +61,8 @@ public class IcaAtomEadImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportManager importManager = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class)
-                .setTolerant(Boolean.TRUE);
+        ImportManager importManager = new SaxImportManager(graph, agent, validUser, true, false,
+                IcaAtomEadImporter.class, IcaAtomEadHandler.class);
         ImportLog log = importManager.importFile(ios, logMessage);
 //        printGraph(graph);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadSingleEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadSingleEadTest.java
@@ -22,7 +22,6 @@ package eu.ehri.project.importers.ead;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Accessible;
@@ -40,9 +39,6 @@ import static org.junit.Assert.assertTrue;
 public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
     protected final String SINGLE_EAD = "single-ead.xml";
 
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-
     // Depends on single-ead.xml
     protected final String IMPORTED_ITEM_ID = "C00001";
 
@@ -54,8 +50,7 @@ public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
-                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        ImportLog log = saxImportManager(IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .importFile(ios, logMessage);
 
         printGraph(graph);
@@ -106,8 +101,7 @@ public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
 
         // Now re-import the same file
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log2 = new SaxImportManager(graph, agent, validUser, false, false,
-                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        ImportLog log2 = saxImportManager(IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .importFile(ios2, logMessage);
 
         // We should no new nodes (not even a SystemEvent)

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadSingleEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadSingleEadTest.java
@@ -54,7 +54,9 @@ public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
+                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+                .importFile(ios, logMessage);
 
         printGraph(graph);
         // How many new nodes will have been created? We should have
@@ -104,7 +106,9 @@ public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
 
         // Now re-import the same file
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log2 = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class).importFile(ios2, logMessage);
+        ImportLog log2 = new SaxImportManager(graph, agent, validUser, false, false,
+                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+                .importFile(ios2, logMessage);
 
         // We should no new nodes (not even a SystemEvent)
         assertEquals(createCount, getNodeCount(graph));

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomJohnCageTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomJohnCageTest.java
@@ -44,8 +44,9 @@ public class IcaAtomJohnCageTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(JOHNCAGEXML);
-        new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class,
-                IcaAtomEadHandler.class).importFile(ios, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false,
+                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+                .importFile(ios, logMessage);
         printGraph(graph);
 
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomJohnCageTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomJohnCageTest.java
@@ -20,8 +20,6 @@
 package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -32,20 +30,15 @@ import static org.junit.Assert.assertEquals;
 public class IcaAtomJohnCageTest extends AbstractImporterTest {
 
     protected final String JOHNCAGEXML = "johnCage.xml";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-    // Depends on hierarchical-ead.xml
 
     @Test
     public void testImportItemsT() throws Exception {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a single EAD";
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(JOHNCAGEXML);
-        new SaxImportManager(graph, agent, validUser, false, false,
-                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        saxImportManager(IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .importFile(ios, logMessage);
         printGraph(graph);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Description;
@@ -40,9 +39,6 @@ import static org.junit.Assert.assertTrue;
 public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
     protected final String SINGLE_EAD = "zbirka-gradiva-za-povijest-zidova-collection-of-material-concerning-history-of-jews.xml";
 
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-
     // Depends on single-ead.xml
     protected final String IMPORTED_ITEM_ID = "HR r000382HR HR-HDA 1551";
 
@@ -54,8 +50,7 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
-                IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        ImportLog log = saxImportManager(IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .importFile(ios, logMessage);
 
         printGraph(graph);
@@ -110,8 +105,7 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
 
         // Now re-import the same file
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log2 = new SaxImportManager(graph, agent, validUser, false, true,
-                    IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+        ImportLog log2 = saxImportManager(IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .importFile(ios2, logMessage);
 
         // We should have no new nodes, not even SystemEvent

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
@@ -54,7 +54,9 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, IcaAtomEadImporter.class, IcaAtomEadHandler.class).setTolerant(Boolean.TRUE).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
+                IcaAtomEadImporter.class, IcaAtomEadHandler.class)
+                .importFile(ios, logMessage);
 
         printGraph(graph);
         // How many new nodes will have been created? We should have
@@ -108,7 +110,7 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
 
         // Now re-import the same file
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log2 = new SaxImportManager(graph, agent, validUser,
+        ImportLog log2 = new SaxImportManager(graph, agent, validUser, false, true,
                     IcaAtomEadImporter.class, IcaAtomEadHandler.class)
                 .importFile(ios2, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IfzTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IfzTest.java
@@ -70,8 +70,8 @@ public class IfzTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("ifz.properties"))
+        new SaxImportManager(graph, agent, validUser, false, false,
+                    EadImporter.class, EadHandler.class, new XmlImportProperties("ifz.properties"))
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IfzTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IfzTest.java
@@ -28,12 +28,9 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -49,29 +46,25 @@ import static org.junit.Assert.assertFalse;
  */
 public class IfzTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "ifz_ED.xml";
     protected final String ARCHDESC = "G",
             C01 = "G_1",
             C02 = "G_2",
             C03_02 = "MB 35 / 10";
     DocumentaryUnit archdesc, c1, c2, c3_2;
-    int origCount = 0;
 
     @Test
     public void ifzTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example Ifz EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false,
-                    EadImporter.class, EadHandler.class, new XmlImportProperties("ifz.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "ifz.properties")
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IpnTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IpnTest.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+
 public class IpnTest extends AbstractImporterTest {
 
     private static final Logger logger = LoggerFactory.getLogger(IpnTest.class);
@@ -73,14 +74,17 @@ public class IpnTest extends AbstractImporterTest {
         final String logMessage = "Importing a part of the IPN Virtual Collection";
 
         InputStream ios1 = ClassLoader.getSystemResourceAsStream(BRANCH_1_XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios1, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new
+                XmlImportProperties("polishBranch.properties")).importFile(ios1, logMessage);
 
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(BRANCH_2_XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios2, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties"))
+                .importFile(ios2, logMessage);
 
         origCount = getNodeCount(graph);
         InputStream iosVc = ClassLoader.getSystemResourceAsStream(VC_XMLFILE);
-        new SaxImportManager(graph, agent, validUser, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc.properties")).importFile(iosVc, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc.properties"))
+                .importFile(iosVc, logMessage);
 
         printGraph(graph);
         // How many new nodes will have been created? We should have
@@ -115,7 +119,7 @@ public class IpnTest extends AbstractImporterTest {
 //       List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(BRANCH_1_XMLFILE);
         @SuppressWarnings("unused")
-        ImportLog log = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios, logMessage);
         // After...
 //       List<VertexProxy> graphState2 = getGraphState(graph);
 //       GraphDiff diff = diffGraph(graphState1, graphState2);
@@ -207,7 +211,7 @@ public class IpnTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(BRANCH_2_XMLFILE);
         @SuppressWarnings("unused")
-        ImportLog log = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);
@@ -256,7 +260,7 @@ public class IpnTest extends AbstractImporterTest {
         for (DocumentaryUnitDescription d : descriptions) {
             assertEquals("Collections from Biuro Udostępniania i Archiwizacji Dokumentów w Warszawie", d.getName());
             List<String> provenance = d.getProperty("processInfo");
-            assertTrue(provenance.size() > 0);
+            assertTrue(!provenance.isEmpty());
             assertThat(provenance.get(0), startsWith("This selection has been "));
         }
         for (DocumentaryUnitDescription desc : c1_1.getDocumentDescriptions()) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IpnTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IpnTest.java
@@ -22,10 +22,7 @@ package eu.ehri.project.importers.ead;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
@@ -33,31 +30,22 @@ import eu.ehri.project.models.VirtualUnit;
 import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 public class IpnTest extends AbstractImporterTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(IpnTest.class);
-    protected final String TEST_REPO = "r1";
     protected final String BRANCH_1_XMLFILE = "polishBranch.xml";
     // Identifiers of nodes in the imported documentary units
     protected final String BRANCH_1_ARCHDESC = "Pamięci Narodowej",
             BRANCH_1_C01_1 = "2746",
             BRANCH_1_C01_2 = "2747";
-    int origCount = 0;
 
     protected final String BRANCH_2_XMLFILE = "polishBranch_2.xml";
     // Identifiers of nodes in the imported documentary units
@@ -70,20 +58,19 @@ public class IpnTest extends AbstractImporterTest {
     @Test
     @Ignore
     public void polishVirtualCollectionTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of the IPN Virtual Collection";
 
         InputStream ios1 = ClassLoader.getSystemResourceAsStream(BRANCH_1_XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new
-                XmlImportProperties("polishBranch.properties")).importFile(ios1, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class, "polishBranch.properties")
+                .importFile(ios1, logMessage);
 
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(BRANCH_2_XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "polishBranch.properties")
                 .importFile(ios2, logMessage);
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
         InputStream iosVc = ClassLoader.getSystemResourceAsStream(VC_XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc.properties"))
+        saxImportManager(VirtualEadImporter.class, VirtualEadHandler.class, "vc.properties")
                 .importFile(iosVc, logMessage);
 
         printGraph(graph);
@@ -107,26 +94,19 @@ public class IpnTest extends AbstractImporterTest {
     }
 
     @Test
-
     public void polishBranch_1_EadTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
         PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of a the IPN Polish Branches EAD, without preprocessing done";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         // Before...
-//       List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(BRANCH_1_XMLFILE);
-        @SuppressWarnings("unused")
-        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class, "polishBranch.properties")
+                .importFile(ios, logMessage);
         // After...
-//       List<VertexProxy> graphState2 = getGraphState(graph);
-//       GraphDiff diff = diffGraph(graphState1, graphState2);
-//       diff.printDebug(System.out);
 
-
-//        printGraph(graph);
         // How many new nodes will have been created? We should have
         /**
          * null: 4
@@ -205,13 +185,13 @@ public class IpnTest extends AbstractImporterTest {
         PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of a the IPN Polish Branches EAD, without preprocessing done";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(BRANCH_2_XMLFILE);
-        @SuppressWarnings("unused")
-        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class, EadHandler.class, new XmlImportProperties("polishBranch.properties")).importFile(ios, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class, "polishBranch.properties")
+                .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);
@@ -283,8 +263,6 @@ public class IpnTest extends AbstractImporterTest {
             }
         }
         assertTrue(hasDates);
-
     }
-
 }
     

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
@@ -27,10 +27,9 @@ import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
-import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.MaintenanceEvent;
 import eu.ehri.project.models.MaintenanceEventType;
 import eu.ehri.project.models.base.Description;
@@ -62,9 +61,9 @@ public class ItsTest extends AbstractImporterTest {
     public void testUnitdate() throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(EAD_EN);
         final String logMessage = "Importing a single EAD by ItsTest";
-        new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("its-pertinence.properties"))
-                    .importFile(ios, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("its-pertinence.properties")
+                .importFile(ios, logMessage);
         DocumentaryUnit unit = graph.frame(
                 getVertexByIdentifier(graph, IMPORTED_ITEM_ID),
                 DocumentaryUnit.class);
@@ -88,8 +87,8 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        importManager = new SaxImportManager(graph, repository, validUser, false, true,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("its-pertinence.properties"));
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, "its-pertinence" +
+                ".properties").allowUpdates(true);
         ImportLog log_en = importManager.importFile(ios, logMessage);
         ImportLog log_de = importManager.importFile(ios2, logMessage);
 
@@ -169,11 +168,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-
-        importManager = new SaxImportManager(graph, repository, validUser, false, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("its-provenance.properties"))
-                .setTolerant(Boolean.TRUE);
-        importManager.importFile(ios, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("its-provenance.properties")
+                .importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -238,10 +235,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        importManager = new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("its-provenance.properties"));
-
-        importManager.importFile(ios, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("its-provenance.properties")
+                .importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -271,10 +267,9 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class,
-                new XmlImportProperties("its-pertinence.properties"))
-                    .importFile(ios, logMessage);
+        saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("its-pertinence.properties")
+                .importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
@@ -62,8 +62,9 @@ public class ItsTest extends AbstractImporterTest {
     public void testUnitdate() throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(EAD_EN);
         final String logMessage = "Importing a single EAD by ItsTest";
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-pertinence.properties")).setTolerant(Boolean.TRUE);
-        importManager.importFile(ios, logMessage);
+        new SaxImportManager(graph, repository, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("its-pertinence.properties"))
+                    .importFile(ios, logMessage);
         DocumentaryUnit unit = graph.frame(
                 getVertexByIdentifier(graph, IMPORTED_ITEM_ID),
                 DocumentaryUnit.class);
@@ -87,7 +88,8 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-pertinence.properties")).setTolerant(Boolean.TRUE);
+        importManager = new SaxImportManager(graph, repository, validUser, false, true,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("its-pertinence.properties"));
         ImportLog log_en = importManager.importFile(ios, logMessage);
         ImportLog log_de = importManager.importFile(ios2, logMessage);
 
@@ -168,7 +170,7 @@ public class ItsTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
 
-        importManager = new SaxImportManager(graph, repository, validUser,
+        importManager = new SaxImportManager(graph, repository, validUser, false, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("its-provenance.properties"))
                 .setTolerant(Boolean.TRUE);
         importManager.importFile(ios, logMessage);
@@ -236,7 +238,8 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("its-provenance.properties")).setTolerant(Boolean.TRUE);
+        importManager = new SaxImportManager(graph, repository, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("its-provenance.properties"));
 
         importManager.importFile(ios, logMessage);
 
@@ -268,11 +271,10 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        importManager = new SaxImportManager(graph, repository, validUser,
+        new SaxImportManager(graph, repository, validUser, true, false,
                 EadImporter.class, EadHandler.class,
                 new XmlImportProperties("its-pertinence.properties"))
-                .setTolerant(Boolean.TRUE);
-        importManager.importFile(ios, logMessage);
+                    .importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Jmp130Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Jmp130Test.java
@@ -23,11 +23,8 @@ import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
-import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Accessible;
 import org.junit.Test;
 
@@ -42,22 +39,19 @@ import static org.junit.Assert.assertTrue;
 public class Jmp130Test extends AbstractImporterTest {
 
     protected final String SINGLE_EAD = "JMP-130.xml";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
+
     // Depends on hierarchical-ead.xml
     protected final String FONDS = "COLLECTION.JMP.ARCHIVE/130";
 
     @Test
     public void testImportItemsT() throws Exception {
 
-        Repository agent = manager.getEntity(TEST_REPO, Repository.class);
-
         final String logMessage = "Importing JMP EAD";
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("jmp.properties"))
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("jmp.properties")
                 .importFile(ios, logMessage);
 
         List<VertexProxy> graphState1 = getGraphState(graph);
@@ -97,6 +91,6 @@ public class Jmp130Test extends AbstractImporterTest {
         assertEquals(log.getChanged(), subjects.size());
 
         // Check permission scopes
-        assertEquals(agent, fonds.getPermissionScope());
+        assertEquals(repository, fonds.getPermissionScope());
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Jmp130Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Jmp130Test.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -55,12 +56,11 @@ public class Jmp130Test extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("jmp.properties"));
-        importManager.setTolerant(Boolean.TRUE);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("jmp.properties"))
+                .importFile(ios, logMessage);
 
         List<VertexProxy> graphState1 = getGraphState(graph);
-        ImportLog log = importManager.importFile(ios, logMessage);
         printGraph(graph);
 
         // After...
@@ -88,7 +88,7 @@ public class Jmp130Test extends AbstractImporterTest {
 
         for (DocumentaryUnitDescription d : fonds.getDocumentDescriptions()) {
             List<String> langs = d.getProperty("languageOfMaterial");
-            assertTrue(langs.size() > 0);
+            assertFalse(langs.isEmpty());
             assertEquals("ces", langs.get(0));
         }
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/JmpEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/JmpEadTest.java
@@ -23,8 +23,6 @@ import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.Repository;
@@ -42,9 +40,6 @@ import static org.junit.Assert.assertTrue;
 public class JmpEadTest extends AbstractImporterTest {
 
     protected final String SINGLE_EAD = "JMP20141117.xml";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-    // Depends on hierarchical-ead.xml
 
     protected final String FONDS = "COLLECTION.JMP.ARCHIVE/NAD3";
 
@@ -57,8 +52,8 @@ public class JmpEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"))
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("wp2ead.properties")
                 .importFile(ios, logMessage);
 
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/JmpEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/JmpEadTest.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -56,11 +57,9 @@ public class JmpEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
-
-        importManager.setTolerant(Boolean.TRUE);
-
-        ImportLog log = importManager.importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"))
+                .importFile(ios, logMessage);
 
         // How many new nodes will have been created? We should have
         // - 1 more DocumentaryUnits fonds C1 C2 C3 4,5,6
@@ -82,7 +81,7 @@ public class JmpEadTest extends AbstractImporterTest {
 
         for (DocumentaryUnitDescription d : fonds.getDocumentDescriptions()) {
             List<String> langs = d.getProperty("languageOfMaterial");
-            assertTrue(langs.size() > 0);
+            assertFalse(langs.isEmpty());
             assertEquals("deu", langs.get(0));
         }
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/MemShoahTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/MemShoahTest.java
@@ -63,7 +63,7 @@ public class MemShoahTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser,
+        new SaxImportManager(graph, agent, validUser, false, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("memshoah.properties"))
                 .importFile(ios, logMessage);
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/MemShoahTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/MemShoahTest.java
@@ -23,14 +23,11 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.MaintenanceEvent;
 import eu.ehri.project.models.MaintenanceEventType;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -45,26 +42,23 @@ import static org.junit.Assert.assertTrue;
  */
 public class MemShoahTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "memshoah.xml";
     protected final String ARCHDESC = "II, V, VI, VIa";
     DocumentaryUnit archdesc;
-    int origCount = 0;
 
     @Test
     public void cegesomaTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example MemShoah EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("memshoah.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("memshoah.properties")
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
@@ -66,7 +66,7 @@ public class NiodEadXsdTest extends AbstractImporterTest {
         //  Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser,
+        new SaxImportManager(graph, agent, validUser, false, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("niodead.properties"))
                 .importFile(ios, logMessage);
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
@@ -24,12 +24,9 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
-import eu.ehri.project.models.base.PermissionScope;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -44,7 +41,6 @@ import static org.junit.Assert.assertTrue;
 
 public class NiodEadXsdTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "NIOD-38474.xml";
     // Identifiers of nodes in the imported documentary units
     protected final String ARCHDESC = "MF1081500", //"197a",
@@ -53,21 +49,19 @@ public class NiodEadXsdTest extends AbstractImporterTest {
             C02_1 = "MF1086380",
             C03 = "MF1086399",
             C03_2 = "MF1086398";
-    int origCount = 0;
 
     @Test
     public void niodEadTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of a NIOD EAD";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         //  Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("niodead.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("niodead.properties")
                 .importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -115,8 +109,8 @@ public class NiodEadXsdTest extends AbstractImporterTest {
 
         // Check permission scope and hierarchy
         assertNull(archdesc.getParent());
-        assertEquals(agent, archdesc.getRepository());
-        assertEquals(agent, archdesc.getPermissionScope());
+        assertEquals(repository, archdesc.getRepository());
+        assertEquals(repository, archdesc.getPermissionScope());
         assertEquals(archdesc, c1.getParent());
         assertEquals(archdesc, c1.getPermissionScope());
         assertEquals(c1, c2.getParent());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
@@ -23,8 +23,6 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
@@ -37,12 +35,10 @@ import java.io.InputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 
 public class StadsarchiefAdamTest extends AbstractImporterTest {
 
-    protected final String TEST_REPO = "r1";
     protected final String XMLFILE = "stadsarchief30602.xml";
     // Identifiers of nodes in the imported documentary units
     protected final String ARCHDESC = "NL-SAA-22626598", //"197a",
@@ -51,7 +47,6 @@ public class StadsarchiefAdamTest extends AbstractImporterTest {
             C02_1 = "NL-SAA-22730311",
             C03 = "NL-SAA-22752512",
             C03_2 = "NL-SAA-22752538";
-    int origCount = 0;
 
     @Test
     public void niodEadTest() throws ItemNotFound, IOException, ValidationError, InputParseError {
@@ -59,12 +54,11 @@ public class StadsarchiefAdamTest extends AbstractImporterTest {
         PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing a part of a Stadsarchief EAD, with preprocessing done";
 
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
 
         // Before...
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("stadsarchief.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "stadsarchief.properties")
                 .importFile(ios, logMessage);
 
         printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class StadsarchiefAdamTest extends AbstractImporterTest {
@@ -62,8 +63,9 @@ public class StadsarchiefAdamTest extends AbstractImporterTest {
 
         // Before...
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        new SaxImportManager(graph, agent, validUser, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("stadsarchief.properties")).importFile(ios, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false, EadImporter.class,
+                EadHandler.class, new XmlImportProperties("stadsarchief.properties"))
+                .importFile(ios, logMessage);
 
         printGraph(graph);
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/UshmmTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/UshmmTest.java
@@ -22,23 +22,24 @@ package eu.ehri.project.importers.ead;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
-import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.events.SystemEvent;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class UshmmTest extends AbstractImporterTest {
     private static final Logger logger = LoggerFactory.getLogger(UshmmTest.class);
-    
+
     protected final String SINGLE_EAD = "irn44515.xml";
     protected final String IMPORTED_ITEM_ID = "irn44645";
     protected final String IMPORTED_ITEM_ALT_ID = "RG-50.586*0032";
@@ -54,8 +55,7 @@ public class UshmmTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
-                    EadImporter.class, UshmmHandler.class)
+        ImportLog log = saxImportManager(EadImporter.class, UshmmHandler.class)
                 .importFile(ios, logMessage);
 
         printGraph(graph);
@@ -77,22 +77,22 @@ public class UshmmTest extends AbstractImporterTest {
         Iterable<Vertex> docs = graph.getVertices("identifier", IMPORTED_ITEM_ID);
         assertTrue(docs.iterator().hasNext());
         DocumentaryUnit unit = graph.frame(docs.iterator().next(), DocumentaryUnit.class);
-        for(Description d : unit.getDocumentDescriptions()) {
+        for (Description d : unit.getDocumentDescriptions()) {
             assertEquals("Oral history interview with Dobrila Kukolj", d.getName());
-        	assertEquals("eng", d.getLanguageOfDescription());
+            assertEquals("eng", d.getLanguageOfDescription());
         }
         SystemEvent event = unit.getLatestEvent();
         if (event != null) {
             logger.debug("event: " + event.getLogMessage());
         }
-        
+
         // Check the alternative ID was added
         boolean foundAltId = false;
-        for(String altId : unit.<List<String>>getProperty("otherIdentifiers")) {
-        	if (altId.equals(IMPORTED_ITEM_ALT_ID)) {
-        		foundAltId = true;
-        		break;
-        	}
+        for (String altId : unit.<List<String>>getProperty("otherIdentifiers")) {
+            if (altId.equals(IMPORTED_ITEM_ALT_ID)) {
+                foundAltId = true;
+                break;
+            }
         }
         assertTrue(foundAltId);
 
@@ -106,8 +106,8 @@ public class UshmmTest extends AbstractImporterTest {
 
         // Now re-import the same file
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log2 = new SaxImportManager(graph, agent, validUser, false, true, EadImporter.class,
-                UshmmHandler.class).importFile(ios2, logMessage);
+        ImportLog log2 = saxImportManager(EadImporter.class, UshmmHandler.class)
+                .importFile(ios2, logMessage);
 
         // We should only have three more nodes, for
         // the action and

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/UshmmTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/UshmmTest.java
@@ -54,8 +54,9 @@ public class UshmmTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, EadImporter.class, UshmmHandler.class)
-                .setTolerant(Boolean.TRUE).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, true, false,
+                    EadImporter.class, UshmmHandler.class)
+                .importFile(ios, logMessage);
 
         printGraph(graph);
         /* How many new nodes will have been created? We should have
@@ -105,7 +106,7 @@ public class UshmmTest extends AbstractImporterTest {
 
         // Now re-import the same file
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log2 = new SaxImportManager(graph, agent, validUser, EadImporter.class,
+        ImportLog log2 = new SaxImportManager(graph, agent, validUser, false, true, EadImporter.class,
                 UshmmHandler.class).importFile(ios2, logMessage);
 
         // We should only have three more nodes, for

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/VC_ARAImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/VC_ARAImporterTest.java
@@ -43,13 +43,12 @@ public class VC_ARAImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser,
+        new SaxImportManager(graph, repository, validUser, true, false,
                     EadImporter.class, EadHandler.class, new XmlImportProperties("ara.properties"))
-                .setTolerant(Boolean.TRUE);
+                .importFile(ios, logMessage);
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
-        importManager.importFile(ios, logMessage);
         printGraph(graph);
 
         // After...
@@ -61,9 +60,8 @@ public class VC_ARAImporterTest extends AbstractImporterTest {
         printGraph(graph);
 
         InputStream ios_vc = ClassLoader.getSystemResourceAsStream(VC_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc_ara.properties"))
-                .setTolerant(Boolean.TRUE);
-
-        importManager.importFile(ios_vc, logMessage);
+        new SaxImportManager(graph, repository, validUser, false, false,
+                VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc_ara.properties"))
+                .importFile(ios_vc, logMessage);
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/VC_ARAImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/VC_ARAImporterTest.java
@@ -20,8 +20,6 @@
 package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -43,8 +41,7 @@ public class VC_ARAImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new SaxImportManager(graph, repository, validUser, true, false,
-                    EadImporter.class, EadHandler.class, new XmlImportProperties("ara.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "ara.properties")
                 .importFile(ios, logMessage);
 
         // Before...
@@ -60,8 +57,8 @@ public class VC_ARAImporterTest extends AbstractImporterTest {
         printGraph(graph);
 
         InputStream ios_vc = ClassLoader.getSystemResourceAsStream(VC_EAD);
-        new SaxImportManager(graph, repository, validUser, false, false,
-                VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc_ara.properties"))
+        saxImportManager(VirtualEadImporter.class, VirtualEadHandler.class)
+                .withProperties("vc_ara.properties")
                 .importFile(ios_vc, logMessage);
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/VirtualEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/VirtualEadTest.java
@@ -83,7 +83,8 @@ public class VirtualEadTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
 
-        new SaxImportManager(graph, agent, validUser, VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc.properties")).importFile(ios, logMessage);
+        new SaxImportManager(graph, agent, validUser, false, false,
+                VirtualEadImporter.class, VirtualEadHandler.class, new XmlImportProperties("vc.properties")).importFile(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/WegwijzerEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/WegwijzerEadImporterTest.java
@@ -45,8 +45,8 @@ public class WegwijzerEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wegwijzer.properties"))
-                .setTolerant(Boolean.TRUE);
+        importManager = new SaxImportManager(graph, repository, validUser,
+                true, false, EadImporter.class, EadHandler.class, new XmlImportProperties("wegwijzer.properties"));
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/WegwijzerEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/WegwijzerEadImporterTest.java
@@ -21,7 +21,6 @@ package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -34,9 +33,6 @@ public class WegwijzerEadImporterTest extends AbstractImporterTest {
 
     protected final String SINGLE_EAD = "wegwijzer.xml";
 
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-
     @Test
     public void testImportItemsT() throws Exception {
 
@@ -45,8 +41,8 @@ public class WegwijzerEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
         System.out.println(origCount);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser,
-                true, false, EadImporter.class, EadHandler.class, new XmlImportProperties("wegwijzer.properties"));
+        SaxImportManager importManager = saxImportManager(
+                EadImporter.class, EadHandler.class, "wegwijzer.properties");
 
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
@@ -86,12 +86,10 @@ public class Wp2BtEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream iosVC = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
-
-
-        importManager.setTolerant(Boolean.TRUE);
-
+        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
         ImportLog logVC = importManager.importFile(iosVC, logMessage);
+
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);
@@ -164,7 +162,9 @@ public class Wp2BtEadTest extends AbstractImporterTest {
         }
 
         // Check the importer is Idempotent
-        ImportLog log2 = importManager.importFile(ClassLoader.getSystemResourceAsStream(SINGLE_EAD), logMessage);
+        ImportLog log2 = importManager
+                .allowUpdates(true)
+                .importFile(ClassLoader.getSystemResourceAsStream(SINGLE_EAD), logMessage);
         assertEquals(6, log2.getUnchanged());
         //assertEquals(0, log2.getChanged());
         assertEquals(newCount, getNodeCount(graph));

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
@@ -24,7 +24,6 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.EntityClass;
@@ -86,8 +85,8 @@ public class Wp2BtEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream iosVC = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, agent, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
+        SaxImportManager importManager = saxImportManager(
+                EadImporter.class, EadHandler.class, "wp2ead.properties");
         ImportLog logVC = importManager.importFile(iosVC, logMessage);
 
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2JmpEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2JmpEadTest.java
@@ -60,9 +60,8 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser,
+        importManager = new SaxImportManager(graph, repository, validUser, true, false,
                     EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
-        importManager.setTolerant(Boolean.TRUE);
 
         ImportLog log = importManager.importFile(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2JmpEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2JmpEadTest.java
@@ -24,9 +24,8 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
-import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.events.SystemEvent;
 import org.junit.Test;
@@ -60,8 +59,8 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser, true, false,
-                    EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
+        SaxImportManager importManager = saxImportManager(
+                EadImporter.class, EadHandler.class, "wp2ead.properties");
 
         ImportLog log = importManager.importFile(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
@@ -83,10 +83,8 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser,
+        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, true, false,
                 EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
-        importManager.setTolerant(Boolean.TRUE);
-
         ImportLog log = importManager.importFile(ios, logMessage);
 
         //printGraph(graph);
@@ -156,7 +154,9 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         }
 
         // Check the importer is Idempotent
-        ImportLog log2 = importManager.importFile(ClassLoader.getSystemResourceAsStream(SINGLE_EAD), logMessage);
+        ImportLog log2 = importManager
+                .allowUpdates(true)
+                .importFile(ClassLoader.getSystemResourceAsStream(SINGLE_EAD), logMessage);
         assertEquals(4, log2.getUnchanged());
         //assertEquals(0, log2.getChanged());
         assertEquals(newCount, getNodeCount(graph));

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
@@ -25,7 +25,6 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.EntityClass;
@@ -52,9 +51,6 @@ public class Wp2YvEadTest extends AbstractImporterTest {
 
     private static final Logger logger = LoggerFactory.getLogger(Wp2YvEadTest.class);
     protected final String SINGLE_EAD = "wp2_yv_ead.xml";
-    // Depends on fixtures
-    protected final String TEST_REPO = "r1";
-    // Depends on hierarchical-ead.xml
     protected final String C1 = "O.64.2-A.";
     protected final String C2 = "O.64.2-A.A.";
     protected final String C3 = "3685529";
@@ -69,8 +65,8 @@ public class Wp2YvEadTest extends AbstractImporterTest {
                 .withDataValue(Ontology.NAME_KEY, "WP2 Keywords");
         Bundle conceptBundle = new Bundle(EntityClass.CVOC_CONCEPT)
                 .withDataValue(Ontology.IDENTIFIER_KEY, "KEYWORD.JMP.288");
-        Vocabulary vocabulary = new CrudViews<>(graph, Vocabulary.class).create(vocabularyBundle,
-                validUser);
+        Vocabulary vocabulary = new CrudViews<>(graph, Vocabulary.class)
+                .create(vocabularyBundle, validUser);
         logger.debug(vocabulary.getId());
         Concept concept_288 = new CrudViews<>(graph, Concept.class).create(conceptBundle, validUser);
         vocabulary.addItem(concept_288);
@@ -83,8 +79,8 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("wp2ead.properties"));
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("wp2ead.properties");
         ImportLog log = importManager.importFile(ios, logMessage);
 
         //printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
@@ -83,10 +83,9 @@ public class YadVashemTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_C1);
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class,
-                EadHandler.class, new XmlImportProperties("yadvashem.properties"))
-                .setTolerant(Boolean.TRUE);
-        importManager.importFile(ios, logMessage);
+        new SaxImportManager(graph, repository, validUser, false, true,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
+                .importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -125,8 +124,8 @@ public class YadVashemTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        importManager = new SaxImportManager(graph, repository, validUser, EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
-                .setTolerant(Boolean.TRUE);
+        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, false, true,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"));
         importManager.importFile(ios, logMessage);
 
         // After...
@@ -159,7 +158,7 @@ public class YadVashemTest extends AbstractImporterTest {
         assertEquals(1, nrOfDesc);
 
         ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_HEB);
-        importManager.importFile(ios, logMessage);
+        importManager.allowUpdates(true).importFile(ios, logMessage);
 
         //HEB also imported:
         assertEquals(3, toList(m19.getDocumentDescriptions()).size());
@@ -210,9 +209,8 @@ public class YadVashemTest extends AbstractImporterTest {
     public void testIdempotentImportViaXmlAndZip() throws Exception {
         String resource = "MS1_O84_HEB-partial-unicode.xml";
         InputStream ios = ClassLoader.getSystemResourceAsStream(resource);
-        importManager = new SaxImportManager(graph, repository, validUser,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
-                .setTolerant(Boolean.TRUE);
+        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, true, false,
+                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"));
         ImportLog log = importManager.importFile(ios, "Test");
         assertEquals(1, log.getCreated());
 
@@ -225,6 +223,7 @@ public class YadVashemTest extends AbstractImporterTest {
                      ArchiveStreamFactory(StandardCharsets.UTF_8.displayName())
                      .createArchiveInputStream(bis)) {
             ImportLog log2 = importManager
+                    .allowUpdates(true)
                     .importFiles(archiveInputStream, "Test 2");
             assertEquals(1, log2.getUnchanged());
             assertEquals(0, log2.getUpdated());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
@@ -56,8 +56,7 @@ public class YadVashemTest extends AbstractImporterTest {
     protected final String SINGLE_EAD_HEB = "YV_m19_heb.xml";
     protected final String SINGLE_EAD_C1 = "YV_c1.xml";
     // Depends on fixtures
-    protected final String TEST_REPO = "r1",
-            ARCHDESC = "M.19",
+    protected final String ARCHDESC = "M.19",
             C1 = "M.19/7",
             C2 = "M.19/7.1";
 
@@ -66,8 +65,6 @@ public class YadVashemTest extends AbstractImporterTest {
      * the unit described in the test file that is imported here.
      * This test checks that the existing description (which has a different source)
      * is untouched and the description from the test file is added.
-     *
-     * @throws Exception
      */
     @Test
     public void testWithExistingDescription() throws Exception {
@@ -83,8 +80,8 @@ public class YadVashemTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_C1);
-        new SaxImportManager(graph, repository, validUser, false, true,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"))
+        saxImportManager(EadImporter.class, EadHandler.class, "yadvashem.properties")
+                .allowUpdates(true)
                 .importFile(ios, logMessage);
 
         // After...
@@ -115,7 +112,6 @@ public class YadVashemTest extends AbstractImporterTest {
         final String logMessage = "Importing a single EAD";
 
         int count = getNodeCount(graph);
-        System.out.println(count);
         DocumentaryUnit m19 = manager.getEntity("nl-r1-m19", DocumentaryUnit.class);
 
         assertEquals("m19", m19.getIdentifier());
@@ -124,9 +120,9 @@ public class YadVashemTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, false, true,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"));
-        importManager.importFile(ios, logMessage);
+        SaxImportManager importManager = saxImportManager(
+                EadImporter.class, EadHandler.class, "yadvashem.properties");
+        importManager.allowUpdates(true).importFile(ios, logMessage);
 
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
@@ -209,8 +205,8 @@ public class YadVashemTest extends AbstractImporterTest {
     public void testIdempotentImportViaXmlAndZip() throws Exception {
         String resource = "MS1_O84_HEB-partial-unicode.xml";
         InputStream ios = ClassLoader.getSystemResourceAsStream(resource);
-        SaxImportManager importManager = new SaxImportManager(graph, repository, validUser, true, false,
-                EadImporter.class, EadHandler.class, new XmlImportProperties("yadvashem.properties"));
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class)
+                .withProperties("yadvashem.properties");
         ImportLog log = importManager.importFile(ios, "Test");
         assertEquals(1, log.getCreated());
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
@@ -61,7 +61,8 @@ public class Eag2896Test extends AbstractImporterTest {
         logger.info("count of nodes before importing: " + count);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_UNIT);
-        SaxImportManager importManager = new SaxImportManager(graph, country, validUser, EagImporter.class, EagHandler.class);
+        SaxImportManager importManager = new SaxImportManager(graph, country, validUser, false, false,
+                EagImporter.class, EagHandler.class);
         ImportLog log = importManager.importFile(ios, logMessage);
         //printGraph(graph);
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
@@ -61,7 +61,7 @@ public class Eag2896Test extends AbstractImporterTest {
         logger.info("count of nodes before importing: " + count);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_UNIT);
-        SaxImportManager importManager = new SaxImportManager(graph, country, validUser, false, false,
+        SaxImportManager importManager = new SaxImportManager(graph, country, validUser,
                 EagImporter.class, EagHandler.class);
         ImportLog log = importManager.importFile(ios, logMessage);
         //printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/xml/Bbwo2HandlerTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/xml/Bbwo2HandlerTest.java
@@ -25,11 +25,8 @@ import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.AbstractImporterTest;
-import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.ead.EadImporter;
 import eu.ehri.project.importers.exceptions.InputParseError;
-import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.DocumentaryUnitDescription;
@@ -55,16 +52,13 @@ import java.util.List;
 
 public class Bbwo2HandlerTest extends AbstractImporterTest {
     private static final Logger logger = LoggerFactory.getLogger(Bbwo2HandlerTest.class);
-    protected final String TEST_REPO = "r1";
+
     protected final String XMLFILE_NL = "bbwo2.xml";
     protected final String ARCHDESC = "1505";
-    DocumentaryUnit archdesc;
-    int origCount = 0;
 
     @Test
     public void bbwo2Test() throws ItemNotFound, IOException, ValidationError, InputParseError, PermissionDenied, IntegrityError {
 
-        PermissionScope agent = manager.getEntity(TEST_REPO, PermissionScope.class);
         final String logMessage = "Importing an example BBWO2 DC";
 
         //id="joodse-raad" source="niod-trefwoorden" term="Kinderen"
@@ -81,16 +75,14 @@ public class Bbwo2HandlerTest extends AbstractImporterTest {
         Vocabulary vocabularyTest = manager.getEntity("niod_trefwoorden", Vocabulary.class);
         Assert.assertNotNull(vocabularyTest);
 
-
         // Before...
         List<VertexProxy> graphState1 = GraphTestBase.getGraphState(graph);
 
-
-        origCount = getNodeCount(graph);
+        int origCount = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE_NL);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false,
-                EadImporter.class, DcEuropeanaHandler.class, new XmlImportProperties("dceuropeana.properties")).importFile(ios, logMessage);
-//        printGraph(graph);
+        saxImportManager(EadImporter.class, DcEuropeanaHandler.class, "dceuropeana.properties")
+                .importFile(ios, logMessage);
+
         // After...
         List<VertexProxy> graphState2 = GraphTestBase.getGraphState(graph);
         GraphDiff diff = GraphTestBase.diffGraph(graphState1, graphState2);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/xml/Bbwo2HandlerTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/xml/Bbwo2HandlerTest.java
@@ -88,7 +88,8 @@ public class Bbwo2HandlerTest extends AbstractImporterTest {
 
         origCount = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE_NL);
-        ImportLog log = new SaxImportManager(graph, agent, validUser, EadImporter.class, DcEuropeanaHandler.class, new XmlImportProperties("dceuropeana.properties")).importFile(ios, logMessage);
+        ImportLog log = new SaxImportManager(graph, agent, validUser, false, false,
+                EadImporter.class, DcEuropeanaHandler.class, new XmlImportProperties("dceuropeana.properties")).importFile(ios, logMessage);
 //        printGraph(graph);
         // After...
         List<VertexProxy> graphState2 = GraphTestBase.getGraphState(graph);

--- a/ehri-io/src/test/resources/comprehensive-ead.xml
+++ b/ehri-io/src/test/resources/comprehensive-ead.xml
@@ -971,7 +971,7 @@
             <c01 id="ref239" level="series">
                 <did>
                     <unittitle>ELIZABETH BLODGETT AND LIVINGSTON HALL</unittitle>
-                    <unitid>Series I</unitid>
+                    <unitid>Series VI |||</unitid>
                     <unitdate normal="1823/2006" type="inclusive">1823-2006</unitdate>
                 </did>
                 <odd id="ref241">

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -442,7 +442,7 @@ public class ImportResource extends AbstractRestResource {
         try (BufferedInputStream bis = new BufferedInputStream(data);
              ArchiveInputStream archiveInputStream = new
                      ArchiveStreamFactory(StandardCharsets.UTF_8.displayName())
-                        .createArchiveInputStream(bis)) {
+                     .createArchiveInputStream(bis)) {
             return importManager
                     .importFiles(archiveInputStream, logMessage);
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -240,7 +240,9 @@ public class ImportResource extends AbstractRestResource {
             // Run the import!
             String message = getLogMessage(logMessage).orNull();
             ImportManager importManager = new SaxImportManager(
-                    graph, scope, user, tolerant, allowUpdates, importer, handler)
+                    graph, scope, user, importer, handler)
+                    .allowUpdates(allowUpdates)
+                    .setTolerant(tolerant)
                     .withProperties(propertyFile);
             ImportLog log = importDataStream(importManager, message, data,
                     MediaType.APPLICATION_XML_TYPE, MediaType.TEXT_XML_TYPE);

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -91,6 +91,7 @@ public class ImportResource extends AbstractRestResource {
     public static final String LOG_PARAM = "log";
     public static final String SCOPE_PARAM = "scope";
     public static final String TOLERANT_PARAM = "tolerant";
+    public static final String ALLOW_UPDATES_PARAM = "allow-update";
     public static final String VERSION_PARAM = "version";
     public static final String HANDLER_PARAM = "handler";
     public static final String IMPORTER_PARAM = "importer";
@@ -215,6 +216,7 @@ public class ImportResource extends AbstractRestResource {
     public ImportLog importEad(
             @QueryParam(SCOPE_PARAM) String scopeId,
             @DefaultValue("false") @QueryParam(TOLERANT_PARAM) Boolean tolerant,
+            @DefaultValue("false") @QueryParam(ALLOW_UPDATES_PARAM) Boolean allowUpdates,
             @QueryParam(LOG_PARAM) String logMessage,
             @QueryParam(PROPERTIES_PARAM) String propertyFile,
             @QueryParam(HANDLER_PARAM) String handlerClass,
@@ -237,9 +239,9 @@ public class ImportResource extends AbstractRestResource {
 
             // Run the import!
             String message = getLogMessage(logMessage).orNull();
-            ImportManager importManager = new SaxImportManager(graph, scope, user, importer, handler)
-                    .withProperties(propertyFile)
-                    .setTolerant(tolerant);
+            ImportManager importManager = new SaxImportManager(
+                    graph, scope, user, tolerant, allowUpdates, importer, handler)
+                    .withProperties(propertyFile);
             ImportLog log = importDataStream(importManager, message, data,
                     MediaType.APPLICATION_XML_TYPE, MediaType.TEXT_XML_TYPE);
             tx.success();
@@ -262,13 +264,14 @@ public class ImportResource extends AbstractRestResource {
     public ImportLog importEag(
             @QueryParam(SCOPE_PARAM) String scopeId,
             @DefaultValue("false") @QueryParam(TOLERANT_PARAM) Boolean tolerant,
+            @DefaultValue("false") @QueryParam(ALLOW_UPDATES_PARAM) Boolean allowUpdates,
             @QueryParam(LOG_PARAM) String logMessage,
             @QueryParam(PROPERTIES_PARAM) String propertyFile,
             @QueryParam(HANDLER_PARAM) String handlerClass,
             @QueryParam(IMPORTER_PARAM) String importerClass,
             InputStream data)
             throws ItemNotFound, ValidationError, IOException, DeserializationError {
-        return importEad(scopeId, tolerant, logMessage, propertyFile,
+        return importEad(scopeId, tolerant, allowUpdates, logMessage, propertyFile,
                 nameOrDefault(handlerClass, EagHandler.class.getName()),
                 nameOrDefault(importerClass, EagImporter.class.getName()), data);
     }
@@ -284,13 +287,14 @@ public class ImportResource extends AbstractRestResource {
     public ImportLog importEac(
             @QueryParam(SCOPE_PARAM) String scopeId,
             @DefaultValue("false") @QueryParam(TOLERANT_PARAM) Boolean tolerant,
+            @DefaultValue("false") @QueryParam(ALLOW_UPDATES_PARAM) Boolean allowUpdates,
             @QueryParam(LOG_PARAM) String logMessage,
             @QueryParam(PROPERTIES_PARAM) String propertyFile,
             @QueryParam(HANDLER_PARAM) String handlerClass,
             @QueryParam(IMPORTER_PARAM) String importerClass,
             InputStream data)
             throws ItemNotFound, ValidationError, IOException, DeserializationError {
-        return importEad(scopeId, tolerant, logMessage, propertyFile,
+        return importEad(scopeId, tolerant, allowUpdates, logMessage, propertyFile,
                 nameOrDefault(handlerClass, EacHandler.class.getName()),
                 nameOrDefault(importerClass, EacImporter.class.getName()), data);
     }
@@ -309,6 +313,8 @@ public class ImportResource extends AbstractRestResource {
     @Path("csv")
     public ImportLog importCsv(
             @QueryParam(SCOPE_PARAM) String scopeId,
+            @DefaultValue("false") @QueryParam(TOLERANT_PARAM) Boolean tolerant,
+            @DefaultValue("false") @QueryParam(ALLOW_UPDATES_PARAM) Boolean allowUpdates,
             @QueryParam(LOG_PARAM) String logMessage,
             @QueryParam(IMPORTER_PARAM) String importerClass,
             InputStream data)
@@ -326,7 +332,8 @@ public class ImportResource extends AbstractRestResource {
 
             // Run the import!
             String message = getLogMessage(logMessage).orNull();
-            ImportManager importManager = new CsvImportManager(graph, scope, user, importer);
+            ImportManager importManager = new CsvImportManager(
+                    graph, scope, user, tolerant, allowUpdates, importer);
             ImportLog log = importDataStream(importManager, message, data,
                     MediaType.valueOf(CSV_MEDIA_TYPE));
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/ModeViolationMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/errors/mappers/ModeViolationMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.extension.errors.mappers;
+
+import com.google.common.base.Charsets;
+import eu.ehri.project.importers.exceptions.ModeViolation;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ModeViolationMapper implements ExceptionMapper<ModeViolation> {
+    @Override
+    public Response toResponse(ModeViolation e) {
+        return Response
+                .status(Status.BAD_REQUEST)
+                .type(MediaType.TEXT_PLAIN_TYPE)
+                .entity(e.getMessage().getBytes(Charsets.UTF_8)).build();
+    }
+}

--- a/src/site/markdown/ingest.md
+++ b/src/site/markdown/ingest.md
@@ -1,0 +1,101 @@
+# Example Ingest
+
+The current ingest procedure is somewhat long-winded and technical. This is an example
+given a single EAD XML file containing a large number (48,000) of individual documentary
+unit items in a single fonds. The repository is the Internation Tracing Service (ITS),
+which has EHRI repository ID `de-002409`.
+
+This ingest covers importing the EAD file into the staging server, at which time it
+should be ready for verification and if necessary, changes, before the production
+ingest.
+
+First, log into the EHRI staging server via SSH and open a bunch of shells.
+In one of them, tail the following file, which will give us some information
+about what goes wrong, when something inevitably goes wrong the first few times
+we try:
+
+    tail -f /opt/webapps/neo4j-version/data/log/console.log
+
+Next, in another shell, copy the file(s) to be ingested to the server and place them
+in `/opt/webapps/data/import-data/de/de-002409`, the working directory for ITS data.
+
+Import properties handle cerain mappings between tags (with particular attributes)
+and EHRI fields. The ITS data has a particular mapping indicating that when the
+`<unitid>` has a `type="refcode"` that is the main doc unit identifier, and that the
+rest are the alternates. This file is, in this case:
+
+    /opt/webapps/data/import-data/de/de-002409/its-pertinence.properties
+
+The actual import is done via the /ehri/import/ead endpoint on the Neo4j extension. It is
+documented here: http://ehri.github.io/docs/api/ehri-rest/ehri-extension/wsdocs/resource_ImportResource.html
+
+The basic procedure is:
+
+ - obtain an appropriate import properties file (which we've done in this case)
+ - write an appropriate log file, describing what we're doing
+ - stick the EAD XML on the server
+ - run a curl command, POSTing the XML data to the ingest endpoint, with
+   the appropriate parameters
+ - re-index the data held by our repository (ITS, de-002409) to make it
+   searchable in the portal UI
+
+To make the curl command less cumbersome, lets export the path to the properties
+file as an environment variable:
+
+    export PROPERTIES=/opt/webapps/data/import-data/de/de-002409/its-pertinence.properties
+
+Also, lets write a log file and export it's path as an environment variable:
+
+    echo "Importing ITS data with properties: $PROPERTIES" > LOG.txt
+    export LOG=`pwd`/LOG.txt
+
+Now we can POST the data to the ingest endpoint:
+
+    curl -XPOST \
+        -H "X-User:mike" \
+        -H "Content-type: text/xml" \
+        --data-binary @KHSK_GER.xml \
+        "http://localhost:7474/ehri/import/ead?scope=de-002409&log=$LOG&properties=$PROPERTIES"
+
+These parameters are:
+
+ - the `X-User` header tells the web service which user is responsible for the ingest
+ - the `Content-type` header tells it to expect XML data
+ - the `scope=de-002409` query parameter tells it we're importing this EAD into
+   the ITS repository
+ - the `log=$LOG` parameter tells it to find the log text in a local file
+ - the `properties=$PROPERTIES` parameter tells it to file the import properties
+   in a local file
+
+*Note*: when importing a single EAD containing ~50,000 items in a single transaction the
+staging server might run out of memory. If it does the only option is to increase the
+Neo4j heap size  by uncommenting and setting the `wrapper.java.maxmemory=MORE_MB` (say,
+ 3000) in `$NEO4J_HOME/conf/neo4j-wrapper.conf` and restarting Neo4j by running:
+
+    sudo service neo4j-service restart
+
+*Additional note*: _Certain date patterns are fuzzy parsed by the importer and invalid
+dates such as 31st April will currently throw a runtime exception. So fix all these first_ ;)
+
+If all goes well you should get something like this:
+
+    {"created":48430,"unchanged":0,"message":"Import ITS 0.4 data using its-pertinence.properties.\n","updated":0,"errors":{}}
+
+In theory, that ingest should be idemotent, so you can run the same command again and not change anything. Instead you'd
+get a reply like:
+
+    {"created":0,"unchanged":48430,"message":"Import ITS 0.4 data using its-pertinence.properties.\n","updated":0,"errors":{}}
+
+The final step is the re-index the ITS repository, making the items searchable. This can be done
+from the Portal Admin UI, or via the following command:
+
+    java -jar /opt/webapps/docview/bin/indexer.jar \
+         --clear-key-value holderId=de-002409 \
+         --index -H "X-User=admin" \
+         --stats \
+         --solr http://localhost:8080/ehri/portal \
+         --rest http://localhost:7474/ehri \
+         "Repository|de-002409"
+
+(This tool is a library/CLI utility the is used by the portal UI and available on the server: see
+the https://github.com/EHRI/ehri-search-tools project for more details.)


### PR DESCRIPTION
This prevents accidentally updating material if there is, for example, an ID collision on the data provider's side. An `allow-updates=true` flag must be given for overwriting or periodic harvesting.

Numerous other test cleanups.