### PR TITLE
Refactor web service transactions in streaming responses.

### DIFF
--- a/ehri-ws/src/main/java/eu/ehri/extension/AdminResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AdminResource.java
@@ -81,7 +81,7 @@ public class AdminResource extends AbstractResource {
     @Path("export-graphson")
     public Response getGraphSON() throws Exception {
         return Response.ok((StreamingOutput) stream -> {
-            try (final Tx tx = graph.getBaseGraph().beginTx()) {
+            try (final Tx tx = beginTx()) {
                 Accessor accessor = getRequesterUserProfile();
                 AclGraph<?> aclGraph = new AclGraph<Graph>(graph.getBaseGraph(), accessor);
                 GraphSONWriter.outputGraph(aclGraph, stream, GraphSONMode.EXTENDED);
@@ -95,7 +95,7 @@ public class AdminResource extends AbstractResource {
     @Path("export-json")
     public Response exportNodes() throws Exception {
         return Response.ok((StreamingOutput) stream -> {
-            try (final Tx tx = graph.getBaseGraph().beginTx()) {
+            try (final Tx tx = beginTx()) {
                 Accessor accessor = getRequesterUserProfile();
                 AclGraph<?> aclGraph = new AclGraph<Graph>(graph.getBaseGraph(), accessor);
                 JsonDataExporter.outputGraph(aclGraph, stream);
@@ -118,7 +118,7 @@ public class AdminResource extends AbstractResource {
     @Path("create-default-user-profile")
     public Response createDefaultUserProfile(String jsonData,
             @QueryParam(GROUP_PARAM) List<String> groups) throws Exception {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             String ident = getNextDefaultUserId();
             Bundle bundle = Bundle.Builder.withClass(EntityClass.USER_PROFILE)
                     .addDataValue(Ontology.IDENTIFIER_KEY, ident)

--- a/ehri-ws/src/main/java/eu/ehri/extension/AnnotationResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AnnotationResource.java
@@ -105,7 +105,7 @@ public class AnnotationResource extends AbstractAccessibleResource<Annotation>
             Bundle bundle)
             throws PermissionDenied, AccessDenied, ValidationError, DeserializationError,
             ItemNotFound, SerializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             if (id == null) {
                 throw new DeserializationError("Target must be provided");
             }
@@ -123,7 +123,7 @@ public class AnnotationResource extends AbstractAccessibleResource<Annotation>
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ItemNotFound, ValidationError, DeserializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response response = updateItem(id, bundle);
             tx.success();
             return response;
@@ -135,7 +135,7 @@ public class AnnotationResource extends AbstractAccessibleResource<Annotation>
     @Override
     public void delete(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             deleteItem(id);
             tx.success();
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
@@ -89,7 +89,7 @@ public class CvocConceptResource
     public Response update(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = updateItem(id, bundle);
             tx.success();
             return item;
@@ -101,7 +101,7 @@ public class CvocConceptResource
     @Override
     public void delete(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             deleteItem(id);
             tx.success();
         }
@@ -113,14 +113,12 @@ public class CvocConceptResource
     @Override
     public Response listChildren(@PathParam("id") String id,
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            return streamingPage(getQuery()
-                    .page(concept.getNarrowerConcepts(), Concept.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(concept.getNarrowerConcepts(), Concept.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -133,7 +131,7 @@ public class CvocConceptResource
             Bundle bundle, @QueryParam(ACCESSOR_PARAM) List<String> accessors)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             final Concept parent = api().detail(id, cls);
             Response item = createItem(bundle, accessors, concept -> {
                 parent.addNarrowerConcept(concept);
@@ -159,7 +157,7 @@ public class CvocConceptResource
             @PathParam("id") String id,
             @QueryParam(ID_PARAM) List<String> narrower)
             throws AccessDenied, PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = single(api().concepts()
                     .addNarrowerConcepts(id, narrower));
             tx.success();
@@ -181,7 +179,7 @@ public class CvocConceptResource
             @PathParam("id") String id,
             @QueryParam(ID_PARAM) List<String> narrower)
             throws PermissionDenied, AccessDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = single(api().concepts()
                     .removeNarrowerConcepts(id, narrower));
             tx.success();
@@ -202,13 +200,11 @@ public class CvocConceptResource
     @Path("{id:[^/]+}/broader")
     public Response getCvocBroaderConcepts(@PathParam("id") String id)
             throws ItemNotFound, AccessDenied {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            return streamingList(concept.getBroaderConcepts(), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingList(concept.getBroaderConcepts());
+            tx.success();
+            return response;
         }
     }
 
@@ -223,13 +219,11 @@ public class CvocConceptResource
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/related")
     public Response getCvocRelatedConcepts(@PathParam("id") String id) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            return streamingList(concept.getRelatedConcepts(), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingList(concept.getRelatedConcepts());
+            tx.success();
+            return response;
         }
     }
 
@@ -246,13 +240,11 @@ public class CvocConceptResource
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{id:[^/]+}/relatedBy")
     public Response getCvocRelatedByConcepts(@PathParam("id") String id) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            return streamingList(concept.getRelatedByConcepts(), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingList(concept.getRelatedByConcepts());
+            tx.success();
+            return response;
         }
     }
 
@@ -272,7 +264,7 @@ public class CvocConceptResource
             @PathParam("id") String id,
             @QueryParam(ID_PARAM) List<String> related)
             throws AccessDenied, PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = single(api().concepts()
                     .addRelatedConcepts(id, related));
             tx.success();
@@ -296,7 +288,7 @@ public class CvocConceptResource
             @PathParam("id") String id,
             @QueryParam(ID_PARAM) List<String> related)
             throws AccessDenied, PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = single(api().concepts()
                     .removeRelatedConcepts(id, related));
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/extension/HistoricalAgentResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/HistoricalAgentResource.java
@@ -93,7 +93,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
     public Response create(Bundle bundle,
             @QueryParam(ACCESSOR_PARAM) List<String> accessors)
             throws PermissionDenied, ValidationError, DeserializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = createItem(bundle, accessors);
             tx.success();
             return item;
@@ -108,7 +108,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
     public Response update(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response response = updateItem(id, bundle);
             tx.success();
             return response;
@@ -120,7 +120,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
     @Override
     public void delete(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             deleteItem(id);
             tx.success();
         }
@@ -141,7 +141,7 @@ public class HistoricalAgentResource extends AbstractAccessibleResource<Historic
     public Response exportEac(@PathParam("id") String id,
             final @QueryParam("lang") @DefaultValue("eng") String lang)
             throws IOException, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             HistoricalAgent agent = api().detail(id, HistoricalAgent.class);
             EacExporter eacExporter = new Eac2010Exporter(graph, api());
             final Document document = eacExporter.export(agent, lang);

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -144,7 +144,7 @@ public class ImportResource extends AbstractResource {
             throws ItemNotFound, ValidationError,
             IOException, DeserializationError {
 
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             // Get the current user from the Authorization header and the scope
             // from the query params...
             UserProfile user = getCurrentUser();
@@ -232,7 +232,7 @@ public class ImportResource extends AbstractResource {
             throws ItemNotFound, ValidationError,
             IOException, DeserializationError {
 
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             checkPropertyFile(propertyFile);
             Class<? extends SaxXmlHandler> handler
                     = getHandlerCls(handlerClass, DEFAULT_EAD_HANDLER);
@@ -331,7 +331,7 @@ public class ImportResource extends AbstractResource {
             throws ItemNotFound, ValidationError,
             IOException, DeserializationError {
 
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Class<? extends AbstractImporter> importer
                     = getImporterCls(importerClass, DEFAULT_EAD_IMPORTER);
 
@@ -384,7 +384,7 @@ public class ImportResource extends AbstractResource {
             @DefaultValue("true") @QueryParam(VERSION_PARAM) Boolean version,
             @QueryParam(LOG_PARAM) String logMessage, InputStream inputStream)
             throws IOException, ItemNotFound, ValidationError, DeserializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = getCurrentUser();
             PermissionScope scope = scopeId != null
                     ? manager.getEntity(scopeId, PermissionScope.class)
@@ -417,7 +417,7 @@ public class ImportResource extends AbstractResource {
             @QueryParam(LOG_PARAM) String logMessage,
             @QueryParam(ID_PARAM) List<String> ids)
             throws IOException, ItemNotFound, DeserializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = getCurrentUser();
             PermissionScope scope = scopeId != null
                     ? manager.getEntity(scopeId, PermissionScope.class)

--- a/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
@@ -84,7 +84,7 @@ public class LinkResource extends AbstractAccessibleResource<Link>
     @Override
     public Response update(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ItemNotFound, ValidationError, DeserializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = updateItem(id, bundle);
             tx.success();
             return item;
@@ -116,7 +116,7 @@ public class LinkResource extends AbstractAccessibleResource<Link>
             @QueryParam(ACCESSOR_PARAM) List<String> accessors)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             if (source == null || target == null) {
                 throw new DeserializationError("Both source and target must be provided");
             }
@@ -134,7 +134,7 @@ public class LinkResource extends AbstractAccessibleResource<Link>
     @Override
     public void delete(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             deleteItem(id);
             tx.success();
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/PermissionGrantResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/PermissionGrantResource.java
@@ -61,7 +61,7 @@ public class PermissionGrantResource extends AbstractResource implements DeleteR
     @Path("{id:[^/]+}")
     @Override
     public Response get(@PathParam("id") String id) throws ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             PermissionGrant grant = manager.getEntity(id,
                     EntityClass.PERMISSION_GRANT, PermissionGrant.class);
             Response response = single(grant);
@@ -81,7 +81,7 @@ public class PermissionGrantResource extends AbstractResource implements DeleteR
     @Path("{id:[^/]+}")
     @Override
     public void delete(@PathParam("id") String id) throws ItemNotFound, PermissionDenied {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             api().acl().revokePermissionGrant(manager.getEntity(id,
                     EntityClass.PERMISSION_GRANT, PermissionGrant.class));
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/extension/PermissionsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/PermissionsResource.java
@@ -81,7 +81,7 @@ public class PermissionsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     public InheritedGlobalPermissionSet getGlobalMatrix() throws PermissionDenied,
             ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             InheritedGlobalPermissionSet matrix = getGlobalMatrix(getRequesterUserProfile().getId());
             tx.success();
             return matrix;
@@ -101,7 +101,7 @@ public class PermissionsResource extends AbstractResource {
     @Path("{userOrGroup:[^/]+}")
     public InheritedGlobalPermissionSet getGlobalMatrix(@PathParam("userOrGroup") String userId)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             InheritedGlobalPermissionSet set = api()
                     .aclManager()
@@ -127,7 +127,7 @@ public class PermissionsResource extends AbstractResource {
     public InheritedGlobalPermissionSet setGlobalMatrix(
             @PathParam("userOrGroup") String userId,
             GlobalPermissionSet globals) throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             InheritedGlobalPermissionSet newPerms
                     = api().acl().setGlobalPermissionMatrix(accessor, globals);
@@ -151,7 +151,7 @@ public class PermissionsResource extends AbstractResource {
     public InheritedItemPermissionSet getEntityMatrix(
             @PathParam("userOrGroup") String userId,
             @PathParam("id") String id) throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             Accessible entity = manager.getEntity(id, Accessible.class);
             AclManager acl = api().withScope(entity.getPermissionScope()).aclManager();
@@ -178,7 +178,7 @@ public class PermissionsResource extends AbstractResource {
             @PathParam("userOrGroup") String userId,
             @PathParam("id") String id,
             ItemPermissionSet itemPerms) throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             Accessible item = manager.getEntity(id, Accessible.class);
             InheritedItemPermissionSet set = api().acl()
@@ -201,7 +201,7 @@ public class PermissionsResource extends AbstractResource {
     @Path("{userOrGroup:[^/]+}/scope/{id:[^/]+}")
     public InheritedGlobalPermissionSet getScopedMatrix(@PathParam("userOrGroup") String userId,
             @PathParam("id") String id) throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             PermissionScope scope = manager.getEntity(id, PermissionScope.class);
             InheritedGlobalPermissionSet set = api()
@@ -231,7 +231,7 @@ public class PermissionsResource extends AbstractResource {
             @PathParam("userOrGroup") String userId,
             @PathParam("id") String id,
             GlobalPermissionSet globals) throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             PermissionScope scope = manager.getEntity(id, PermissionScope.class);
             InheritedGlobalPermissionSet matrix = api()
@@ -254,14 +254,12 @@ public class PermissionsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userOrGroup:[^/]+}/" + GenericResource.PERMISSION_GRANTS)
     public Response listPermissionGrants(@PathParam("userOrGroup") String id) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             Accessor user = manager.getEntity(id, Accessor.class);
-            return streamingPage(getQuery()
-                    .page(user.getPermissionGrants(), PermissionGrant.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getPermissionGrants(), PermissionGrant.class));
+            tx.success();
+            return response;
         }
     }
 }

--- a/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -139,7 +139,7 @@ public class ToolsResource extends AbstractResource {
             @QueryParam(TOLERANT_PARAM) @DefaultValue("false") boolean tolerant)
             throws ItemNotFound, ValidationError,
             PermissionDenied, DeserializationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile user = getCurrentUser();
             Repository repository = manager.getEntity(repositoryId, Repository.class);
             Vocabulary vocabulary = manager.getEntity(vocabularyId, Vocabulary.class);
@@ -188,7 +188,7 @@ public class ToolsResource extends AbstractResource {
             @QueryParam("tolerant") @DefaultValue("false") boolean tolerant,
             @QueryParam("commit") @DefaultValue("false") boolean commit)
             throws ItemNotFound, IOException, IdRegenerator.IdCollisionError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessible item = manager.getEntity(id, Accessible.class);
             Optional<List<String>> remap = new IdRegenerator(graph)
                     .withActualRename(commit)
@@ -230,7 +230,7 @@ public class ToolsResource extends AbstractResource {
             @QueryParam("tolerant") @DefaultValue("false") boolean tolerant,
             @QueryParam("commit") @DefaultValue("false") boolean commit)
             throws IOException, IdRegenerator.IdCollisionError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             EntityClass entityClass = EntityClass.withName(type);
             try (CloseableIterable<Accessible> frames = manager
                     .getEntities(entityClass, Accessible.class)) {
@@ -276,7 +276,7 @@ public class ToolsResource extends AbstractResource {
             @QueryParam("tolerant") @DefaultValue("false") boolean tolerant,
             @QueryParam("commit") @DefaultValue("false") boolean commit)
             throws IOException, ItemNotFound, IdRegenerator.IdCollisionError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             PermissionScope scope = manager.getEntity(scopeId, PermissionScope.class);
             List<List<String>> lists = new IdRegenerator(graph)
                     .withActualRename(commit)
@@ -306,7 +306,7 @@ public class ToolsResource extends AbstractResource {
                 .REPOSITORY_DESCRIPTION};
         Serializer depSerializer = new Serializer.Builder(graph).dependentOnly().build();
         int done = 0;
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             for (EntityClass entityClass : types) {
                 try (CloseableIterable<Description> descriptions = manager.getEntities(entityClass, Description.class)) {
                     for (Description desc : descriptions) {
@@ -346,7 +346,7 @@ public class ToolsResource extends AbstractResource {
     public String setLabels()
             throws IOException, ItemNotFound, IdRegenerator.IdCollisionError {
         long done = 0;
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             for (Vertex v : graph.getVertices()) {
                 try {
                     ((Neo4jGraphManager) manager).setLabels(v);
@@ -370,7 +370,7 @@ public class ToolsResource extends AbstractResource {
     @Produces("text/plain")
     @Path("set-constraints")
     public void setConstraints() {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             logger.info("Initializing graph schema...");
             manager.initialize();
             tx.success();
@@ -382,7 +382,7 @@ public class ToolsResource extends AbstractResource {
     @Path("upgrade-1to2")
     public String upgradeDb1to2() throws IOException {
         final AtomicInteger done = new AtomicInteger();
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             logger.info("Upgrading DB schema...");
             DbUpgrader1to2 upgrader1to2 = new DbUpgrader1to2(graph, () -> {
                 if (done.getAndIncrement() % 100000 == 0) {
@@ -407,7 +407,7 @@ public class ToolsResource extends AbstractResource {
         upgradeDb1to2();
         setLabels();
         setConstraints();
-        try (Tx tx = graph.getBaseGraph().beginTx()) {
+        try (Tx tx = beginTx()) {
             new DbUpgrader1to2(graph, () -> {
             }).setDbSchemaVersion();
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/extension/UserProfileResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/UserProfileResource.java
@@ -108,7 +108,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @QueryParam(ACCESSOR_PARAM) List<String> accessors) throws PermissionDenied,
             ValidationError, DeserializationError,
             ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             final Api.Acl acl = api().acl();
             final Set<Group> groups = Sets.newHashSet();
             for (String groupId : groupIds) {
@@ -134,7 +134,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response update(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = updateItem(id, bundle);
             tx.success();
             return item;
@@ -146,7 +146,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Override
     public void delete(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             deleteItem(id);
             tx.success();
         }
@@ -156,14 +156,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + FOLLOWERS)
     public Response listFollowers(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getFollowers(), UserProfile.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getFollowers(), UserProfile.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -171,14 +169,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + FOLLOWING)
     public Response listFollowing(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getFollowing(), UserProfile.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getFollowing(), UserProfile.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -189,7 +185,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @PathParam("otherId") String otherId)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
             boolean following = user.isFollowing(
                     manager.getEntity(otherId, UserProfile.class));
@@ -205,7 +201,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @PathParam("otherId") String otherId)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
             boolean follower = user.isFollower(manager.getEntity(otherId, UserProfile.class));
             tx.success();
@@ -219,7 +215,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             userProfilesApi().addFollowers(userId, otherIds);
             tx.success();
         }
@@ -231,7 +227,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             userProfilesApi().removeFollowers(userId, otherIds);
             tx.success();
         }
@@ -241,14 +237,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + BLOCKED)
     public Response listBlocked(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getBlocked(), UserProfile.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getBlocked(), UserProfile.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -259,7 +253,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @PathParam("otherId") String otherId)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
             boolean blocking = user.isBlocking(manager.getEntity(otherId, UserProfile.class));
             tx.success();
@@ -273,7 +267,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             userProfilesApi().addBlocked(userId, otherIds);
             tx.success();
         }
@@ -285,7 +279,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             userProfilesApi().removeBlocked(userId, otherIds);
             tx.success();
         }
@@ -295,14 +289,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + WATCHING)
     public Response listWatching(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getWatching(), Watchable.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getWatching(), Watchable.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -312,7 +304,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             userProfilesApi().addWatching(userId, otherIds);
             tx.success();
         }
@@ -324,7 +316,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(ID_PARAM) List<String> otherIds)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             userProfilesApi().removeWatching(userId, otherIds);
             tx.success();
         }
@@ -337,7 +329,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @PathParam("otherId") String otherId)
             throws PermissionDenied, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
             boolean watching = user.isWatching(manager.getEntity(otherId, Watchable.class));
             tx.success();
@@ -349,14 +341,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + GenericResource.ANNOTATIONS)
     public Response listAnnotations(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getAnnotations(), Annotation.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getAnnotations(), Annotation.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -364,14 +354,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + GenericResource.LINKS)
     public Response pageLinks(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getLinks(), Link.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getLinks(), Link.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -379,14 +367,12 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{userId:[^/]+}/" + Entities.VIRTUAL_UNIT)
     public Response pageVirtualUnits(@PathParam("userId") String userId) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            return streamingPage(getQuery()
-                    .page(user.getVirtualUnits(), VirtualUnit.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(user.getVirtualUnits(), VirtualUnit.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -407,15 +393,13 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(AGGREGATION_PARAM) @DefaultValue("strict") EventsApi.Aggregation aggregation)
             throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile user = manager.getEntity(userId, UserProfile.class);
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            return streamingListOfLists(eventsApi.aggregateUserActions(user), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingListOfLists(eventsApi.aggregateUserActions(user));
+            tx.success();
+            return response;
         }
     }
 
@@ -437,15 +421,13 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             @PathParam("userId") String userId,
             @QueryParam(AGGREGATION_PARAM) @DefaultValue("user") EventsApi.Aggregation aggregation)
             throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             UserProfile asUser = manager.getEntity(userId, UserProfile.class);
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            return streamingListOfLists(eventsApi.aggregateAsUser(asUser), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingListOfLists(eventsApi.aggregateAsUser(asUser));
+            tx.success();
+            return response;
         }
     }
 
@@ -454,16 +436,13 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     @Path("{userId:[^/]+}/" + VIRTUAL_UNITS)
     public Response listVirtualUnitsForUser(@PathParam("userId") String userId)
             throws AccessDenied, ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             Accessor accessor = manager.getEntity(userId, Accessor.class);
             Iterable<VirtualUnit> units = api().virtualUnits()
                     .getVirtualCollectionsForUser(accessor);
-            return streamingPage(getQuery()
-                    .page(units, VirtualUnit.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery().page(units, VirtualUnit.class));
+            tx.success();
+            return response;
         }
     }
 

--- a/ehri-ws/src/main/java/eu/ehri/extension/VirtualUnitResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VirtualUnitResource.java
@@ -95,16 +95,14 @@ public final class VirtualUnitResource extends
     public Response listChildVirtualUnits(
             @PathParam("id") String id,
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             VirtualUnit parent = manager.getEntity(id, VirtualUnit.class);
             Iterable<VirtualUnit> units = all
                     ? parent.getAllChildren()
                     : parent.getChildren();
-            return streamingPage(getQuery().page(units, cls), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery().page(units, cls));
+            tx.success();
+            return response;
         }
     }
 
@@ -113,14 +111,12 @@ public final class VirtualUnitResource extends
     @Path("{id:[^/]+}/" + INCLUDED)
     public Response listIncludedVirtualUnits(
             @PathParam("id") String id) throws ItemNotFound {
-        final Tx tx = graph.getBaseGraph().beginTx();
-        try {
+        try (final Tx tx = beginTx()) {
             VirtualUnit parent = manager.getEntity(id, VirtualUnit.class);
-            return streamingPage(getQuery()
-                    .page(parent.getIncludedUnits(), DocumentaryUnit.class), tx);
-        } catch (Exception e) {
-            tx.close();
-            throw e;
+            Response response = streamingPage(getQuery()
+                    .page(parent.getIncludedUnits(), DocumentaryUnit.class));
+            tx.success();
+            return response;
         }
     }
 
@@ -129,7 +125,7 @@ public final class VirtualUnitResource extends
     public Response addIncludedVirtualUnits(
             @PathParam("id") String id, @QueryParam(ID_PARAM) List<String> includedIds)
             throws ItemNotFound, PermissionDenied {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile currentUser = getCurrentUser();
             VirtualUnit parent = api().detail(id, cls);
             Response item = single(api().virtualUnits().addIncludedUnits(parent,
@@ -144,7 +140,7 @@ public final class VirtualUnitResource extends
     public Response removeIncludedVirtualUnits(
             @PathParam("id") String id, @QueryParam(ID_PARAM) List<String> includedIds)
             throws ItemNotFound, PermissionDenied {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile currentUser = getCurrentUser();
             VirtualUnit parent = api().detail(id, cls);
             Response item = single(api().virtualUnits().removeIncludedUnits(parent,
@@ -160,7 +156,7 @@ public final class VirtualUnitResource extends
             @PathParam("from") String fromId, @PathParam("to") String toId,
             @QueryParam(ID_PARAM) List<String> includedIds)
             throws ItemNotFound, PermissionDenied {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             UserProfile currentUser = getCurrentUser();
             VirtualUnit fromVu = api().detail(fromId, cls);
             VirtualUnit toVu = api().detail(toId, cls);
@@ -178,7 +174,7 @@ public final class VirtualUnitResource extends
             @QueryParam(ID_PARAM) List<String> includedIds)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             final Accessor currentUser = getCurrentUser();
             final Iterable<DocumentaryUnit> includedUnits
                     = getIncludedUnits(includedIds, currentUser);
@@ -202,7 +198,7 @@ public final class VirtualUnitResource extends
     public Response update(@PathParam("id") String id, Bundle bundle)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Response item = updateItem(id, bundle);
             tx.success();
             return item;
@@ -214,7 +210,7 @@ public final class VirtualUnitResource extends
     @Override
     public void delete(@PathParam("id") String id)
             throws PermissionDenied, ItemNotFound, ValidationError {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             deleteItem(id);
             tx.success();
         }
@@ -229,7 +225,7 @@ public final class VirtualUnitResource extends
             @QueryParam(ID_PARAM) List<String> includedIds)
             throws AccessDenied, PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
-        try (final Tx tx = graph.getBaseGraph().beginTx()) {
+        try (final Tx tx = beginTx()) {
             Accessor currentUser = getRequesterUserProfile();
             final Iterable<DocumentaryUnit> includedUnits
                     = getIncludedUnits(includedIds, currentUser);


### PR DESCRIPTION
Streaming responses now run in a different transaction to the body of the request. This is less _transactional_, but much simpler, and doesn't have problems with edge cases like HEAD requests where Jersey skips the body altogether.