### PR TITLE
Correct some badly-named maintenance event properties

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/exporters/eac/Eac2010Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/eac/Eac2010Exporter.java
@@ -404,7 +404,7 @@ public class Eac2010Exporter implements EacExporter {
 
             Element eventDateTimeElem = doc.createElement("eventDateTime");
             // TODO: Normalise and put standardDateTime attribute here?
-            eventDateTimeElem.setTextContent((String) event.getProperty("maintenanceEvent/date"));
+            eventDateTimeElem.setTextContent((String) event.getProperty("date"));
             eventElem.appendChild(eventDateTimeElem);
 
             Element agentTypeElem = doc.createElement("agentType");
@@ -415,7 +415,7 @@ public class Eac2010Exporter implements EacExporter {
             agentElem.setTextContent("EHRI");
             eventElem.appendChild(agentElem);
 
-            String eventDesc = event.getProperty("maintenanceEvent/source");
+            String eventDesc = event.getProperty("source");
             if (eventDesc != null && !eventDesc.trim().isEmpty()) {
                 Element eventDescElem = doc.createElement("eventDescription");
                 eventElem.appendChild(eventDescElem);

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/eag/Eag2012Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/eag/Eag2012Exporter.java
@@ -284,7 +284,7 @@ public class Eag2012Exporter implements EagExporter {
             eventElem.appendChild(agentType);
 
             Element eventDateTime = doc.createElement("eventDateTime");
-            eventDateTime.setTextContent((String) event.getProperty("maintenanceEvent/date"));
+            eventDateTime.setTextContent((String) event.getProperty("date"));
             eventElem.appendChild(eventDateTime);
 
             Element eventType = doc.createElement("eventType");

--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/MapImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/MapImporter.java
@@ -201,11 +201,11 @@ public abstract class MapImporter extends AbstractImporter<Map<String, Object>> 
     public Map<String, Object> getMaintenanceEvent(Map<String, Object> event) {
         Map<String, Object> me = Maps.newHashMap();
         for (Entry<String, Object> eventEntry : event.entrySet()) {
-            if (eventEntry.getKey().equals("maintenanceEvent/type")) {
+            // Hack for EAG 1 and 2012 compatibility - maps maintenance event
+            // types from old to new values
+            if (eventEntry.getKey().equals(Ontology.MAINTENANCE_EVENT_TYPE)) {
                 me.put(Ontology.MAINTENANCE_EVENT_TYPE, MaintenanceEventType
-                        .withName((String) eventEntry.getValue()));
-            } else if (eventEntry.getKey().equals("maintenanceEvent/agentType")) {
-                me.put(Ontology.MAINTENANCE_EVENT_AGENT_TYPE, eventEntry.getValue());
+                        .withName((String) eventEntry.getValue()).toString());
             } else {
                 me.put(eventEntry.getKey(), eventEntry.getValue());
             }

--- a/ehri-io/src/main/resources/eag.properties
+++ b/ehri-io/src/main/resources/eag.properties
@@ -1,11 +1,11 @@
 eagid/=descriptionIdentifier
 mainhist/mainevent/=maintenanceEvent
-mainhist/mainevent/@maintenanceType=maintenanceEvent/type
-mainhist/mainevent/date/@normaldate=maintenanceEvent/date
-mainhist/mainevent/respevent/charge/=maintenanceEvent/agentType
-mainhist/mainevent/respevent/firstname/=maintenanceEvent/agent
-mainhist/mainevent/respevent/surnames/=maintenanceEvent/agent
-mainhist/mainevent/source/=maintenanceEvent/source
+mainhist/mainevent/@maintenanceType=eventType
+mainhist/mainevent/date/@normaldate=date
+mainhist/mainevent/respevent/charge/=agentType
+mainhist/mainevent/respevent/firstname/=agent
+mainhist/mainevent/respevent/surnames/=agent
+mainhist/mainevent/source/=source
 identity/repositorid/@identifier=objectIdentifier
 entityType/=typeOfEntity
 autform/=name

--- a/ehri-io/src/main/resources/wienerlib.properties
+++ b/ehri-io/src/main/resources/wienerlib.properties
@@ -5,8 +5,8 @@ did/unitid/@ehrilabel$ehri_main_identifier=objectIdentifier
 did/unitid/@ehrilabel$ehri_multiple_identifier=otherIdentifiers
 #--maintenanceEvents
 revisiondesc/change/=maintenanceEvent
-revisiondesc/change/date/=maintenanceEvent/date
-revisiondesc/change/item/=maintenanceEvent/source
+revisiondesc/change/date/=date
+revisiondesc/change/item/=source
 
 #generic ead properties:
 #maybe change to did/unittitle/@ehrilabel$ehri_title=name

--- a/ehri-io/src/test/resources/exportdata.yaml
+++ b/ehri-io/src/test/resources/exportdata.yaml
@@ -73,8 +73,8 @@
             - id: example-maintenance-event-1
               type: MaintenanceEvent
               data:
-                maintenanceEvent/date: !!str 2013-09-09
-                maintenanceEvent/source: Exported from ICA-AtoM
+                date: !!str 2013-09-09
+                source: Exported from ICA-AtoM
                 eventType: updated
           hasAddress:
             - id: example-address-1
@@ -152,8 +152,8 @@
             - id: example-maintenance-event-2
               type: MaintenanceEvent
               data:
-                maintenanceEvent/date: !!str 2013-09-09
-                maintenanceEvent/source: Exported from ICA-AtoM
+                date: !!str 2013-09-09
+                source: Exported from ICA-AtoM
                 eventType: updated
           hasDate:
             - id: example-date-1


### PR DESCRIPTION
In some cases these have to be renamed in the DB via Cypher:

```cypher
MATCH (me:MaintenanceEvent)
WHERE me.`maintenanceEvent/date` IS NOT NULL
SET me.date = me.`maintenanceEvent/date`
REMOVE me.`maintenanceEvent/date`
RETURN COUNT(me)
```
```cypher
MATCH (me:MaintenanceEvent)
WHERE me.`maintenanceEvent/source` IS NOT NULL
SET me.source = me.`maintenanceEvent/source`
REMOVE me.`maintenanceEvent/source`
RETURN COUNT(me)
```
```cypher
MATCH (me:MaintenanceEvent)
WHERE me.type IS NOT NULL
SET me.eventType = me.type
REMOVE me.type
RETURN COUNT(me)
```
