### PR TITLE
Update Enunciate to 2.5.0, which works with Java 8.

### DIFF
--- a/ehri-cli/src/main/java/eu/ehri/project/commands/BaseCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/BaseCommand.java
@@ -38,7 +38,7 @@ import java.io.StringWriter;
 /**
  * Abstract base class for commands. Provides the main
  * entry points for interaction:
- * <p/>
+ * <p>
  * <ul>
  * <li>Set options</li>
  * <li>Get help</li>

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/Check.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/Check.java
@@ -84,7 +84,7 @@ public class Check extends BaseCommand {
 
     /**
      * The following types of item should ALL have a permission scope.
-     * <p/>
+     * <p>
      * Doc unit - either a repository or another doc unit
      * Concept - a vocabulary
      * Repository - a country
@@ -92,9 +92,8 @@ public class Check extends BaseCommand {
      *
      * @param graph   The graph
      * @param manager The graph manager
-     * @throws Exception
      */
-    public void checkPermissionScopes(FramedGraph<?> graph,
+    private void checkPermissionScopes(FramedGraph<?> graph,
                                       GraphManager manager) {
 
         List<EntityClass> types = Lists.newArrayList(DOCUMENTARY_UNIT, REPOSITORY, CVOC_CONCEPT, HISTORICAL_AGENT);

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/GraphSON.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/GraphSON.java
@@ -39,7 +39,7 @@ import java.util.zip.GZIPInputStream;
 
 /**
  * Dump the complete graph as graphSON file, or import such a dump
- * <p/>
+ * <p>
  * Example usage:
  * <pre>
  *     <code>

--- a/ehri-core/src/main/java/eu/ehri/project/acl/ItemPermissionSet.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/ItemPermissionSet.java
@@ -28,7 +28,7 @@ import java.util.Set;
 /**
  * Convenience wrapper for the permission set data structure, which
  * looks like:
- * <p/>
+ * <p>
  * <pre>
  *     <code>
  *  {

--- a/ehri-core/src/main/java/eu/ehri/project/api/QueryApi.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/QueryApi.java
@@ -103,7 +103,7 @@ public interface QueryApi {
 
     /**
      * Count all items of a given type.
-     * <p/>
+     * <p>
      * NB: Count doesn't 'account' for ACL privileges!
      */
     long count(EntityClass type);

--- a/ehri-core/src/main/java/eu/ehri/project/api/impl/QueryApiImpl.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/impl/QueryApiImpl.java
@@ -311,7 +311,7 @@ public final class QueryApiImpl implements QueryApi {
 
     /**
      * Count items accessible to a given user.
-     * <p/>
+     * <p>
      * NB: Count doesn't 'account' for ACL privileges!
      */
     @Override
@@ -322,7 +322,7 @@ public final class QueryApiImpl implements QueryApi {
 
     /**
      * Count all items of a given type.
-     * <p/>
+     * <p>
      * NB: Count doesn't 'account' for ACL privileges!
      */
     @Override

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/BlueprintsGraphManager.java
@@ -41,7 +41,7 @@ import java.util.NoSuchElementException;
 
 /**
  * Implementation of GraphManager that uses a single index to manage all nodes.
- * <p/>
+ * <p>
  * This class can be extended for when specific graph implementations (such
  * as Neo4j) can provide more efficient implementations of certain methods.
  */

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2Graph.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2Graph.java
@@ -163,7 +163,7 @@ public class Neo4j2Graph implements TransactionalGraph, MetaGraph<GraphDatabaseS
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * The underlying Neo4j graph does not natively support this method within a
      * transaction. If the graph is not currently in a transaction, then the
      * operation runs efficiently and correctly. If the graph is currently in a
@@ -212,7 +212,7 @@ public class Neo4j2Graph implements TransactionalGraph, MetaGraph<GraphDatabaseS
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * The underlying Neo4j graph does not natively support this method within a
      * transaction. If the graph is not currently in a transaction, then the
      * operation runs efficiently and correctly. If the graph is currently in a

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -52,7 +52,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Class that represents a graph entity and subtree relations
  * prior to being materialised as vertices and edges.
- * <p/>
+ * <p>
  * Note: unlike a vertex, a bundle can contain null values
  * in its data map, though these values will not be externally
  * visible. Null values <i>are</i> however used in merge operations,

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/DataConverter.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/DataConverter.java
@@ -224,10 +224,10 @@ class DataConverter {
 
     /**
      * Convert generic data into a bundle.
-     * <p/>
+     * <p>
      * Prize to whomever can remove all the unchecked warnings. I don't really
      * know how else to do this otherwise.
-     * <p/>
+     * <p>
      * NB: We also strip out all NULL property values at this stage.
      *
      * @throws DeserializationError

--- a/ehri-core/src/main/java/eu/ehri/project/tools/DbUpgrader1to2.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/DbUpgrader1to2.java
@@ -29,11 +29,11 @@ import java.util.UUID;
 /**
  * Single-use code to upgrade the DB schema from version
  * 1 to version 2.
- * <p/>
+ * <p>
  * Ideally, we'd use some declarative script for this, and were
  * it not for the JSON data in Version nodes that represents
  * prior incarnations of items, we could.
- * <p/>
+ * <p>
  * This function de-serializes the serialized data, upgrades it
  * to the new format, and serializes it again.
  */

--- a/ehri-core/src/main/java/eu/ehri/project/tools/Linker.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/Linker.java
@@ -91,15 +91,15 @@ public class Linker {
      * Populate a pre-created vocabulary with concepts created based on
      * access points for all collections within a repository, then link
      * those concepts to the relevant documentary units.
-     * <p/>
+     * <p>
      * One creation event will be generated for the newly-created concepts
      * (with the vocabulary as the scope) and another for the newly-created
      * links. Currently events will still be created if no concepts/links
      * are made.
-     * <p/>
+     * <p>
      * It should be advised that this function is not idempotent and
      * running it twice will generate concepts/links twice.
-     * <p/>
+     * <p>
      * NB. One could argue this function does too much...
      *
      * @param repository the repository

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiPromotionTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiPromotionTest.java
@@ -33,12 +33,12 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Test promotion/demotion.
- * <p/>
+ * <p>
  * NB: An item can be promoted multiple times (meaning there's
  * a "promotedBy" relationship from an item to a user. To
  * properly demote an item all "promotedBy" relationships must
  * be removed.
- * <p/>
+ * <p>
  * NB2: This might be to change.
  */
 public class ApiPromotionTest extends AbstractFixtureTest {

--- a/ehri-core/src/test/java/eu/ehri/project/models/CvocConceptTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/CvocConceptTest.java
@@ -45,7 +45,7 @@ public class CvocConceptTest extends ModelTestBase {
 
     /**
      * Just play a bit with a small 'graph' of concepts.
-     * <p/>
+     * <p>
      * NOTE: Better wait for the improved testing 'fixture' before doing
      * extensive testing on Concepts
      *

--- a/ehri-core/src/test/java/eu/ehri/project/test/utils/GraphCleaner.java
+++ b/ehri-core/src/test/java/eu/ehri/project/test/utils/GraphCleaner.java
@@ -25,7 +25,7 @@ import com.tinkerpop.frames.FramedGraph;
 
 /**
  * Deletes all nodes and indices from a Neo4j graph. Use with care.
- * <p/>
+ * <p>
  * Note: This does NOT reset the Neo4j node auto-increment id.
  */
 public class GraphCleaner<T extends Graph> {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/SaxXmlHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/SaxXmlHandler.java
@@ -40,17 +40,17 @@ import static eu.ehri.project.definitions.Ontology.LANGUAGE_OF_DESCRIPTION;
 /**
  * Reader of XML files, creator of {@link Map}-based representations of EA* files.
  * Makes use of properties file with format:
- * <p/>
+ * <p>
  * path/within/xml/=node/property
- * <p/>
+ * <p>
  * if no &lt;node&gt; is given, it is the default logical-unit or unit-description of this property file.
  * with eac.properties this would be an HistoricalAgent with an HistoricalAgentDescription
  * if there is a &lt;node&gt; given, it will translate to another graph node, like Address.
- * <p/>
+ * <p>
  * lines starting with '{@literal @}' give the attributes:
  * <code>{@literal @}attribute=tmpname
  * path/within/xml/@tmpname=node/property</code>
- * <p/>
+ * <p>
  * all tags not included in the properties file that have a  nodevalue will be put in a unknownproperties node,
  * with an edge to the unit-description.
  */
@@ -301,7 +301,7 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
      * @param path the stacked element names forming a path from the root to the current element
      * @return the corresponding value to this path from the properties file. the search is inside out, so if
      * both eadheader/ and ead/eadheader/ are specified, it will return the value for the first
-     * <p/>
+     * <p>
      * if this path has no corresponding value in the properties file, it will return the entire path name, with _
      * replacing the /
      */
@@ -317,7 +317,7 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
      * @param value     $ehri_main_identifier
      * @return the corresponding value to this path from the properties file. The search is inside out, so if
      * both eadheader/ and ead/eadheader/ are specified, it will return the value for the first.
-     * <p/>
+     * <p>
      * If this path has no corresponding value in the properties file, it will return the entire path name, with _
      * replacing the /
      */
@@ -335,7 +335,7 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
 
     /**
      * If this path has no corresponding value in the properties file, it will return false
-     * <p/>
+     * <p>
      * did/unitid/{@literal @}ehrilabel$ehri_main_identifier=objectIdentifier
      *
      * @param path      did/unitid/

--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/SaxXmlImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/SaxXmlImporter.java
@@ -75,7 +75,7 @@ public abstract class SaxXmlImporter extends MapImporter {
     /**
      * Extract DocumentaryUnit properties from the itemData and return them as a new Map.
      * This implementation only extracts the objectIdentifier.
-     * <p/>
+     * <p>
      * This implementation does not throw ValidationErrors.
      *
      * @param itemData a Map containing raw properties of a DocumentaryUnit

--- a/ehri-io/src/main/java/eu/ehri/project/importers/csv/PersonalitiesImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/csv/PersonalitiesImporter.java
@@ -48,7 +48,7 @@ import java.util.Map;
 
 /**
  * Importer of historical agents encoded in {@link Map}s.
- * <p/>
+ * <p>
  * Before importing the file: delete the columns with the reordering of the first and last name
  * add a column 'id' with a unique identifier, prefixed with EHRI-Personalities or some such.
  */

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
@@ -180,7 +180,7 @@ public class EadHandler extends SaxXmlHandler {
 
     /**
      * Called when the XML parser encounters an end tag. This is tuned for EAD files, which come in many flavours.
-     * <p/>
+     * <p>
      * Certain elements represent subcollections, for which we create new nodes (here, we create representative Maps for nodes).
      * Many EAD producers use the standard in their own special way, so this method calls generalised methods to filter, get data
      * in the right place and reformat.

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
@@ -63,7 +63,7 @@ import java.util.Stack;
  * procedure. An EAD a single entity at the highest level of description or multiple top-level entities, with or without
  * a hierarchical structure describing their child items. This means that we need to recursively descend through the
  * archdesc and c,c01-12 levels.
- * <p/>
+ * <p>
  * TODO: Extensive cleanups, optimisation, and rationalisation.
  */
 public class EadImporter extends SaxXmlImporter {
@@ -142,7 +142,7 @@ public class EadImporter extends SaxXmlImporter {
 
     /**
      * Extract the documentary unit description bundle from the raw map data.
-     * <p/>
+     * <p>
      * Note: the itemData map is mutable and should be considered an out parameter.
      *
      * @param itemData the raw data map
@@ -256,14 +256,14 @@ public class EadImporter extends SaxXmlImporter {
     /**
      * Subclasses can override this method to cater to their special needs for UndeterminedRelationships
      * by default, it expects something like this in the original EAD:
-     * <p/>
+     * <p>
      * <pre>
      * {@code
      * <persname source="terezin-victims" authfilenumber="PERSON.ITI.1514982">Kien,
      * Leonhard (* 11.5.1886)</persname>
      * }
      * </pre>
-     * <p/>
+     * <p>
      * it works in unison with the extractRelations() method.
      *
      * @param unit the current unit

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadHandler.java
@@ -149,7 +149,7 @@ public class VirtualEadHandler extends SaxXmlHandler {
 
     /**
      * Called when the XML parser encounters an end tag. This is tuned for EAD files, which come in many flavours.
-     * <p/>
+     * <p>
      * Certain elements represent subcollections, for which we create new nodes (here, we create representative Maps for nodes).
      * Many EAD producers use the standard in their own special way, so this method calls generalised methods to filter, get data
      * in the right place and reformat.

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadImporter.java
@@ -46,17 +46,17 @@ import java.util.Map;
 
 /**
  * Import EAD describing a Virtual Collection. some rules governing virtual collections:
- * <p/>
+ * <p>
  * the archdesc should describe the purpose of this vc. it can not in itself refer to a DU.
- * <p/>
+ * <p>
  * every c level is either 1) a virtual level (=VirtualLevel), or 2) it points to an existing DocumentaryUnit
  * (=VirtualReferrer) (and consequently to the entire subtree beneath it) 1) there is no repository-tag with a
  * ehri-label
- * <p/>
+ * <p>
  * 2) there is exactly one repository-tag with an ehri-label &lt;repository
  * label="ehri_repository_vc"&gt;il-002777&lt;/repository&gt; (this will not be shown in the portal) and exactly one unitid with
  * a ehri-main-identifier label, that is identical to the existing unitid within the graph for this repository
- * <p/>
+ * <p>
  * all other tags will be ignored, since the DocumentsDescription of the referred DocumentaryUnit will be shown. there
  * should not be any c-levels beneath such a c-level
  */
@@ -168,7 +168,7 @@ public class VirtualEadImporter extends EadImporter {
 
     /**
      * Creates a Map containing properties of a Virtual Unit.
-     * <p/>
+     * <p>
      * These properties are the unit's identifiers.
      *
      * @param itemData Map of all extracted information

--- a/ehri-io/src/main/java/eu/ehri/project/importers/properties/XmlImportProperties.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/properties/XmlImportProperties.java
@@ -177,7 +177,7 @@ abstract class PropertyLoader {
      * Looks up a resource named 'name' in the classpath. The resource must map to a file with .properties extension.
      * The name is assumed to be absolute and can use either "/" or "." for package segment separation with an optional
      * leading "/" and optional ".properties" suffix. Thus, the following names refer to the same resource:
-     * <p/>
+     * <p>
      * <pre>
      * some.pkg.Resource
      * some.pkg.Resource.properties

--- a/ehri-ws/enunciate.xml
+++ b/ehri-ws/enunciate.xml
@@ -1,22 +1,33 @@
 <?xml version="1.0"?>
-<enunciate label="ehri-ws-api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://enunciate.codehaus.org/schemas/enunciate-1.25.xsd">
 
-    <services>
-        <rest defaultRestSubcontext="/"/>
-    </services>
+<enunciate slug="api"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.5.0.xsd">
 
-    <api-classes>
-        <include pattern="eu.ehri.extension.*"/>
-    </api-classes>
+    <title>EHRI Web Service API</title>
+    <copyright>The EHRI Project</copyright>
+
+    <application root="http://localhost:7474/ehri"/>
 
     <modules>
-        <docs
-            includeExampleXml="false"
-            includeExampleJson="true" 
-            docsDir="restapi"
-            title="EHRI Web Service API"
-            copyright="The EHRI Project"
-             />
+        <!-- everything disabled except docs -->
+
+        <c-xml-client disabled="true"/>
+        <csharp-xml-client disabled="true"/>
+        <gwt-json-overlay disabled="true"/>
+        <idl disabled="true"/>
+        <jackson disabled="true" />
+        <jackson1 disabled="true"/>
+        <java-json-client disabled="true"/>
+        <java-xml-client disabled="true"/>
+        <javascript-client disabled="true"/>
+        <jaxb disabled="true"/>
+        <jaxws disabled="true"/>
+        <obj-c-xml-client disabled="true"/>
+        <php-json-client disabled="true"/>
+        <php-xml-client disabled="true"/>
+        <ruby-json-client disabled="true"/>
+        <spring-web disabled="true"/>
+        <swagger disabled="true"/>
     </modules>
 </enunciate>

--- a/ehri-ws/pom.xml
+++ b/ehri-ws/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <name>Web Service</name>
-    <description>Web service layer exposed via a Neo4j extension.</description>
+    <description>Web service layer exposed via a Neo4j extension at path: /ehri</description>
 
     <artifactId>ehri-ws</artifactId>
     <version>0.13.4-SNAPSHOT</version>
@@ -60,14 +60,20 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.enunciate</groupId>
-                <artifactId>maven-enunciate-plugin</artifactId>
-                <version>1.29</version>
+                <groupId>com.webcohesion.enunciate</groupId>
+                <artifactId>enunciate-maven-plugin</artifactId>
+                <version>2.5.0</version>
                 <configuration>
                     <configFile>enunciate.xml</configFile>
-                    <enunciateArtifactId>docs</enunciateArtifactId>
-                    <moduleName>docs</moduleName>
+                    <docsDir>${project.build.directory}</docsDir>
                     <docsSubdir>wsdocs</docsSubdir>
+                    <excludes>
+                        <exclude>org.neo4j.**</exclude>
+                    </excludes>
+                    <includes>
+                        <include>eu.ehri.extension.**</include>
+                    </includes>
+                    <enunciateArtifactId>docs</enunciateArtifactId>
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -80,6 +86,7 @@
             </plugin>
         </plugins>
     </reporting>
+
 
     <dependencies>
         <!-- the ehri data via tinkerpop frames project -->

--- a/ehri-ws/src/main/java/eu/ehri/extension/AdminResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AdminResource.java
@@ -73,7 +73,7 @@ public class AdminResource extends AbstractResource {
     /**
      * Export the DB as a stream of JSON in
      * <a href="https://github.com/tinkerpop/blueprints/wiki/GraphSON-Reader-and-Writer-Library">GraphSON</a> format.
-     * <p/>
+     * <p>
      * The mode used is EXTENDED.
      */
     @GET

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -109,16 +109,16 @@ public class ImportResource extends AbstractResource {
     /**
      * Import a SKOS file, of varying formats, as specified by the &quot;language&quot;
      * column of the file extensions table <a href="https://jena.apache.org/documentation/io/">here</a>.
-     * <p/>
+     * <p>
      * Example:
-     * <p/>
+     * <p>
      * <pre>
-     * {@code
+     *    <code>
      * curl -X POST \
      *      -H "X-User: mike" \
      *      --data-binary @skos-data.rdf \
-     *      "http://localhost:7474/ehri/import/skos?scope=gb-my-vocabulary&log=testing&tolerant=true"
-     * }
+     *      "http://localhost:7474/ehri/import/skos?scope=gb-my-vocabulary&amp;log=testing&amp;tolerant=true"
+     *     </code>
      * </pre>
      *
      * @param scopeId    the id of the import scope (i.e. repository)
@@ -176,23 +176,23 @@ public class ImportResource extends AbstractResource {
      * The Content-Type header is used to distinguish the contents.
      * <br>
      * <b>Note:</b> The archive does not currently support compression.
-     * <p/>
+     * <p>
      * The way you would run with would typically be:
-     * <p/>
+     * <p>
      * <pre>
-     * {@code
+     *    <code>
      *     curl -X POST \
      *      -H "X-User: mike" \
      *      --data-binary @ead-list.txt \
-     *      "http://localhost:7474/ehri/import/ead?scope=my-repo-id&log=testing&tolerant=true"
+     *      "http://localhost:7474/ehri/import/ead?scope=my-repo-id&amp;log=testing&amp;tolerant=true"
      *
      * # NB: Data is sent using --data-binary to preserve line-breaks - otherwise
      * # it needs url encoding.
-     * }
+     *    </code>
      * </pre>
-     * <p/>
+     * <p>
      * (Assuming <code>ead-list.txt</code> is a list of newline separated EAD file paths.)
-     * <p/>
+     * <p>
      * (TODO: Might be better to use a different way of encoding the local file paths...)
      *
      * @param scopeId       the id of the import scope (i.e. repository)
@@ -313,7 +313,7 @@ public class ImportResource extends AbstractResource {
      * Import a set of CSV files. See EAD handler for options and
      * defaults but substitute text/csv for the input mimetype when
      * a single file is POSTed.
-     * <p/>
+     * <p>
      * Additional note: no handler class is required.
      */
     @POST

--- a/ehri-ws/src/main/java/eu/ehri/extension/SystemEventResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/SystemEventResource.java
@@ -48,7 +48,7 @@ import javax.ws.rs.core.Response;
  * <p>
  * The following query parameters apply to all actions in this
  * resource to apply filtering to the event streams.
- * </p>
+ * <p>
  * <dl>
  * <dt>eventTypes</dt><dd>Filter events by type</dd>
  * <dt>itemTypes</dt><dd>Filter events based on the item type of their subjects</dd>
@@ -57,7 +57,7 @@ import javax.ws.rs.core.Response;
  * <dt>from</dt><dd>Exclude events prior to this date (ISO 8601 format)</dd>
  * <dt>to</dt><dd>Exclude events after this date (ISO 8601 format)</dd>
  * </dl>
- * <p/>
+ * <p>
  * Additionally the aggregate* end-points accept an <code>aggregation</code>
  * parameter that groups sequential events according to one of two different
  * strategies:
@@ -76,9 +76,9 @@ import javax.ws.rs.core.Response;
  * </ul>
  * </dd>
  * </dl>
- * <p/>
+ * <p>
  * Additionally, aggregation can be disabled by using <code>aggregation=off</code>.
- * <p/>
+ * <p>
  * Standard paging parameters apply to all end-points.
  */
 @Path(AbstractResource.RESOURCE_ENDPOINT_PREFIX + "/" + Entities.SYSTEM_EVENT)

--- a/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -160,12 +160,12 @@ public class ToolsResource extends AbstractResource {
     /**
      * Regenerate the hierarchical graph ID for a given item, optionally
      * renaming it.
-     * <p/>
+     * <p>
      * The default mode is to output items whose IDs would change, without
      * actually changing them. The {@code collisions} parameter will <b>only</b>
      * output items that would cause collisions if renamed, whereas {@code tolerant}
      * mode will skip them altogether.
-     * <p/>
+     * <p>
      * The {@code commit} flag will cause renaming to take place.
      *
      * @param id         the item's existing ID
@@ -203,12 +203,12 @@ public class ToolsResource extends AbstractResource {
     /**
      * Regenerate the hierarchical graph ID all items of a given
      * type.
-     * <p/>
+     * <p>
      * The default mode is to output items whose IDs would change, without
      * actually changing them. The {@code collisions} parameter will <b>only</b>
      * output items that would cause collisions if renamed, whereas {@code tolerant}
      * mode will skip them altogether.
-     * <p/>
+     * <p>
      * The {@code commit} flag will cause renaming to take place.
      *
      * @param type       the item type
@@ -248,12 +248,12 @@ public class ToolsResource extends AbstractResource {
     /**
      * Regenerate the hierarchical graph ID for all items within the
      * permission scope and lower levels.
-     * <p/>
+     * <p>
      * The default mode is to output items whose IDs would change, without
      * actually changing them. The {@code collisions} parameter will <b>only</b>
      * output items that would cause collisions if renamed, whereas {@code tolerant}
      * mode will skip them altogether.
-     * <p/>
+     * <p>
      * The {@code commit} flag will cause renaming to take place.
      *
      * @param scopeId    the scope item's ID

--- a/ehri-ws/src/main/java/eu/ehri/extension/base/AbstractResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/base/AbstractResource.java
@@ -164,7 +164,7 @@ public abstract class AbstractResource implements TxCheckedResource {
 
     /**
      * Get a serializer according to passed-in serialization config.
-     * <p/>
+     * <p>
      * Currently the only parameter is <code>_ip=[propertyName]</code> which
      * ensures a given property is always included in the output.
      *
@@ -361,7 +361,7 @@ public abstract class AbstractResource implements TxCheckedResource {
     /**
      * An abstraction class that handles streaming responses that
      * need to manage a transaction.
-     * <p/>
+     * <p>
      * We cannot just return a regular StreamingResponse here
      * because then HEAD requests will leak the transaction.
      */

--- a/ehri-ws/src/main/java/eu/ehri/extension/base/ListResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/base/ListResource.java
@@ -37,16 +37,16 @@ public interface ListResource {
      * header in the form:
      * <p>
      * <pre><code>page=1; count=20; total=50</code></pre>
-     * <p>
+     *
      * If the header <code>X-Stream</code> is set to <code>true</code>
      * no count of total items will be performed. This is more efficient when returning large
      * numbers of items or when limiting is disabled completely.
-     * <p>
+     *
      * Example:
      * <pre>
-     * {@code
-     * curl http://localhost:7474/ehri/[RESOURCE]/list?page=5&limit=10
-     * }
+     *      <code>
+     * curl http://localhost:7474/ehri/[RESOURCE]/list?page=5&amp;limit=10
+     *      </code>
      * </pre>
      *
      * @return A list of serialized item representations

--- a/ehri-ws/src/main/java/eu/ehri/extension/package-info.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/package-info.java
@@ -20,6 +20,6 @@
 /**
  * Jersey resource classes for providing
  * web service access to the graph, via
- * the {@link eu.ehri.project.views} layer.
+ * the {@link eu.ehri.project.api} layer.
  */
 package eu.ehri.extension;


### PR DESCRIPTION
Various additional Javadoc fixes to prevent linting errors.

Fixes #177.