### PR TITLE
Attempt to prevent network access for XML-schema validation tests.

### DIFF
--- a/ehri-io/src/main/resources/simpledc20021212.xsd
+++ b/ehri-io/src/main/resources/simpledc20021212.xsd
@@ -1,0 +1,78 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://purl.org/dc/elements/1.1/"
+           targetNamespace="http://purl.org/dc/elements/1.1/"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      Simple DC XML Schema, 2002-10-09
+      by Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu), Andy Powell (a.powell@ukoln.ac.uk),
+      Herbert Van de Sompel (hvdsomp@yahoo.com).
+      This schema defines terms for Simple Dublin Core, i.e. the 15
+      elements from the http://purl.org/dc/elements/1.1/ namespace, with
+      no use of encoding schemes or element refinements.
+      Default content type for all elements is xs:string with xml:lang
+      attribute available.
+
+      Supercedes version of 2002-03-12. 
+      Amended to remove namespace declaration for http://www.w3.org/XML/1998/namespace namespace,
+      and to reference lang attribute via built-in xml: namespace prefix.
+      xs:appinfo also removed.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/03/xml.xsd">
+  </xs:import>
+
+  <xs:element name="title" type="elementType"/>
+  <xs:element name="creator" type="elementType"/>
+  <xs:element name="subject" type="elementType"/>
+  <xs:element name="description" type="elementType"/>
+  <xs:element name="publisher" type="elementType"/>
+  <xs:element name="contributor" type="elementType"/>
+  <xs:element name="date" type="elementType"/>
+  <xs:element name="type" type="elementType"/>
+  <xs:element name="format" type="elementType"/>
+  <xs:element name="identifier" type="elementType"/>
+  <xs:element name="source" type="elementType"/>
+  <xs:element name="language" type="elementType"/>
+  <xs:element name="relation" type="elementType"/>
+  <xs:element name="coverage" type="elementType"/>
+  <xs:element name="rights" type="elementType"/>
+
+  <xs:group name="elementsGroup">
+  <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="title"/>
+      <xs:element ref="creator"/>
+      <xs:element ref="subject"/>
+      <xs:element ref="description"/>
+      <xs:element ref="publisher"/>
+      <xs:element ref="contributor"/>
+      <xs:element ref="date"/>
+      <xs:element ref="type"/>
+      <xs:element ref="format"/>
+      <xs:element ref="identifier"/>
+      <xs:element ref="source"/>
+      <xs:element ref="language"/>
+      <xs:element ref="relation"/>
+      <xs:element ref="coverage"/>
+      <xs:element ref="rights"/>
+    </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="elementType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>
+
+

--- a/ehri-io/src/main/resources/xml.xsd
+++ b/ehri-io/src/main/resources/xml.xsd
@@ -1,0 +1,145 @@
+<?xml version='1.0'?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    id   (as an attribute name): denotes an attribute whose value
+         should be interpreted as if declared to be of type ID.
+         This name is reserved by virtue of its definition in the
+         xml:id specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang, xml:space or xml:id
+        attributes on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2007/08/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself, or with the XML namespace itself.  In other words, if the XML
+   Schema or XML namespaces change, the version of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2007/08/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>Attempting to install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values is probably never
+         going to be a realistic possibility.  See
+         RFC 3066 at http://www.ietf.org/rfc/rfc3066.txt and the IANA registry
+         at http://www.iana.org/assignments/lang-tag-apps.htm for
+         further information.
+
+         The union allows for the 'un-declaration' of xml:lang with
+         the empty string.</xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xml-id/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/test/LocalResourceResolver.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/test/LocalResourceResolver.java
@@ -1,0 +1,113 @@
+package eu.ehri.project.exporters.test;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URL;
+
+/**
+ * XML resource resolver that tries to resolve links
+ * to local resources, and complains if it can't find
+ * them.
+ * <p>
+ * Largely borrowed from <a href="http://stackoverflow.com/a/2342859/285374">
+ * this StackOverflow answer</a>.
+ */
+class LocalResourceResolver implements LSResourceResolver {
+
+    public LSInput resolveResource(String type, String namespaceURI,
+            String publicId, String systemId, String baseURI) {
+
+        // note: in this sample, the XSD's are expected to be in the root of the classpath
+        String id = systemId.substring(systemId.lastIndexOf("/") + 1);
+        try {
+            try {
+                URL resourceUrl = Resources.getResource(id);
+                String s = Resources.toString(resourceUrl, Charsets.UTF_8);
+                return new Input(publicId, systemId, s);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("No local resource found for id: " + systemId);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class Input implements LSInput {
+
+        private String publicId;
+
+        private String systemId;
+
+        public String getPublicId() {
+            return publicId;
+        }
+
+        public void setPublicId(String publicId) {
+            this.publicId = publicId;
+        }
+
+        public String getBaseURI() {
+            return null;
+        }
+
+        public InputStream getByteStream() {
+            return null;
+        }
+
+        public boolean getCertifiedText() {
+            return false;
+        }
+
+        public Reader getCharacterStream() {
+            return null;
+        }
+
+        public String getEncoding() {
+            return null;
+        }
+
+        public String getStringData() {
+            return stringData;
+        }
+
+        public void setBaseURI(String baseURI) {
+        }
+
+        public void setByteStream(InputStream byteStream) {
+        }
+
+        public void setCertifiedText(boolean certifiedText) {
+        }
+
+        public void setCharacterStream(Reader characterStream) {
+        }
+
+        public void setEncoding(String encoding) {
+        }
+
+        public void setStringData(String stringData) {
+        }
+
+        public String getSystemId() {
+            return systemId;
+        }
+
+        public void setSystemId(String systemId) {
+            this.systemId = systemId;
+        }
+
+        private final String stringData;
+
+        Input(String publicId, String sysId, String stringData) {
+            this.publicId = publicId;
+            this.systemId = sysId;
+            this.stringData = stringData;
+        }
+    }
+}

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/test/XmlExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/test/XmlExporterTest.java
@@ -45,6 +45,8 @@ public class XmlExporterTest extends AbstractImporterTest {
     protected void validatesSchema(String xml, String schemaResourceName) throws IOException, SAXException {
         SchemaFactory factory = SchemaFactory
                 .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        factory.setResourceResolver(new LocalResourceResolver());
+
         Schema schema = factory.newSchema(Resources.getResource(schemaResourceName));
         Validator validator = schema.newValidator();
         validator.validate(new StreamSource(new ByteArrayInputStream(xml.getBytes("UTF-8"))));


### PR DESCRIPTION
This should make sure that everything that should be resolved in an XML file (e.g. the xlink schema) is present as a local resource.

Fixes #242.