### PR TITLE
Small changes to date normalisation and error handling.

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/MapImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/MapImporter.java
@@ -55,6 +55,8 @@ import java.util.regex.Pattern;
 public abstract class MapImporter extends AbstractImporter<Map<String, Object>> {
 
     private static final Logger logger = LoggerFactory.getLogger(MapImporter.class);
+    private final SimpleDateFormat yearMonthDateFormat = new SimpleDateFormat("yyyy-MM");
+    private final SimpleDateFormat yearDateFormat = new SimpleDateFormat("yyyy");
     protected final String OBJECT_ID = "objectIdentifier";
     private final XmlImportProperties dates = new XmlImportProperties("dates.properties");
 
@@ -98,7 +100,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
      * @param data the data map
      * @return returns a List with the separated datevalues
      */
-    protected static Map<String, String> returnDatesAsString(Map<String, Object> data, XmlImportProperties dates) {
+    protected Map<String, String> returnDatesAsString(Map<String, Object> data, XmlImportProperties dates) {
         Map<String, String> datesAsString = Maps.newHashMap();
         Object value;
         for (Entry<String, Object> property : data.entrySet()) {
@@ -267,7 +269,7 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
         return data;
     }
 
-    private static String normaliseDate(String date) {
+    private String normaliseDate(String date) {
         return normaliseDate(date, Ontology.DATE_PERIOD_START_DATE);
     }
 
@@ -279,29 +281,29 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
      *                   a period or the end of a period
      * @return a String containing the formatted date.
      */
-    public static String normaliseDate(String date, String beginOrEnd) {
+    protected String normaliseDate(String date, String beginOrEnd) {
         DateTimeFormatter fmt = ISODateTimeFormat.date();
-        String returndate = fmt.print(DateTime.parse(date));
-        if (returndate.startsWith("00")) {
-            returndate = "19" + returndate.substring(2);
+        String returnDate = fmt.print(DateTime.parse(date));
+        if (returnDate.startsWith("00")) {
+            returnDate = "19" + returnDate.substring(2);
             date = "19" + date;
         }
         if (Ontology.DATE_PERIOD_END_DATE.equals(beginOrEnd)) {
-            if (!date.equals(returndate)) {
+            if (!date.equals(returnDate)) {
                 ParsePosition p = new ParsePosition(0);
-                new SimpleDateFormat("yyyy-MM").parse(date, p);
+                yearMonthDateFormat.parse(date, p);
                 if (p.getIndex() > 0) {
-                    returndate = fmt.print(DateTime.parse(date).plusMonths(1).minusDays(1));
+                    returnDate = fmt.print(DateTime.parse(date).plusMonths(1).minusDays(1));
                 } else {
                     p = new ParsePosition(0);
-                    new SimpleDateFormat("yyyy").parse(date, p);
+                    yearDateFormat.parse(date, p);
                     if (p.getIndex() > 0) {
-                        returndate = fmt.print(DateTime.parse(date).plusYears(1).minusDays(1));
+                        returnDate = fmt.print(DateTime.parse(date).plusYears(1).minusDays(1));
                     }
                 }
             }
         }
-        return returndate;
+        return returnDate;
     }
 
     //TODO: for now, it only returns 1 unknown node object, but it could be more accurate to return several

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -198,8 +198,7 @@ public class SaxImportManager extends AbstractImportManager {
             SAXParser saxParser = spf.newSAXParser();
             saxParser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
             saxParser.parse(ios, handler);
-        } catch (InstantiationException | IllegalAccessException |
-                IllegalArgumentException | InvocationTargetException |
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                 NoSuchMethodException | SecurityException |
                 ParserConfigurationException e) {
             logger.error("{}: {}", e.getMessage(), e);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/MapImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/MapImporterTest.java
@@ -39,9 +39,6 @@ import static org.junit.Assert.assertTrue;
 
 public class MapImporterTest extends AbstractImporterTest {
 
-    public MapImporterTest() {
-    }
-
     private Map<String, Object> mapWithOneParseableDate;
     private Map<String, Object> mapWithMultipleDates;
     private Map<String, Object> mapWithMultipleDatesAsList;
@@ -63,19 +60,20 @@ public class MapImporterTest extends AbstractImporterTest {
         datelist.add("1934/1936");
         datelist.add("1978");
         mapWithMultipleDatesAsList.put("unitDates", datelist);
-
     }
 
     @Test
     public void splitDatesFromDateProperty() {
-        Map<String, String> dates = MapImporter.returnDatesAsString(mapWithOneParseableDate, new XmlImportProperties("dates.properties"));
+        Map<String, String> dates = importer
+                .returnDatesAsString(mapWithOneParseableDate,
+                        new XmlImportProperties("dates.properties"));
         assertTrue(dates.containsKey("1934/1936"));
     }
 
     @Test
     public void extractDatesFromDateProperty() throws ItemNotFound {
-        List<Map<String, Object>> extractedDates = importer.extractDates(mapWithOneParseableDate);
-
+        List<Map<String, Object>> extractedDates = importer
+                .extractDates(mapWithOneParseableDate);
         for (Map<String, Object> dateMap : extractedDates) {
             assertEquals("1934/1936", dateMap.get(Ontology.DATE_HAS_DESCRIPTION));
         }
@@ -84,7 +82,8 @@ public class MapImporterTest extends AbstractImporterTest {
     @Test
     public void removeDateFromDateProperty() throws ItemNotFound {
         assertTrue(mapWithOneParseableDate.containsKey("unitDates"));
-        importer.replaceDates(mapWithOneParseableDate, importer.extractDates(mapWithOneParseableDate));
+        importer.replaceDates(mapWithOneParseableDate, importer
+                .extractDates(mapWithOneParseableDate));
         assertFalse(mapWithOneParseableDate.containsKey("unitDates"));
     }
 
@@ -101,31 +100,32 @@ public class MapImporterTest extends AbstractImporterTest {
     @Test
     public void removeDatesFromDatePropertyList() throws ItemNotFound {
         assertTrue(mapWithMultipleDatesAsList.containsKey("unitDates"));
-        importer.replaceDates(mapWithMultipleDatesAsList, importer.extractDates(mapWithMultipleDatesAsList));
+        importer.replaceDates(mapWithMultipleDatesAsList,
+                importer.extractDates(mapWithMultipleDatesAsList));
         assertFalse(mapWithMultipleDatesAsList.containsKey("unitDates"));
     }
 
     @Test
     public void beginDateYear() {
-        assertEquals("1944-01-01", MapImporter.normaliseDate("1944", Ontology.DATE_PERIOD_START_DATE));
+        assertEquals("1944-01-01",
+                importer.normaliseDate("1944", Ontology.DATE_PERIOD_START_DATE));
     }
 
     @Test
     public void beginDateYearMonth() {
-
-        assertEquals("1944-01-01", MapImporter.normaliseDate("1944-01", Ontology.DATE_PERIOD_START_DATE));
-
+        assertEquals("1944-01-01",
+                importer.normaliseDate("1944-01", Ontology.DATE_PERIOD_START_DATE));
     }
 
     @Test
     public void endDateYear() {
-        assertEquals("1944-12-31", MapImporter.normaliseDate("1944", Ontology.DATE_PERIOD_END_DATE));
+        assertEquals("1944-12-31",
+                importer.normaliseDate("1944", Ontology.DATE_PERIOD_END_DATE));
     }
 
     @Test
     public void endDateYearMonth() {
-        assertEquals("1944-01-31", MapImporter.normaliseDate("1944-01", Ontology.DATE_PERIOD_END_DATE));
-
+        assertEquals("1944-01-31",
+                importer.normaliseDate("1944-01", Ontology.DATE_PERIOD_END_DATE));
     }
-
 }


### PR DESCRIPTION
 - Make the date normalisation functions non-static since they use non-reentrant parsers internally. Make these parsers instance fields.
 - Don't catch and re-throw illegal argument exceptions in the Sax import manager since it eats too many errors that could be usefully passed to the client