### PR TITLE
Initial GraphQL implementation, wrapping the API.

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -63,6 +63,10 @@
                             <include>org.openrdf.sesame:sesame-queryalgebra-evaluation</include>
                             <include>org.openrdf.*</include>
                             <include>net.fortytwo.sesametools:*</include>
+
+                            <!-- GraphQL deps -->
+                            <include>org.antlr:*</include>
+                            <include>com.graphql-java:*</include>
                         </includes>
                     </artifactSet>
                 </configuration>
@@ -108,6 +112,11 @@
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-io</artifactId>
+            <version>${project.parent.version} </version>
+        </dependency>
+        <dependency>
+            <groupId>ehri-project</groupId>
+            <artifactId>ehri-ws-graphql</artifactId>
             <version>${project.parent.version} </version>
         </dependency>
         <dependency>

--- a/ehri-cli/pom.xml
+++ b/ehri-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-cli</artifactId>
     <name>Command Line Tools</name>

--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-core</artifactId>
     <packaging>jar</packaging>

--- a/ehri-core/src/main/java/eu/ehri/project/api/QueryApi.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/QueryApi.java
@@ -88,7 +88,7 @@ public interface QueryApi {
      * Return a Page instance containing a total of total items, and an iterable
      * for the given page/count.
      */
-    <E extends Entity> Page<E> page(Iterable<E> entities, Class<E> cls);
+    <E extends Entity> Page<E> page(Iterable<? extends E> entities, Class<E> cls);
 
     /**
      * Return a Page instance containing a total of total items, and an iterable

--- a/ehri-core/src/main/java/eu/ehri/project/api/impl/QueryApiImpl.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/impl/QueryApiImpl.java
@@ -262,7 +262,7 @@ public final class QueryApiImpl implements QueryApi {
      * for the given page/count.
      */
     @Override
-    public <E extends Entity> Page<E> page(Iterable<E> entities, Class<E> cls) {
+    public <E extends Entity> Page<E> page(Iterable<? extends E> entities, Class<E> cls) {
         PipeFunction<Vertex, Boolean> aclFilterFunction = AclManager
                 .getAclFilterFunction(accessor);
 

--- a/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
@@ -75,7 +75,7 @@ public class AclGraphTest extends AbstractFixtureTest {
     public void testGetEdgesAttachedToInvisibleNodes() throws Exception {
         List<Edge> edges1 = Lists.newArrayList(validUserGraph.getEdges());
         List<Edge> edges2 = Lists.newArrayList(invalidUserGraph.getEdges());
-        assertEquals(edges2.size() + 34, edges1.size());
+        assertEquals(edges2.size() + 38, edges1.size());
     }
 
     @Test

--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -146,7 +146,7 @@
               data:
                 name: An Address
                 street: 1 Some St.
-                city: Amsterdam
+                municipality: Amsterdam
                 email:
                   - test@example.com
                 webpage:
@@ -518,6 +518,19 @@
       - moderators
     promotedBy: tim
     demotedBy: linda
+
+- id: ann7
+  type: Annotation
+  data:
+    identifier: ann7
+    body: Created by
+    isPromotable: !!bool true
+  relationships:
+    hasAnnotationTarget: c4
+    hasAnnotationBody: mike
+    access:
+      - mike
+      - moderators
 
 --- # Links
  - id: link1

--- a/ehri-cypher/pom.xml
+++ b/ehri-cypher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
     <artifactId>ehri-io</artifactId>
 

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/ead/Ead2002Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/ead/Ead2002Exporter.java
@@ -303,8 +303,7 @@ public final class Ead2002Exporter implements EadExporter {
                 Country country = repository.getCountry();
                 Element lineElem = doc.createElement("addressline");
                 addrElem.appendChild(lineElem);
-                lineElem.setTextContent(new java.util.Locale(Locale.ENGLISH.getLanguage(), country.getCode())
-                        .getDisplayCountry());
+                lineElem.setTextContent(LanguageHelpers.countryCodeToName(country.getId()));
             }
         }
     }

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/eag/Eag2012Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/eag/Eag2012Exporter.java
@@ -133,7 +133,7 @@ public final class Eag2012Exporter implements EagExporter {
                 locationElem.appendChild(countryElem);
                 String cc = Optional.fromNullable(((String) address.getProperty("countryCode")))
                         .or(country.getCode());
-                countryElem.setTextContent(new Locale("en", cc).getDisplayCountry());
+                countryElem.setTextContent(LanguageHelpers.countryCodeToName(cc));
                 Element postCodeElem = doc.createElement("municipalityPostalcode");
                 locationElem.appendChild(postCodeElem);
                 postCodeElem.setTextContent(address.getProperty("postalcode"));

--- a/ehri-io/src/main/java/eu/ehri/project/utils/LanguageHelpers.java
+++ b/ehri-io/src/main/java/eu/ehri/project/utils/LanguageHelpers.java
@@ -468,4 +468,15 @@ public class LanguageHelpers {
         return new Locale(Locale.ENGLISH.getLanguage(), code)
                 .getDisplayCountry(Locale.ENGLISH);
     }
+
+    /**
+     * Convert and ISO639-2 code to its (English) name.
+     *
+     * @param code the 2-letter country code
+     * @return the country name
+     */
+    public static String countryCodeToName(String code) {
+        return new java.util.Locale(Locale.ENGLISH.getLanguage(), code)
+                .getDisplayCountry();
+    }
 }

--- a/ehri-ws-graphql/pom.xml
+++ b/ehri-ws-graphql/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ehri-data</artifactId>
+        <groupId>ehri-project</groupId>
+        <version>0.13.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ehri-ws-graphql</artifactId>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>ehri-project</groupId>
+            <artifactId>ehri-ws</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>ehri-project</groupId>
+            <artifactId>ehri-core</artifactId>
+            <version>${project.parent.version} </version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ehri-project</groupId>
+            <artifactId>ehri-ws</artifactId>
+            <version>${project.parent.version} </version>
+            <type>test-jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.app</groupId>
+            <artifactId>neo4j-server</artifactId>
+            <version>${neo4j.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-kernel</artifactId>
+            <version>${neo4j.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-io</artifactId>
+            <version>${neo4j.version}</version>
+            <type>test-jar</type>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>2.7.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/ehri-ws-graphql/src/main/java/eu/ehri/extension/GraphQLResource.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/extension/GraphQLResource.java
@@ -1,0 +1,72 @@
+package eu.ehri.extension;
+
+import eu.ehri.extension.base.AbstractAccessibleResource;
+import eu.ehri.extension.errors.ExecutionError;
+import eu.ehri.extension.errors.ExecutionException;
+import eu.ehri.project.core.Tx;
+import eu.ehri.project.graphql.GraphQLImpl;
+import eu.ehri.project.graphql.GraphQLQuery;
+import eu.ehri.project.models.base.Accessible;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLException;
+import graphql.introspection.IntrospectionQuery;
+import graphql.schema.GraphQLSchema;
+import org.neo4j.graphdb.GraphDatabaseService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+@Path(GraphQLResource.ENDPOINT)
+public class GraphQLResource extends AbstractAccessibleResource<Accessible> {
+
+    public static final String ENDPOINT = "graphql";
+
+    public GraphQLResource(@Context GraphDatabaseService database) {
+        super(database, Accessible.class);
+    }
+
+    // Helpers
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ExecutionResult describe() throws Exception {
+        try (final Tx tx = beginTx()) {
+            GraphQLSchema schema = new GraphQLImpl(api()).getSchema();
+            tx.success();
+            return new GraphQL(schema).execute(IntrospectionQuery.INTROSPECTION_QUERY);
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ExecutionResult query(GraphQLQuery q) throws Exception {
+        try (final Tx tx = beginTx()) {
+            GraphQLSchema schema = new GraphQLImpl(api()).getSchema();
+            ExecutionResult executionResult = new GraphQL(schema).execute(
+                    q.getQuery(), (Object) null, q.getVariablesAsMap());
+            tx.success();
+
+            if (!executionResult.getErrors().isEmpty()) {
+                throw new ExecutionError(executionResult.getErrors());
+            }
+
+            return executionResult;
+        } catch (GraphQLException e) {
+            throw new ExecutionException(e);
+        }
+    }
+
+    @POST
+    @Consumes({MediaType.TEXT_PLAIN, MediaType.APPLICATION_OCTET_STREAM})
+    @Produces(MediaType.APPLICATION_JSON)
+    public ExecutionResult query(String q) throws Exception {
+        return query(new GraphQLQuery(q));
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/extension/errors/ExecutionError.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/extension/errors/ExecutionError.java
@@ -1,0 +1,39 @@
+package eu.ehri.extension.errors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import graphql.GraphQLError;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExecutionError extends WebApplicationException {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public ExecutionError(List<GraphQLError> errors) {
+        super(Response.status(Response.Status.BAD_REQUEST)
+                .entity(errorToJson(errors).getBytes(Charsets.UTF_8)).build());
+    }
+
+    private static String errorToJson(List<GraphQLError> errors) {
+        try {
+            return mapper.writeValueAsString(
+                    ImmutableMap.of("errors", errors.stream().map(e -> ImmutableMap.of(
+                            "message", e.getMessage(),
+                            "location", e.getLocations().stream().map(s -> ImmutableMap.of(
+                                    "line", s.getLine(),
+                                    "column", s.getColumn()
+                            )).collect(Collectors.toList()),
+                            "type", e.getErrorType().name()
+                            )).collect(Collectors.toList())
+                    )
+            );
+        } catch (JsonProcessingException err) {
+            throw new RuntimeException(err);
+        }
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/extension/errors/ExecutionException.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/extension/errors/ExecutionException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.extension.errors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import graphql.GraphQLException;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class ExecutionException extends WebApplicationException {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public ExecutionException(GraphQLException cause) {
+        super(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(errorToJson(cause).getBytes(Charsets.UTF_8)).build());
+    }
+
+    private static String errorToJson(GraphQLException cause) {
+        try {
+            Map<String, Object> error = ImmutableMap.of(
+                    "message", cause.getMessage(),
+                    "type", "ExecutionException"
+            );
+            return mapper.writeValueAsString(
+                    ImmutableMap.of("errors", ImmutableList.of(error))
+            );
+        } catch (JsonProcessingException err) {
+            throw new RuntimeException(err);
+        }
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/extension/errors/InvalidJsonError.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/extension/errors/InvalidJsonError.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.extension.errors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class InvalidJsonError extends WebApplicationException {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public InvalidJsonError(JsonProcessingException cause) {
+        super(Response.status(Response.Status.BAD_REQUEST)
+                .entity(errorToJson(cause).getBytes(Charsets.UTF_8)).build());
+    }
+
+    private static String errorToJson(JsonProcessingException cause) {
+        try {
+            Map<String, Object> error = ImmutableMap.of(
+                    "message", cause.getOriginalMessage(),
+                    "location", ImmutableList.of(ImmutableMap.of(
+                            "line", cause.getLocation().getLineNr(),
+                            "column", cause.getLocation().getColumnNr()
+                    )),
+                    "type", "JsonError"
+            );
+            return mapper.writeValueAsString(
+                    ImmutableMap.of("errors", ImmutableList.of(error))
+            );
+        } catch (JsonProcessingException err) {
+            throw new RuntimeException(err);
+        }
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/extension/providers/ExecutionResultProvider.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/extension/providers/ExecutionResultProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.extension.providers;
+
+import com.google.common.collect.ImmutableMap;
+import graphql.ExecutionResult;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class ExecutionResultProvider implements MessageBodyWriter<ExecutionResult>, JsonMessageBodyHandler {
+
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return ExecutionResult.class.isAssignableFrom(aClass);
+    }
+
+    @Override
+    public long getSize(ExecutionResult executionResult, Class<?> aClass, Type type, Annotation[] annotations,
+            MediaType mediaType) {
+        return -1L;
+    }
+
+    @Override
+    public void writeTo(ExecutionResult executionResult,
+            Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> headers, OutputStream outputStream) throws IOException,
+            WebApplicationException {
+
+        if (executionResult.getData() != null) {
+            mapper.writeValue(outputStream, ImmutableMap.of(
+                    "data", executionResult.getData()));
+        }
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/extension/providers/GraphQLQueryProvider.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/extension/providers/GraphQLQueryProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.extension.providers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.ehri.project.graphql.GraphQLQuery;
+import eu.ehri.extension.errors.InvalidJsonError;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class GraphQLQueryProvider implements MessageBodyReader<GraphQLQuery>,
+        MessageBodyWriter<GraphQLQuery>, JsonMessageBodyHandler {
+
+    @Override
+    public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return GraphQLQuery.class.isAssignableFrom(aClass);
+    }
+
+    @Override
+    public GraphQLQuery readFrom(Class<GraphQLQuery> aClass, Type type, Annotation[] annotations,
+            MediaType mediaType, MultivaluedMap<String, String> multivaluedMap,
+            InputStream inputStream) throws IOException, WebApplicationException {
+        try {
+            return mapper.readValue(inputStream, GraphQLQuery.class);
+        } catch (JsonProcessingException e) {
+            throw new InvalidJsonError(e);
+        }
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return GraphQLQuery.class.isAssignableFrom(aClass);
+    }
+
+    @Override
+    public long getSize(GraphQLQuery graphQLQuery, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public void writeTo(GraphQLQuery graphQLQuery, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
+        mapper.writeValue(outputStream, graphQLQuery);
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/DefinitionList.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/DefinitionList.java
@@ -1,0 +1,47 @@
+package eu.ehri.project.definitions;
+
+import com.google.common.collect.Lists;
+
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+public interface DefinitionList {
+
+    Boolean isMultiValued();
+    String name();
+
+    static ResourceBundle bundle = ResourceBundle.getBundle("eu.ehri.project.definitions.messages");
+
+    static Map<String,String> getMap(DefinitionList[] items, Boolean multivalued) {
+        return Lists.newArrayList(items).stream()
+                .filter(i -> multivalued == null || i.isMultiValued() == multivalued)
+                .map(i -> Lists.newArrayList(i.getName(), i.getDescription()))
+                .collect(Collectors.toMap(i -> i.get(0), i -> i.get(1)));
+    }
+
+    static Map<String,String> getMap(DefinitionList[] items) {
+        return getMap(items, null);
+    }
+
+    default String getResourceKey(String key) {
+        try {
+            return bundle.getString(key);
+        } catch (MissingResourceException e) {
+            return "!" + key + "!";
+        }
+    }
+
+    default String messageKey() {
+        return String.format("%s.%s", getClass().getSimpleName(), name());
+    }
+
+    default String getName() {
+        return getResourceKey(messageKey());
+    }
+
+    default String getDescription() {
+        return getResourceKey(String.format("%s.description", messageKey()));
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/Isaar.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/Isaar.java
@@ -1,0 +1,36 @@
+package eu.ehri.project.definitions;
+
+public enum Isaar implements DefinitionList {
+
+    lastName,
+    firstName,
+    source,
+    typeOfEntity,
+    otherFormsOfName(true),
+    datesOfExistence,
+    biographicalHistory,
+    place(true),
+    functions(true),
+    mandates(true),
+    legalStatus,
+    structure,
+    generalContext,
+    scripts(true),
+    sources(true),
+    occupation;
+
+    private final Boolean multiValued;
+
+
+    Isaar() {
+        this(false);
+    }
+
+    Isaar(Boolean multiValued) {
+        this.multiValued = multiValued;
+    }
+
+    public Boolean isMultiValued() {
+        return multiValued;
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/IsadG.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/IsadG.java
@@ -1,0 +1,46 @@
+package eu.ehri.project.definitions;
+
+public enum IsadG implements DefinitionList {
+
+    archivistNote,
+    archivalHistory,
+    acquisition,
+    appraisal,
+    accruals,
+    biographicalHistory,
+    conditionsOfAccess,
+    conditionsOfReproduction,
+    //dates,
+    datesOfDescriptions,
+    extentAndMedium,
+    findingAids(true),
+    languageOfMaterial(true),
+    locationOfOriginals(true),
+    locationOfCopies(true),
+    relatedUnitsOfDescription,
+    physicalCharacteristics,
+    physicalLocation(true),
+    publicationNote,
+    notes(true),
+    rulesAndConventions,
+    scopeAndContent,
+    scriptOfMaterial(true),
+    separatedUnitsOfDescription,
+    sources(true),
+    systemOfArrangement;
+
+    private final Boolean multiValued;
+
+
+    IsadG() {
+        this(false);
+    }
+
+    IsadG(Boolean multiValued) {
+        this.multiValued = multiValued;
+    }
+
+    public Boolean isMultiValued() {
+        return multiValued;
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/Isdiah.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/Isdiah.java
@@ -1,0 +1,44 @@
+package eu.ehri.project.definitions;
+
+public enum Isdiah implements DefinitionList {
+
+    typeOfEntity,
+    otherFormsOfName(true),
+    parallelFormsOfName(true),
+    history,
+    geoculturalContext,
+    mandates,
+    administrativeStructure,
+    records,
+    buildings,
+    holdings,
+    findingAids,
+    openingTimes,
+    conditions,
+    accessibility,
+    researchServices,
+    reproductionServices,
+    publicAreas,
+    rulesAndConventions,
+    status,
+    datesOfDescription,
+    languages(true),
+    scripts(true),
+    sources(true),
+    maintenanceNotes;
+
+    private final Boolean multiValued;
+
+
+    Isdiah() {
+        this(false);
+    }
+
+    Isdiah(Boolean multiValued) {
+        this.multiValued = multiValued;
+    }
+
+    public Boolean isMultiValued() {
+        return multiValued;
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/messages.properties
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/definitions/messages.properties
@@ -1,0 +1,314 @@
+#
+# Copyright 2015 Data Archiving and Networked Services (an institute of
+# Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+# Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+# the European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Licence is distributed on an "AS IS" basis,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the Licence for the specific language governing
+# permissions and limitations under the Licence.
+#
+
+# ISAD(G)
+
+IsadG.name=Title
+IsadG.name.description=Name the unit of description.
+
+IsadG.identifier=Description Code
+IsadG.identifier.description=Uniquely identifies the unit of description
+
+IsadG.archivistNote=Archivists note
+IsadG.archivistNote.description=To explain how the description was prepared and by whom.
+
+IsadG.archivalHistory=Archival history
+IsadG.archivalHistory.description=Provides information on the history of the unit of description \
+  that is significant for its authenticity, integrity and interpretation.
+
+IsadG.acquisition=Acquisition
+IsadG.acquisition.description=To identify the immediate source of acquisition or transfer.
+
+IsadG.appraisal=Appraisal
+IsadG.appraisal.description=To provide information on any appraisal, destruction and scheduling action.
+
+IsadG.accruals=Accruals
+IsadG.accruals.description=To inform the user of foreseen additions to the unit of description.
+
+IsadG.biographicalHistory=Biographical history
+IsadG.biographicalHistory.description=Provides an administrative history of, or biographical details on, \
+  the creator (or creators) of the unit of description to place the material in context and make it \
+  better understood.
+
+IsadG.conditionsOfAccess=Conditions of access
+IsadG.conditionsOfAccess.description=To provide information on the legal status or other \
+  regulations that restrict or affect access to the unit of description.
+
+IsadG.conditionsOfReproduction=Conditions of reproduction
+IsadG.conditionsOfReproduction.description=To identify any restrictions on reproduction \
+  of the unit of description.
+
+IsadG.dates=Dates
+IsadG.dates.description=Identifies and records the date(s) of the unit of description.
+
+IsadG.datesOfDescriptions=Dates of descriptions
+IsadG.datesOfDescriptions.description=To indicate when this description was prepared and/or revised.
+
+IsadG.extentAndMedium=Extent and medium
+IsadG.extentAndMedium.description=\
+  To identify and describe:\n\
+   1. the physical or logical extent and\n\
+   2. the medium of the unit of description.
+
+IsadG.findingAids=Finding aids
+IsadG.findingAids.description=To identify any finding aids to the unit of description.
+
+IsadG.languageOfMaterial=Language of material
+IsadG.languageOfMaterial.description=To identify the language(s) employed in the unit of description.
+
+IsadG.locationOfOriginals=Location of originals
+IsadG.locationOfOriginals.description=To indicate the existence, location, availability \
+  and/or destruction of originals where the unit of description consists of copies.
+
+IsadG.locationOfCopies=Location of copies
+IsadG.locationOfCopies.description=To indicate the existence, location and availability \
+  of copies of the unit of description.
+
+IsadG.relatedUnitsOfDescription=Related units of description
+IsadG.relatedUnitsOfDescription.description=To identify related units of description.
+
+IsadG.physicalCharacteristics=Physical characteristics
+IsadG.physicalCharacteristics.description=To provide information about any important physical \
+  characteristics or technical requirements that affect use of the unit of description.
+
+IsadG.physicalLocation=Physical location
+IsadG.physicalLocation.description=The physical location or shelf number of the item(s) \
+  within their repository or holding institution. (No direct ISAD(G) field equivalent.)
+
+IsadG.publicationNote=Publication note
+IsadG.publicationNote.description=To identify any publications that are about or are \
+  based on the use, study, or analysis of the unit of description.
+
+IsadG.notes=Notes
+IsadG.notes.description=To provide information that cannot be accommodated in any of the other areas.
+
+IsadG.rulesAndConventions=Rules and conventions
+IsadG.rulesAndConventions.description=To identify the protocols on which the description is based.
+
+IsadG.scopeAndContent=Scope and content
+IsadG.scopeAndContent.description=Enables users to judge the potential relevance of the unit of description.
+
+IsadG.scriptOfMaterial=Script of material
+IsadG.scriptOfMaterial.description=To identify the script(s) employed in the unit of description.
+
+IsadG.separatedUnitsOfDescription=Separated units of description
+IsadG.separatedUnitsOfDescription.description=Information about materials that are associated by provenance \
+  to the described materials but that have been physically separated or removed. Items may be separated for various \
+  reasons, including the dispersal of special formats to more appropriate custodial units; the outright destruction \
+  of duplicate or nonessential material; and the deliberate or unintentional scattering of fonds among different \
+  repositories.
+
+IsadG.sources=Sources
+IsadG.sources.description=Record notes on sources consulted in preparing the \
+  description and who prepared it.
+
+IsadG.systemOfArrangement=System of arrangement
+IsadG.systemOfArrangement.description=To provide information on the internal structure, the order \
+  and/or the system of classification of the unit of description.
+
+
+# ISDIAH
+
+Isdiah.name=Authorized form of name
+Isdiah.name.description=To create an authorised access point that uniquely identifies the institution with \
+  archival holdings.
+
+Isdiah.parallelFormsOfName=Parallel names
+Isdiah.parallelFormsOfName.description=To indicate the various forms in which the authorised form \
+  of name of an institution with archival holdings occurs in other languages or script form(s).
+
+Isdiah.otherFormsOfName=Other names
+Isdiah.otherFormsOfName.description=To indicate any other name(s) for the institution with \
+  archival holdings not used elsewhere in the Identity Area.
+
+Isdiah.institutionType=Type of institution
+Isdiah.institutionType.description=To identify the type of an institution with archival holdings.
+
+Isdiah.contactPerson=Contact person
+Isdiah.contactPerson.description=To provide users with all the information needed to contact members of staff.
+
+Isdiah.history=History
+Isdiah.history.description=To provide a concise history of the institution with archival holdings.
+
+Isdiah.geoculturalContext=Geographical and cultural context
+Isdiah.geoculturalContext.description=To provide information about the geographical and \
+  cultural context of the institution with archival holdings.
+
+Isdiah.mandates=Mandates/sources of authority
+Isdiah.mandates.description=To indicate the sources of authority for the institution with \
+  archival holdings in terms of its powers, functions, responsibilities or sphere of \
+  activities, including territorial.
+
+Isdiah.administrativeStructure=Administrative structure
+Isdiah.administrativeStructure.description=To represent the current administrative structure \
+  of the institution with archival holdings.
+
+Isdiah.records=Records management and collecting policies
+Isdiah.records.description=To provide information about the records management and collecting \
+  policies of the institution with archival holdings.
+
+Isdiah.buildings=Building(s)
+Isdiah.buildings.description=To provide information about the building(s) of the institution \
+  with archival holdings.
+
+Isdiah.holdings=Archival and other holdings
+Isdiah.holdings.description=To provide a profile of the holdings of the institution.
+
+Isdiah.findingAids=Finding aids, guides, and publication
+Isdiah.findingAids.description=To provide a general overview of the published and/or \
+  unpublished finding aids and guides prepared by the institution with archival \
+  holdings and any other relevant publications.
+
+Isdiah.openingTimes=Opening times
+Isdiah.openingTimes.description=To provide information on opening times and dates of annual closures.
+
+Isdiah.conditions=Conditions of access
+Isdiah.conditions.description=To provide information about the conditions, requirements \
+  and procedures for access to, and use of institutional services.
+
+Isdiah.accessibility=Accessibility
+Isdiah.accessibility.description=To provide accessibility information related to the \
+  institution with archival holdings and its services.
+
+Isdiah.researchServices=Research services
+Isdiah.researchServices.description=To describe the research services provided by the \
+  institution with archival holdings.
+
+Isdiah.reproductionServices=Reproduction services
+Isdiah.reproductionServices.description=To provide information about reproduction services.
+
+Isdiah.publicAreas=Public Areas
+Isdiah.publicAreas.description=To provide information about areas of the institution \
+  available for public use.
+
+Isdiah.descriptionIdentifier=Description identifier
+Isdiah.descriptionIdentifier.description=To identify the description of the institution with \
+  archival holdings uniquely within the context in which it will be used.
+
+Isdiah.institutionIdentifier=Institution identifier
+Isdiah.institutionIdentifier.description=To identify the agency(ies) responsible for the description.
+
+Isdiah.rulesAndConventions=Rules and conventions
+Isdiah.rulesAndConventions.description=To identify the national or international conventions \
+  or rules applied in creating the description.
+
+Isdiah.status=Status
+Isdiah.status.description=To indicate the drafting status of the description so \
+  that users can understand the current status of the description.
+
+Isdiah.languages=Languages
+Isdiah.languages.description=To indicate the language(s) used to create the description of the \
+  institution with archival holdings.
+
+Isdiah.scripts=Scripts
+Isdiah.scripts.description=To indicate the script(s) used to create the description of the \
+  institution with archival holdings.
+
+Isdiah.levelOfDetail=Level of detail
+Isdiah.levelOfDetail.description=To indicate whether the description applies a minimal, \
+  partial or a full level of detail.
+
+Isdiah.datesCVD=Dates of creation and deletion
+Isdiah.datesCVD.description=To indicate when this description was created, revised or deleted.
+
+Isdiah.sources=Sources
+Isdiah.sources.description=To indicate the sources consulted in creating the description \
+  of the institution with archival holdings.
+
+Isdiah.maintenanceNotes=Maintenance notes
+Isdiah.maintenanceNotes.description=To document additional information relating to the \
+  creation of and changes to the description.
+
+
+# ISAAR
+
+Isaar.parallelFormsOfName=Parallel names
+Isaar.parallelFormsOfName.description=To indicate the various forms in which the Authorized \
+  form of name occurs in other languages or script forms(s).
+
+Isaar.standardisedFormsOfName=Standardized names According to other rules
+Isaar.standarisedFormsOfName.description=To indicate standardized forms of name for the corporate \
+  body, person or family that have been constructed according to rules other than those \
+  used to construct the authorised form of name. This can facilitate the sharing of authority \
+  records between different professional communities.
+
+Isaar.otherFormsOfName=Other names
+Isaar.otherFormsOfName.description=To indicate any other name(s) for the corporate body, person or \
+  family not used elsewhere in the Identity Area.
+
+Isaar.datesOfExistence=Dates of existence
+Isaar.datesOfExistence.description=To indicate the dates of existence of the corporate body, person or family.
+
+Isaar.biographicalHistory=History
+Isaar.biographicalHistory.description=To provide a concise history of the corporate body, person or family.
+
+Isaar.place=Places
+Isaar.place.description=To indicate the predominant places and/or jurisdictions where the corporate body, person \
+  or family was based, lived or resided or had some other connection.
+
+Isaar.legalStatus=Legal Status
+Isaar.legalStatus.description=To indicate the legal status of a corporate body.
+
+Isaar.functions=Functions
+Isaar.functions.description=To indicate the functions, occupations and activities performed by the \
+  corporate body, person or family.
+
+Isaar.mandates=Mandates
+Isaar.mandates.description=To indicate the sources of authority for the corporate body, person \
+  or family in terms of its powers, functions, responsibilities or sphere of activities, \
+  including territorial.
+
+Isaar.structure=Internal structure
+Isaar.structure.description=To describe and/or represent the internal administrative structure(s) \
+  of a corporate body or the genealogy of a family.
+
+Isaar.generalContext=General context
+Isaar.generalContext.description=To provide significant information on the general social, \
+  cultural, economic, political and/or historical context in which the corporate body, person \
+  or family operated, lived or was active.
+
+Isaar.institutionIdentifier=Institution identifier
+Isaar.institutionIdentifier.description=To identify the agency(ies) responsible for the authority record.
+
+Isaar.rulesAndConventions=Rules and conventions
+Isaar.rulesAndConventions.description=To identify the national or international conventions \
+  or rules applied in creating the archival authority record.
+
+Isaar.status=Status
+Isaar.status.description=To indicate the drafting status of the authority record \
+  so that users can understand the current status of the authority record.
+
+Isaar.levelOfDetail=Level of detail
+Isaar.levelOfDetail.description=To indicate whether the authority record applies a minimal, \
+  partial or a full level of detail.
+
+Isaar.datesCVD=Dates of creation and deletion
+Isaar.datesCVD.description=To indicate when this authority record was created, revised or deleted.
+
+Isaar.languages=Languages
+Isaar.languages.description=To indicate the language(s) used to create the authority record.
+
+Isaar.scripts=Scripts
+Isaar.scripts.description=To indicate the script(s) used to create the authority record.
+
+Isaar.source=Sources
+Isaar.source.description=To identify the sources consulted in creating the authority record.
+
+Isaar.maintenanceNotes=Maintenance notes
+Isaar.maintenanceNotes.description=To document the creation of and changes to the authority record.

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
@@ -1,0 +1,1004 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.graphql;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import eu.ehri.project.acl.AclManager;
+import eu.ehri.project.api.Api;
+import eu.ehri.project.api.QueryApi;
+import eu.ehri.project.definitions.DefinitionList;
+import eu.ehri.project.definitions.Entities;
+import eu.ehri.project.definitions.Isaar;
+import eu.ehri.project.definitions.IsadG;
+import eu.ehri.project.definitions.Isdiah;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.exceptions.ItemNotFound;
+import eu.ehri.project.models.Annotation;
+import eu.ehri.project.models.Country;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.Link;
+import eu.ehri.project.models.Repository;
+import eu.ehri.project.models.RepositoryDescription;
+import eu.ehri.project.models.annotations.EntityType;
+import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Annotatable;
+import eu.ehri.project.models.base.Described;
+import eu.ehri.project.models.base.Description;
+import eu.ehri.project.models.base.Entity;
+import eu.ehri.project.models.base.Linkable;
+import eu.ehri.project.models.base.Temporal;
+import eu.ehri.project.models.cvoc.AuthoritativeSet;
+import eu.ehri.project.models.cvoc.Concept;
+import eu.ehri.project.models.cvoc.Vocabulary;
+import eu.ehri.project.persistence.Bundle;
+import eu.ehri.project.utils.LanguageHelpers;
+import graphql.relay.Base64;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.TypeResolver;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static graphql.Scalars.GraphQLBoolean;
+import static graphql.Scalars.GraphQLInt;
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLArgument.newArgument;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInterfaceType.newInterface;
+import static graphql.schema.GraphQLObjectType.newObject;
+
+/**
+ * Implementation of a GraphQL schema over the API
+ */
+public class GraphQLImpl {
+
+    private static final String SLICE_PARAM = "at";
+    private static final String FIRST_PARAM = "first";
+    private static final String FROM_PARAM = "from";
+    private static final String AFTER_PARAM = "after";
+
+    private static final String HAS_PREVIOUS_PAGE = "hasPreviousPage";
+    private static final String HAS_NEXT_PAGE = "hasNextPage";
+    private static final String PAGE_INFO = "pageInfo";
+    private static final String ITEMS = "items";
+    private static final String EDGES = "edges";
+    private static final String NODE = "node";
+    private static final String CURSOR = "cursor";
+    private static final String NEXT_PAGE = "nextPage";
+    private static final String PREVIOUS_PAGE = "previousPage";
+
+    private static final int DEFAULT_LIST_LIMIT = 40;
+    private static final int MAX_LIST_LIMIT = 100;
+
+    private final Api _api;
+
+    public GraphQLImpl(Api api) {
+        this._api = api;
+    }
+
+    private Api api() {
+        return _api;
+    }
+
+    public GraphQLSchema getSchema() {
+        return graphql.schema.GraphQLSchema.newSchema()
+                .query(queryType())
+                .build();
+    }
+
+    private static Map<String, Object> mapOf(Object... items) {
+        Preconditions.checkArgument(items.length % 2 == 0, "Items must be pairs of key/value");
+        Map<String, Object> map = Maps.newHashMap();
+        for (int i = 0; i < items.length; i += 2) {
+            map.put(((String) items[i]), items[i + 1]);
+        }
+        return map;
+    }
+
+    private static int decodeCursor(String cursor, int defaultVal) {
+        try {
+            return cursor != null
+                    ? Math.max(-1, Integer.parseInt(Base64.fromBase64(cursor)))
+                    : defaultVal;
+        } catch (NumberFormatException e) {
+            return defaultVal;
+        }
+    }
+
+    private int getLimit(Integer limitArg) {
+        if (limitArg == null) {
+            return DEFAULT_LIST_LIMIT;
+        } else if (limitArg < 0) {
+            return MAX_LIST_LIMIT;
+        } else {
+            return Math.min(MAX_LIST_LIMIT, limitArg);
+        }
+    }
+
+    private int getOffset(String afterCursor, String fromCursor) {
+        if (afterCursor != null) {
+            return decodeCursor(afterCursor, -1) + 1;
+        } else if (fromCursor != null) {
+            return decodeCursor(fromCursor, 0);
+        } else {
+            return 0;
+        }
+    }
+
+    // Field definitions
+
+    private final Map<String, String> conceptDescStringFields = ImmutableMap.<String, String>builder()
+            .put("otherFormsOfName", "")
+            .put("definition", "A description of the subject resource")
+            .put("scopeNote", "")
+            .build();
+
+    private final Map<String, String> countryStringFields = ImmutableMap.<String, String>builder()
+            .put("history", "")
+            .put("situation", "")
+            .put("summary", "")
+            .put("extensive", "")
+            .build();
+
+    private final Map<String, String> addressStringFields = ImmutableMap.<String, String>builder()
+            .put("contactPerson", "")
+            .put("street", "")
+            .put("municipality", "")
+            .put("firstdem", "")
+            .put("countryCode", "")
+            .put("postalCode", "")
+            .build();
+
+    private final Map<String, String> addressListStringFields = ImmutableMap.<String, String>builder()
+            .put("email", "")
+            .put("telephone", "")
+            .put("fax", "")
+            .put("webpage", "")
+            .build();
+
+    // Argument helpers...
+
+    private GraphQLScalarType wrappedString(String name, String description) {
+        return new GraphQLScalarType(name, description, GraphQLString.getCoercing());
+    }
+
+    private final GraphQLScalarType IdType = wrappedString("Id", "An entity global string identifier");
+    private final GraphQLScalarType CursorType = wrappedString("Cursor", "A connection cursor");
+
+    private final GraphQLArgument idArgument = newArgument()
+            .name(Bundle.ID_KEY)
+            .type(new GraphQLNonNull(IdType))
+            .build();
+
+    // Data fetchers...
+
+    private DataFetcher entityTypeConnectionDataFetcher(EntityClass type) {
+        // FIXME: The only way to get a list of all items of a given
+        // type via the API alone is to run a query as a stream w/ no limit.
+        // However, this means that ACL filtering will be applied twice,
+        // once here, and once by the connection data fetcher, which also
+        // applies pagination.
+        return connectionDataFetcher(api().query()
+                .setStream(true).setLimit(-1).page(type, Accessible.class));
+    }
+
+    private DataFetcher oneToManyRelationshipConnectionFetcher(Function<Accessible, Iterable<? extends Accessible>> f) {
+        return env -> {
+            Iterable<? extends Accessible> iter = f.apply(((Accessible) env.getSource()));
+            return connectionDataFetcher(iter).get(env);
+        };
+    }
+
+    private DataFetcher connectionDataFetcher(Iterable<? extends Accessible> iter) {
+        return env -> {
+            int limit = getLimit(env.getArgument(FIRST_PARAM));
+            int offset = getOffset(env.getArgument(AFTER_PARAM), env.getArgument(FROM_PARAM));
+
+            QueryApi.Page<Accessible> page = api()
+                    .query()
+                    .setLimit(limit)
+                    .setOffset(offset)
+                    .page(iter, Accessible.class);
+            List<Accessible> items = Lists.newArrayList(page.getIterable());
+
+            boolean hasNext = page.getOffset() + items.size() < page.getTotal();
+            boolean hasPrev = page.getOffset() > 0;
+
+            // Create a list of edges, with the cursor taking into
+            // account each item's offset
+            List<Map<String, Object>> edges = Lists.newArrayListWithExpectedSize(items.size());
+            for (int i = 0; i < items.size(); i++) {
+                edges.add(mapOf(
+                        CURSOR, Base64.toBase64(String.valueOf(offset + i)),
+                        NODE, items.get(i)
+                ));
+            }
+
+            String nextCursor = Base64.toBase64(String.valueOf(offset + limit));
+            String prevCursor = Base64.toBase64(String.valueOf(offset - limit));
+
+            return mapOf(
+                    ITEMS, items,
+                    EDGES, edges,
+                    PAGE_INFO, mapOf(
+                            HAS_NEXT_PAGE, hasNext,
+                            NEXT_PAGE, hasNext ? nextCursor : null,
+                            HAS_PREVIOUS_PAGE, hasPrev,
+                            PREVIOUS_PAGE, hasPrev ? prevCursor : null
+                    )
+            );
+        };
+    }
+
+    private final DataFetcher entityIdDataFetcher = env -> {
+        try {
+            return api().detail(env.getArgument(Bundle.ID_KEY), Accessible.class);
+        } catch (ItemNotFound e) {
+            return null;
+        }
+    };
+
+    private final DataFetcher idDataFetcher =
+            environment -> ((Entity) environment.getSource()).getProperty(EntityType.ID_KEY);
+
+    private final DataFetcher typeDataFetcher =
+            environment -> ((Entity) environment.getSource()).getProperty(EntityType.TYPE_KEY);
+
+    private final DataFetcher attributeDataFetcher =
+            environment -> ((Entity) environment.getSource())
+                    .getProperty(environment.getFields().get(0).getName());
+
+    private DataFetcher listDataFetcher(DataFetcher fetcher) {
+        return environment -> {
+            Object obj = fetcher.get(environment);
+            if (obj == null) {
+                return Lists.newArrayList();
+            } else if (obj instanceof List) {
+                return obj;
+            } else {
+                return Lists.newArrayList(obj);
+            }
+        };
+    }
+
+    private final DataFetcher descriptionDataFetcher = environment -> {
+        String lang = environment.getArgument(Ontology.LANGUAGE_OF_DESCRIPTION);
+        String code = environment.getArgument(Ontology.IDENTIFIER_KEY);
+
+        Accessible source = (Accessible) environment.getSource();
+        Iterable<Description> descriptions = source.as(Described.class).getDescriptions();
+
+        if (lang == null && code == null) {
+            int at = environment.getArgument(SLICE_PARAM);
+            List<Description> descList = Lists.newArrayList(descriptions);
+            return at >= 1 && descList.size() >= at ? descList.get(at - 1) : null;
+        } else {
+            for (Description next : descriptions) {
+                String langCode = next.getLanguageOfDescription();
+                if (langCode.equalsIgnoreCase(lang)) {
+                    if (code != null && !code.isEmpty()) {
+                        String ident = next.getDescriptionCode();
+                        if (ident.equals(code)) {
+                            return next;
+                        }
+                    } else {
+                        return next;
+                    }
+                }
+            }
+            return null;
+        }
+    };
+
+    private DataFetcher transformingDataFetcher(DataFetcher fetcher, Function<Object, Object> transformer) {
+        return environment -> transformer.apply(fetcher.get(environment));
+    }
+
+    private DataFetcher oneToManyRelationshipFetcher(Function<Accessible, Iterable<? extends Entity>> f) {
+        return environment -> {
+            Iterable<? extends Entity> elements = f.apply(((Accessible) environment.getSource()));
+            QueryApi.Page<Entity> page = api()
+                    .query().setStream(true).setLimit(-1).page(elements, Entity.class);
+            return Lists.newArrayList(page);
+        };
+    }
+
+    private DataFetcher manyToOneRelationshipFetcher(Function<Accessible, Accessible> f) {
+        return environment -> {
+            Accessible elem = f.apply((Accessible) environment.getSource());
+            Boolean visable = AclManager.getAclFilterFunction(api().accessor()).compute(elem.asVertex());
+            return visable ? elem : null;
+        };
+    }
+
+    // Field definition helpers...
+
+    private GraphQLFieldDefinition nullAttr(String name, String description, GraphQLOutputType type) {
+        return newFieldDefinition()
+                .type(type)
+                .name(name)
+                .description(description)
+                .dataFetcher(attributeDataFetcher)
+                .build();
+    }
+
+    private GraphQLFieldDefinition nullAttr(String name, String description) {
+        return nullAttr(name, description, GraphQLString);
+    }
+
+    private GraphQLFieldDefinition listAttr(String name, String description) {
+        return newFieldDefinition()
+                .type(new GraphQLList(GraphQLString))
+                .name(name)
+                .description(description)
+                .dataFetcher(listDataFetcher(attributeDataFetcher))
+                .build();
+    }
+
+    private GraphQLFieldDefinition nonNullAttr(String name, String description, GraphQLOutputType type) {
+        return newFieldDefinition()
+                .type(type)
+                .name(name)
+                .description(description)
+                .dataFetcher(attributeDataFetcher)
+                .build();
+    }
+
+    private GraphQLFieldDefinition nonNullAttr(String name, String description) {
+        return nonNullAttr(name, description, GraphQLString);
+    }
+
+    private List<GraphQLFieldDefinition> nullStringAttrs(DefinitionList[] items) {
+        return Lists.newArrayList(items)
+                .stream().filter(i -> !i.isMultiValued())
+                .map(f ->
+                        newFieldDefinition()
+                                .type(GraphQLString)
+                                .name(f.name())
+                                .description(f.getDescription())
+                                .dataFetcher(attributeDataFetcher)
+                                .build()
+                ).collect(Collectors.toList());
+    }
+
+    private List<GraphQLFieldDefinition> listStringAttrs(DefinitionList[] items) {
+        return Lists.newArrayList(items)
+                .stream().filter(DefinitionList::isMultiValued)
+                .map(f ->
+                        newFieldDefinition()
+                                .type(new GraphQLList(GraphQLString))
+                                .name(f.name())
+                                .description(f.getDescription())
+                                .dataFetcher(listDataFetcher(attributeDataFetcher))
+                                .build()
+                ).collect(Collectors.toList());
+    }
+
+    private List<GraphQLFieldDefinition> nullStringAttrs(Map<String, String> attrMap) {
+        return attrMap.entrySet().stream().map(e -> nullAttr(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private List<GraphQLFieldDefinition> listStringAttrs(Map<String, String> attrMap) {
+        return attrMap.entrySet().stream().map(e -> listAttr(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private GraphQLFieldDefinition idField() {
+        return newFieldDefinition()
+                .type(new GraphQLNonNull(GraphQLString))
+                .name(Bundle.ID_KEY)
+                .description("The item's EHRI id")
+                .dataFetcher(idDataFetcher)
+                .build();
+    }
+
+    private GraphQLFieldDefinition typeField() {
+        return newFieldDefinition()
+                .type(new GraphQLNonNull(GraphQLString))
+                .name(Bundle.TYPE_KEY)
+                .description("The item's EHRI type")
+                .dataFetcher(typeDataFetcher)
+                .build();
+    }
+
+    private GraphQLFieldDefinition singleDescriptionFieldDefinition(GraphQLObjectType descriptionType) {
+        return newFieldDefinition()
+                .type(descriptionType)
+                .name("description")
+                .argument(newArgument()
+                        .name(Ontology.LANGUAGE_OF_DESCRIPTION)
+                        .description("The description's language code")
+                        .type(GraphQLString)
+                        .build()
+                )
+                .argument(newArgument()
+                        .name(Ontology.IDENTIFIER_KEY)
+                        .description("The description's identifier code")
+                        .type(GraphQLString)
+                        .build()
+                )
+                .argument(newArgument()
+                        .name(SLICE_PARAM)
+                        .description("The description's 1-based index index (default: 1)")
+                        .type(GraphQLInt)
+                        .defaultValue(1)
+                        .build()
+                )
+                .description("Fetch the description at given the given index, or that with the given " +
+                        "languageCode and/or identifier code. Since the default index is 1, no arguments will return " +
+                        "the first available description.")
+                .dataFetcher(descriptionDataFetcher)
+                .build();
+    }
+
+    private GraphQLFieldDefinition descriptionsFieldDefinition(GraphQLObjectType descriptionType) {
+        return newFieldDefinition()
+                .type(new GraphQLList(descriptionType))
+                .name("descriptions")
+                .description("The item's descriptions")
+                .dataFetcher(oneToManyRelationshipFetcher(r -> r.as(Described.class).getDescriptions()))
+                .build();
+    }
+
+    private GraphQLFieldDefinition accessPointFieldDefinition() {
+        return listFieldDefinition("accessPoints", "Access points associated with this description",
+                accessPointType, oneToManyRelationshipFetcher(d -> d.as(Description.class).getAccessPoints()));
+    }
+
+    private GraphQLFieldDefinition datePeriodFieldDefinition() {
+        return listFieldDefinition("dates", "Date periods associated with this description",
+                datePeriodType, oneToManyRelationshipFetcher(d -> d.as(Temporal.class).getDatePeriods()));
+    }
+
+    private GraphQLFieldDefinition listFieldDefinition(String name, String description,
+            GraphQLOutputType type, DataFetcher dataFetcher) {
+        return newFieldDefinition()
+                .name(name)
+                .type(new GraphQLList(type))
+                .description(description)
+                .dataFetcher(dataFetcher)
+                .build();
+    }
+
+    private GraphQLFieldDefinition connectionFieldDefinition(String name, String description,
+            GraphQLOutputType type, DataFetcher dataFetcher) {
+        return newFieldDefinition()
+                .name(name)
+                .description(description)
+                .type(connectionType(type, name, description))
+                .dataFetcher(dataFetcher)
+                .argument(newArgument()
+                        .name(FIRST_PARAM)
+                        .type(GraphQLInt)
+                        .description("The number of items after the cursor")
+                        .defaultValue(DEFAULT_LIST_LIMIT)
+                        .build()
+                )
+                .argument(newArgument()
+                        .name(AFTER_PARAM)
+                        .description("Fetch items after this cursor")
+                        .type(CursorType)
+                        .build()
+                )
+                .argument(newArgument()
+                        .name(FROM_PARAM)
+                        .description("Fetch items from this cursor")
+                        .type(CursorType)
+                        .build()
+                )
+                .build();
+    }
+
+    private GraphQLFieldDefinition itemFieldDefinition(String name, String description,
+            GraphQLOutputType type, DataFetcher dataFetcher, GraphQLArgument... arguments) {
+        return newFieldDefinition()
+                .name(name)
+                .type(type)
+                .description(description)
+                .dataFetcher(dataFetcher)
+                .argument(Lists.newArrayList(arguments))
+                .build();
+    }
+
+    private List<GraphQLFieldDefinition> descriptionFields() {
+        return Lists.newArrayList(
+                nonNullAttr(Ontology.LANGUAGE_OF_DESCRIPTION, "The description's language code"),
+                nonNullAttr(Ontology.NAME_KEY, "The description's title"),
+                nullAttr(Ontology.IDENTIFIER_KEY, "The description's (optional) identifier")
+        );
+    }
+
+    // Interfaces and type resolvers...
+
+    private TypeResolver entityTypeResolver = new TypeResolver() {
+        @Override
+        public GraphQLObjectType getType(Object item) {
+            Entity entity = (Entity) item;
+            switch (entity.getType()) {
+                case Entities.DOCUMENTARY_UNIT:
+                    return documentaryUnitType;
+                case Entities.REPOSITORY:
+                    return repositoryType;
+                case Entities.COUNTRY:
+                    return countryType;
+                case Entities.HISTORICAL_AGENT:
+                    return historicalAgentType;
+                case Entities.CVOC_CONCEPT:
+                    return conceptType;
+                case Entities.CVOC_VOCABULARY:
+                    return vocabularyType;
+                case Entities.AUTHORITATIVE_SET:
+                    return authoritativeSetType;
+                case Entities.ANNOTATION:
+                    return annotationType;
+                case Entities.LINK:
+                    return linkType;
+                case Entities.ACCESS_POINT:
+                    return accessPointType;
+                case Entities.DATE_PERIOD:
+                    return datePeriodType;
+                default:
+                    return entityType;
+            }
+        }
+    };
+
+    private TypeResolver descriptionTypeResolver = new TypeResolver() {
+        @Override
+        public GraphQLObjectType getType(Object item) {
+            Entity entity = (Entity) item;
+            switch (entity.getType()) {
+                case Entities.DOCUMENTARY_UNIT_DESCRIPTION:
+                    return documentaryUnitDescriptionType;
+                case Entities.REPOSITORY_DESCRIPTION:
+                    return repositoryDescriptionType;
+                case Entities.HISTORICAL_AGENT_DESCRIPTION:
+                    return historicalAgentType;
+                case Entities.CVOC_CONCEPT_DESCRIPTION:
+                    return conceptDescriptionType;
+                default:
+                    return null;
+            }
+        }
+    };
+
+    private final GraphQLInterfaceType entityInterface = newInterface()
+            .name("Entity")
+            .description("An entity")
+            .field(idField())
+            .field(typeField())
+            .typeResolver(entityTypeResolver)
+            .build();
+
+    private final GraphQLInterfaceType descriptionInterface = newInterface()
+            .name("Description")
+            .description("A language-specific item description")
+            .fields(descriptionFields())
+            .typeResolver(descriptionTypeResolver)
+            .build();
+
+    // Type definitions...
+
+    private GraphQLOutputType edgeType(GraphQLOutputType wrapped, String description) {
+        return newObject()
+                .name(wrapped.getName() + "Edge")
+                .description(description)
+                .field(newFieldDefinition()
+                        .name(NODE)
+                        .type(wrapped)
+                        .build()
+                )
+                .field(newFieldDefinition()
+                        .name(CURSOR)
+                        .type(GraphQLString)
+                        .build()
+                )
+                .build();
+    }
+
+    private GraphQLOutputType connectionType(GraphQLOutputType wrappedType, String name, String description) {
+        return newObject()
+                .name(name)
+                .description(description)
+                .field(newFieldDefinition()
+                        .name(ITEMS)
+                        .description("A sequence of type: " + wrappedType.getName())
+                        .type(new GraphQLList(wrappedType))
+                        .build()
+                ).field(newFieldDefinition()
+                        .name(EDGES)
+                        .description("A sequence of " + wrappedType.getName() + " edges")
+                        .type(new GraphQLList(edgeType(wrappedType, description)))
+                        .build()
+                ).field(newFieldDefinition()
+                        .name(PAGE_INFO)
+                        .description("Pagination information")
+                        .type(newObject()
+                                .name(PAGE_INFO)
+                                .field(newFieldDefinition()
+                                        .name(HAS_PREVIOUS_PAGE)
+                                        .description("If a previous page of data is available")
+                                        .type(GraphQLBoolean)
+                                        .build()
+                                )
+                                .field(newFieldDefinition()
+                                        .name(PREVIOUS_PAGE)
+                                        .description("A cursor pointing to the previous page of items")
+                                        .type(GraphQLString)
+                                        .build()
+                                )
+                                .field(newFieldDefinition()
+                                        .name(HAS_NEXT_PAGE)
+                                        .description("If another page of data is available")
+                                        .type(GraphQLBoolean)
+                                        .build()
+                                )
+                                .field(newFieldDefinition()
+                                        .name(NEXT_PAGE)
+                                        .description("A cursor pointing to the next page of items")
+                                        .type(GraphQLString)
+                                        .build()
+                                )
+                                .build())
+                        .build()
+                )
+                .build();
+    }
+
+    private final GraphQLObjectType entityType = newObject()
+            .name("Entity")
+            .description("An EHRI entity")
+            .field(idField())
+            .field(typeField())
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType accessPointType = newObject()
+            .name(Entities.ACCESS_POINT)
+            .description("An access point")
+            .field(nonNullAttr(Ontology.NAME_KEY, "The access point's text"))
+            .field(nonNullAttr(Ontology.ACCESS_POINT_TYPE, "The access point's type"))
+            .build();
+
+    private final GraphQLObjectType datePeriodType = newObject()
+            .name(Entities.DATE_PERIOD)
+            .description("A date period")
+            .field(nullAttr(Ontology.DATE_PERIOD_START_DATE, "The start date"))
+            .field(nullAttr(Ontology.DATE_PERIOD_END_DATE, "The end date"))
+            .build();
+
+    private final GraphQLObjectType addressType = newObject()
+            .name(Entities.ADDRESS)
+            .description("An address")
+            .fields(nullStringAttrs(addressStringFields))
+            .fields(listStringAttrs(addressListStringFields))
+            .build();
+
+    private final GraphQLObjectType documentaryUnitDescriptionType = newObject()
+            .name(Entities.DOCUMENTARY_UNIT_DESCRIPTION)
+            .description("An archival description")
+            .fields(descriptionFields())
+            .field(accessPointFieldDefinition())
+            .field(datePeriodFieldDefinition())
+            .fields(nullStringAttrs(IsadG.values()))
+            .fields(listStringAttrs(IsadG.values()))
+            .withInterface(descriptionInterface)
+            .build();
+
+    private final GraphQLObjectType repositoryDescriptionType = newObject()
+            .name(Entities.REPOSITORY_DESCRIPTION)
+            .description("A repository description")
+            .fields(descriptionFields())
+            .field(accessPointFieldDefinition())
+            .field(listFieldDefinition("addresses", "Addresses",
+                    addressType, oneToManyRelationshipFetcher(d ->
+                            d.as(RepositoryDescription.class).getAddresses())))
+            .fields(nullStringAttrs(Isdiah.values()))
+            .fields(listStringAttrs(Isdiah.values()))
+            .withInterface(descriptionInterface)
+            .build();
+
+    private final GraphQLObjectType historicalAgentDescriptionType = newObject()
+            .name(Entities.HISTORICAL_AGENT_DESCRIPTION)
+            .description("An historical agent description")
+            .fields(descriptionFields())
+            .field(accessPointFieldDefinition())
+            .field(datePeriodFieldDefinition())
+            .fields(nullStringAttrs(Isaar.values()))
+            .fields(listStringAttrs(Isaar.values()))
+            .withInterface(descriptionInterface)
+            .build();
+
+    private final GraphQLObjectType conceptDescriptionType = newObject()
+            .name(Entities.CVOC_CONCEPT_DESCRIPTION)
+            .description("A concept description")
+            .fields(descriptionFields())
+            .field(accessPointFieldDefinition())
+            .fields(nullStringAttrs(conceptDescStringFields))
+            .withInterface(descriptionInterface)
+            .build();
+
+    private final GraphQLObjectType repositoryType = newObject()
+            .name(Entities.REPOSITORY)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The repository's EHRI identifier"))
+            .field(connectionFieldDefinition("documentaryUnits", "The repository's top level documentary units",
+                    new GraphQLTypeReference(Entities.DOCUMENTARY_UNIT),
+                    oneToManyRelationshipConnectionFetcher(
+                            r -> r.as(Repository.class).getTopLevelDocumentaryUnits())))
+            .field(singleDescriptionFieldDefinition(repositoryDescriptionType))
+            .field(descriptionsFieldDefinition(repositoryDescriptionType))
+            .field(itemFieldDefinition("country", "The repository's country",
+                    new GraphQLTypeReference(Entities.COUNTRY),
+                    manyToOneRelationshipFetcher(r -> r.as(Repository.class).getCountry())))
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .description("A repository")
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType documentaryUnitType = newObject()
+            .name(Entities.DOCUMENTARY_UNIT)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The item's local identifier"))
+            .field(descriptionsFieldDefinition(documentaryUnitDescriptionType))
+            .field(singleDescriptionFieldDefinition(documentaryUnitDescriptionType))
+            .field(itemFieldDefinition("repository", "The unit's repository, if top level", repositoryType,
+                    manyToOneRelationshipFetcher(d -> d.as(DocumentaryUnit.class).getRepository())))
+            .field(connectionFieldDefinition("children", "The unit's child items",
+                    new GraphQLTypeReference(Entities.DOCUMENTARY_UNIT),
+                    oneToManyRelationshipConnectionFetcher(d -> d.as(DocumentaryUnit.class).getChildren())))
+            .field(itemFieldDefinition("parent", "The unit's parent item, if applicable",
+                    new GraphQLTypeReference(Entities.DOCUMENTARY_UNIT),
+                    manyToOneRelationshipFetcher(d -> d.as(DocumentaryUnit.class).getParent())))
+            .description("An archival unit")
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType historicalAgentType = newObject()
+            .name(Entities.HISTORICAL_AGENT)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The historical agent's EHRI identifier"))
+            .field(singleDescriptionFieldDefinition(historicalAgentDescriptionType))
+            .field(descriptionsFieldDefinition(historicalAgentDescriptionType))
+            .description("An historical agent")
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType authoritativeSetType = newObject()
+            .name(Entities.AUTHORITATIVE_SET)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The set's local identifier"))
+            .field(nonNullAttr(Ontology.NAME_KEY, "The set's name"))
+            .field(nullAttr("description", "The item's description"))
+            .field(connectionFieldDefinition("authorities", "Item's contained in this vocabulary", historicalAgentType,
+                    oneToManyRelationshipConnectionFetcher(
+                            c -> c.as(AuthoritativeSet.class).getAuthoritativeItems())))
+            .description("An authority set")
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+
+    private final GraphQLObjectType countryType = newObject()
+            .name(Entities.COUNTRY)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The country's ISO639-2 code"))
+            .field(newFieldDefinition()
+                    .name(Ontology.NAME_KEY)
+                    .description("The country's English Name")
+                    .type(new GraphQLNonNull(GraphQLString))
+                    .dataFetcher(transformingDataFetcher(idDataFetcher,
+                            obj -> LanguageHelpers.countryCodeToName(obj.toString())))
+                    .build()
+            )
+            .fields(nullStringAttrs(countryStringFields))
+            .field(connectionFieldDefinition("repositories", "Repositories located in the country", repositoryType,
+                    oneToManyRelationshipConnectionFetcher(
+                            c -> c.as(Country.class).getRepositories())))
+            .description("A country")
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType conceptType = newObject()
+            .name(Entities.CVOC_CONCEPT)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The concept's local identifier"))
+            .field(descriptionsFieldDefinition(conceptDescriptionType))
+            .field(singleDescriptionFieldDefinition(conceptDescriptionType))
+            .field(connectionFieldDefinition("related", "Related concepts",
+                    new GraphQLTypeReference(Entities.CVOC_CONCEPT),
+                    oneToManyRelationshipConnectionFetcher(
+                            c -> c.as(Concept.class).getRelatedConcepts())))
+            .field(listFieldDefinition("broader", "Broader concepts",
+                    new GraphQLTypeReference(Entities.CVOC_CONCEPT),
+                    oneToManyRelationshipFetcher(c -> c.as(Concept.class).getBroaderConcepts())))
+            .field(connectionFieldDefinition("narrower", "Narrower concepts",
+                    new GraphQLTypeReference(Entities.CVOC_CONCEPT),
+                    oneToManyRelationshipConnectionFetcher(
+                            c -> c.as(Concept.class).getNarrowerConcepts())))
+            .field(itemFieldDefinition("vocabulary", "The vocabulary",
+                    new GraphQLTypeReference(Entities.CVOC_VOCABULARY),
+                    manyToOneRelationshipFetcher(c -> c.as(Concept.class).getVocabulary())))
+            .description("A concept")
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType vocabularyType = newObject()
+            .name(Entities.CVOC_VOCABULARY)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.IDENTIFIER_KEY, "The vocabulary's local identifier"))
+            .field(nonNullAttr(Ontology.NAME_KEY, "The vocabulary's name"))
+            .field(nullAttr("description", "The item's description"))
+            .field(connectionFieldDefinition("concepts", "Top-level concepts contained in this vocabulary", conceptType,
+                    oneToManyRelationshipConnectionFetcher(
+                            c -> c.as(Vocabulary.class).getConcepts())))
+            .description("A vocabulary")
+            .field(listFieldDefinition("links", "This item's links",
+                    new GraphQLTypeReference(Entities.LINK),
+                    oneToManyRelationshipFetcher(r -> r.as(Linkable.class).getLinks())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType annotationType = newObject()
+            .name(Entities.ANNOTATION)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.ANNOTATION_NOTES_BODY, "The text of the annotation"))
+            .field(listFieldDefinition("targets", "The annotation's target(s)", entityType,
+                    oneToManyRelationshipFetcher(a -> a.as(Annotation.class).getTargets())))
+            .description("An annotation")
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .withInterface(entityInterface)
+            .build();
+
+    private final GraphQLObjectType linkType = newObject()
+            .name(Entities.LINK)
+            .field(idField())
+            .field(typeField())
+            .field(nonNullAttr(Ontology.LINK_HAS_DESCRIPTION, "The link description"))
+            .field(listFieldDefinition("targets", "The annotation's targets", entityType,
+                    oneToManyRelationshipFetcher(a -> a.as(Link.class).getLinkTargets())))
+            .field(listFieldDefinition("body", "The links's body(s)", accessPointType,
+                    oneToManyRelationshipFetcher(a -> a.as(Link.class).getLinkBodies())))
+            .field(listFieldDefinition("annotations", "This item's annotations",
+                    new GraphQLTypeReference(Entities.ANNOTATION),
+                    oneToManyRelationshipFetcher(r -> r.as(Annotatable.class).getAnnotations())))
+            .description("A link")
+            .withInterface(entityInterface)
+            .build();
+
+    private GraphQLObjectType queryType() {
+        return newObject()
+                .name("Root")
+
+                // Single item types...
+                .field(itemFieldDefinition(Entities.DOCUMENTARY_UNIT, "Fetch a single documentary unit",
+                        documentaryUnitType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.REPOSITORY, "Fetch a single repository",
+                        repositoryType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.COUNTRY, "Fetch a single country",
+                        countryType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.HISTORICAL_AGENT, "Fetch a single historical agent",
+                        historicalAgentType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.AUTHORITATIVE_SET, "Fetch a single authority set",
+                        authoritativeSetType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.CVOC_CONCEPT, "Fetch a single concept",
+                        conceptType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.CVOC_VOCABULARY, "Fetch a single vocabulary",
+                        vocabularyType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.ANNOTATION, "Fetch a single annotation",
+                        annotationType, entityIdDataFetcher, idArgument))
+                .field(itemFieldDefinition(Entities.LINK, "Fetch a single link",
+                        linkType, entityIdDataFetcher, idArgument))
+
+                .field(connectionFieldDefinition("documentaryUnits", "A page of documentary units",
+                        documentaryUnitType,
+                        entityTypeConnectionDataFetcher(EntityClass.DOCUMENTARY_UNIT)))
+                .field(connectionFieldDefinition("repositories", "A page of repositories",
+                        repositoryType,
+                        entityTypeConnectionDataFetcher(EntityClass.REPOSITORY)))
+                .field(connectionFieldDefinition("historicalAgents", "A page of historical agents",
+                        historicalAgentType,
+                        entityTypeConnectionDataFetcher(EntityClass.HISTORICAL_AGENT)))
+                .field(connectionFieldDefinition("countries", "A page of countries",
+                        countryType,
+                        entityTypeConnectionDataFetcher(EntityClass.COUNTRY)))
+                .field(connectionFieldDefinition("authoritativeSets", "A page of authoritative sets",
+                        authoritativeSetType,
+                        entityTypeConnectionDataFetcher(EntityClass.AUTHORITATIVE_SET)))
+                .field(connectionFieldDefinition("concepts", "A page of concepts",
+                        conceptType,
+                        entityTypeConnectionDataFetcher(EntityClass.CVOC_CONCEPT)))
+                .field(connectionFieldDefinition("vocabularies", "A page of vocabularies",
+                        vocabularyType,
+                        entityTypeConnectionDataFetcher(EntityClass.CVOC_VOCABULARY)))
+                .field(connectionFieldDefinition("annotations", "A page of annotation",
+                        annotationType,
+                        entityTypeConnectionDataFetcher(EntityClass.ANNOTATION)))
+                .field(connectionFieldDefinition("links", "A page of links",
+                        linkType,
+                        entityTypeConnectionDataFetcher(EntityClass.LINK)))
+
+                .build();
+    }
+}

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLQuery.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLQuery.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.graphql;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class GraphQLQuery {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final String query;
+    private final String variables;
+    private final String operationName;
+
+    private static final TypeReference<Map<String, Object>> ref = new TypeReference<Map<String, Object>>() {
+    };
+
+    @JsonCreator
+    public GraphQLQuery(@JsonProperty("query") String query,
+            @JsonProperty("variables") String variables,
+            @JsonProperty("operationName") String operationName) {
+        this.query = query;
+        this.variables = variables;
+        this.operationName = operationName;
+    }
+
+    public GraphQLQuery(String query) {
+        this(query, "\"{}\"", null);
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    @JsonIgnore
+    public Map<String, Object> getVariablesAsMap() {
+        return deserializeVariables(variables);
+    }
+
+    public String getVariables() {
+        return variables;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    @Override
+    public String toString() {
+        Map<String, Object> m = Maps.newHashMap();
+        m.put("query", query);
+        m.put("variables", variables);
+        return m.toString();
+    }
+
+    private static Map<String, Object> deserializeVariables(String s) {
+        try {
+            return mapper.readValue(s == null ? "" : s, ref);
+        } catch (IOException e) {
+            return Maps.newHashMap();
+        }
+    }
+}

--- a/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.extension.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.jaxrs.annotation.JacksonFeatures;
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import eu.ehri.extension.GraphQLResource;
+import eu.ehri.extension.providers.GraphQLQueryProvider;
+import eu.ehri.project.graphql.GraphQLQuery;
+import eu.ehri.project.persistence.Bundle;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+
+import static com.sun.jersey.api.client.ClientResponse.Status.BAD_REQUEST;
+import static com.sun.jersey.api.client.ClientResponse.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Test for the GraphQL endpoint
+ */
+public class GraphQLResourceClientTest extends AbstractResourceClientTest {
+
+    @Before
+    public void setUp() {
+        ClientConfig config = new DefaultClientConfig();
+        config.getClasses().add(GraphQLQueryProvider.class);
+        config.getClasses().add(JacksonFeatures.class);
+        client = Client.create(config);
+    }
+
+    @Test
+    public void testGraphQLSchema() throws Exception {
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .get(ClientResponse.class);
+
+        JsonNode data = response.getEntity(JsonNode.class);
+        assertStatus(OK, response);
+        assertFalse(data.path("data").path("__schema").isMissingNode());
+    }
+
+    @Test
+    public void testGraphQLQuery() throws Exception {
+        String testQuery = readResourceFileAsString("testquery.graphql");
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .entity(testQuery)
+                .post(ClientResponse.class);
+
+        JsonNode data = response.getEntity(JsonNode.class);
+        //System.out.println(data);
+        assertEquals("c1",
+                data.path("data").path("c1").path("id").textValue());
+        assertEquals("c2",
+                data.path("data").path("c1")
+                        .path("children").path("items").path(0)
+                        .path("id").textValue());
+        assertEquals("c3",
+                data.path("data").path("c1")
+                        .path("children").path("items").path(0)
+                        .path("children").path("items").path(0)
+                        .path("id").textValue());
+        assertEquals("Amsterdam",
+                data.path("data").path("c1").path("repository")
+                        .path("english").path("addresses").path(0)
+                        .path("municipality").textValue());
+        assertEquals("test@example.com",
+                data.path("data").path("c1").path("repository")
+                        .path("english").path("addresses").path(0)
+                        .path("email").path(0).textValue());
+
+        assertEquals("ann7",
+                data.path("data").path("c4").path("annotations").path(0).path("id").textValue());
+        assertStatus(OK, response);
+    }
+
+    @Test
+    public void testGraphQLQueryWithStandardPerms() throws Exception {
+        String testQuery = readResourceFileAsString("testquery.graphql");
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getRegularUserProfileId(), queryUri)
+                .entity(testQuery)
+                .post(ClientResponse.class);
+
+        assertStatus(OK, response);
+        JsonNode data = response.getEntity(JsonNode.class);
+        // c1 should be missing since we can't read this item
+        assertTrue(data.path("data").path("c1").isNull());
+        // the annotation should be missing since its not accessible
+        assertTrue(data.path("data").path("c4")
+                .path("annotations").path(0).path("id").isMissingNode());
+    }
+
+    @Test
+    public void testGraphQLQueryViaJson() throws Exception {
+        String testQuery = readResourceFileAsString("testquery.graphql");
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .entity(new GraphQLQuery(testQuery), MediaType.APPLICATION_JSON_TYPE)
+                .post(ClientResponse.class);
+
+        assertStatus(OK, response);
+        JsonNode data = response.getEntity(JsonNode.class);
+        assertEquals("c1", data.path("data").path("c1")
+                .path(Bundle.ID_KEY).textValue());
+    }
+
+    @Test
+    public void testGraphQLQueryViaJsonWithError() throws Exception {
+
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .entity("{bad-json]", MediaType.APPLICATION_JSON_TYPE)
+                .post(ClientResponse.class);
+
+        assertStatus(BAD_REQUEST, response);
+        JsonNode data = response.getEntity(JsonNode.class);
+        assertEquals("JsonError", data.path("errors").path(0).path("type").textValue());
+    }
+
+    @Test
+    public void testGraphQLQueryErrors() throws Exception {
+        String testQuery = readResourceFileAsString("testquery-bad.graphql");
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .entity(testQuery)
+                .post(ClientResponse.class);
+
+        assertStatus(BAD_REQUEST, response);
+        JsonNode data = response.getEntity(JsonNode.class);
+        assertEquals("ValidationError",
+                data.path("errors").path(0).path("type").textValue());
+    }
+
+    @Test
+    public void testGraphQLQueryConnection() throws Exception {
+        String testQuery = readResourceFileAsString("testquery-connection.graphql");
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .entity(testQuery)
+                .post(ClientResponse.class);
+
+        assertStatus(OK, response);
+        JsonNode data = response.getEntity(JsonNode.class);
+        System.out.println(data);
+
+        assertTrue(data.path("data").path("empty").path("pageInfo").path("hasPreviousPage").asBoolean());
+        assertFalse(data.path("data").path("empty").path("pageInfo").path("hasNextPage").asBoolean());
+    }
+
+    @Test
+    public void testGraphQLQueryVariables() throws Exception {
+        String testQuery = readResourceFileAsString("testquery-variables.graphql");
+        URI queryUri = ehriUriBuilder(GraphQLResource.ENDPOINT).build();
+        ObjectNode vars = jsonMapper.createObjectNode();
+        vars.put("n", 4);
+
+        ClientResponse response = callAs(getAdminUserProfileId(), queryUri)
+                .entity(new GraphQLQuery(testQuery, jsonMapper.writeValueAsString(vars), null))
+                .post(ClientResponse.class);
+
+        JsonNode data = response.getEntity(JsonNode.class);
+        //System.out.println(data);
+        assertEquals(4, data.path("data").path("test").path("items").size());
+        assertFalse(data.path("data").path("test").path("pageInfo").path("nextPage").isNull());
+        assertStatus(OK, response);
+
+        vars.put("from", data.path("data").path("test").path("pageInfo").path("nextPage").textValue());
+        ClientResponse nextResponse = callAs(getAdminUserProfileId(), queryUri)
+                .entity(new GraphQLQuery(testQuery, jsonMapper.writeValueAsString(vars), null))
+                .post(ClientResponse.class);
+        JsonNode nextData = nextResponse.getEntity(JsonNode.class);
+        assertEquals(1, nextData.path("data").path("test").path("items").size());
+        assertStatus(OK, nextResponse);
+    }
+}

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/IsadGTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/IsadGTest.java
@@ -1,0 +1,41 @@
+package eu.ehri.project.definitions;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+
+public class IsadGTest {
+    @Test
+    public void testIsMultiValued() throws Exception {
+        assertFalse(IsadG.scopeAndContent.isMultiValued());
+    }
+
+    @Test
+    public void testName() throws Exception {
+        assertEquals("scopeAndContent", IsadG.scopeAndContent.name());
+    }
+
+    @Test
+    public void testGetName() throws Exception {
+        assertEquals("Scope and content", IsadG.scopeAndContent.getName());
+    }
+
+    @Test
+    public void testGetDescription() throws Exception {
+        assertThat(IsadG.scopeAndContent.getDescription(),
+                containsString("Enables users to judge"));
+    }
+
+    @Test
+    public void testGetMap() throws Exception {
+        assertTrue(DefinitionList.getMap(IsadG.values())
+                .keySet().contains("Scope and content"));
+        assertTrue(DefinitionList.getMap(IsadG.values(), false)
+                .keySet().contains("Scope and content"));
+        assertFalse(DefinitionList.getMap(IsadG.values(), true)
+                .keySet().contains("Scope and content"));
+        assertTrue(DefinitionList.getMap(IsadG.values(), true)
+                .keySet().contains("Notes"));
+    }
+}

--- a/ehri-ws-graphql/src/test/resources/testquery-bad.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery-bad.graphql
@@ -1,0 +1,12 @@
+{
+    DocumentaryUnit(NO_PARAM: "c1") {
+        id
+        type
+        identifier
+        description(languageCode: "eng", identifier: "c1-desc2") {
+            name
+            languageCode
+            scopeAndContent
+        }
+    }
+}

--- a/ehri-ws-graphql/src/test/resources/testquery-connection.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery-connection.graphql
@@ -1,0 +1,94 @@
+{
+    firstTwo: documentaryUnits(first: 2, after: "LTI=") {
+        edges {
+            cursor
+            node {
+                id
+                description {
+                    name
+                }
+            }
+        }
+        pageInfo {
+            hasNextPage
+            nextPage
+            hasPreviousPage
+            previousPage
+        }
+    }
+
+    third: documentaryUnits(first: 1, after: "MQ==") {
+        edges {
+            cursor
+            node {
+                id
+                description {
+                    name
+                }
+            }
+        }
+        pageInfo {
+            hasNextPage
+            nextPage
+            hasPreviousPage
+            previousPage
+        }
+    }
+    lastTwo: documentaryUnits(first: 2, after: "Mg==") {
+        edges {
+            cursor
+            node {
+                id
+                description {
+                    name
+                }
+            }
+        }
+        pageInfo {
+            hasNextPage
+            nextPage
+            hasPreviousPage
+            previousPage
+        }
+    }
+    empty: documentaryUnits(first: 2, after: "NA==") {
+        edges {
+            cursor
+            node {
+                id
+                description {
+                    name
+                }
+            }
+        }
+        pageInfo {
+            hasNextPage
+            nextPage
+            hasPreviousPage
+            previousPage
+        }
+    }
+
+    firstTwoRepos: repositories(first: 2) {
+        items {
+            id
+        }
+        pageInfo {
+            hasNextPage
+            nextPage
+        }
+    }
+    secondRepo: repositories(first: 1, from: "MQ==") {
+        edges {
+            node {
+                id
+            }
+            cursor
+        }
+        pageInfo {
+            hasNextPage
+            nextPage
+        }
+    }
+
+}

--- a/ehri-ws-graphql/src/test/resources/testquery-variables.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery-variables.graphql
@@ -1,0 +1,10 @@
+query FirstN($n: Int!, $from: Cursor) {
+    test: documentaryUnits(first: $n, from: $from) {
+        items {
+            id
+        }
+        pageInfo {
+            nextPage
+        }
+    }
+}

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -1,0 +1,111 @@
+{
+    c1: DocumentaryUnit(id: "c1") {
+        id
+        type
+        identifier
+        firstEnglishDescription: description(languageCode: "eng", identifier: "c1-desc") {
+            identifier
+            dates {
+                startDate
+                endDate
+            }
+            accessPoints {
+                name
+                type
+            }
+        }
+        description(languageCode: "eng", identifier: "c1-desc2") {
+            name
+            languageCode
+            scopeAndContent
+        }
+        repository {
+            id
+            english: description(languageCode: "eng") {
+                name
+                addresses {
+                    municipality
+                    email
+                }
+            }
+            frenchDescription: description(languageCode: "fra") {
+                identifier
+            }
+            country {
+                name
+            }
+        }
+        children {
+            items {
+                id
+                description(languageCode: "eng") {
+                    name
+                }
+                children {
+                    items {
+                        id
+                        description(languageCode: "eng") {
+                            name
+                            rulesAndConventions
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    c4: DocumentaryUnit(id: "c4") {
+        annotations {
+            id
+            body
+        }
+    }
+
+    CvocConcept(id: "cvoc1") {
+        identifier
+        description {
+            name
+        }
+    }
+
+    AuthoritativeSet(id: "auths") {
+        name
+        authorities {
+            items {
+                identifier
+                description {
+                    name
+                }
+            }
+        }
+    }
+
+    firstAgentDesc: HistoricalAgent(id: "a1") {
+        description {
+            name
+        }
+    }
+
+    secondDocDesc: DocumentaryUnit(id: "c1") {
+        description(at: 2) {
+            identifier
+        }
+    }
+
+    countries {
+        items {
+            id
+            name
+        }
+    }
+
+    annotations {
+        items {
+            body
+            targets {
+                id
+                type
+            }
+        }
+    }
+}

--- a/ehri-ws-sparql/pom.xml
+++ b/ehri-ws-sparql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-ws/pom.xml
+++ b/ehri-ws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.5-SNAPSHOT</version>
+        <version>0.13.6-SNAPSHOT</version>
     </parent>
 
     <name>Web Service</name>

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/AbstractResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/AbstractResourceClientTest.java
@@ -63,7 +63,23 @@ import java.util.zip.ZipInputStream;
  */
 public class AbstractResourceClientTest extends RunningServerTest {
 
-    protected static final Client client;
+    protected Client client;
+
+    AbstractResourceClientTest(Class<?> ... additionalProviders) {
+        ClientConfig config = new DefaultClientConfig();
+        List<Class<?>> providers = Lists.newArrayList(
+                GlobalPermissionSetProvider.class,
+                BundleProvider.class,
+                ImportLogProvider.class
+        );
+        for (Class<?> provider : providers) {
+            config.getClasses().add(provider);
+        }
+        for (Class<?> provider : additionalProviders) {
+            config.getClasses().add(provider);
+        }
+        client = Client.create(config);
+    }
 
     protected List<ZipEntry> readZip(InputStream stream) throws IOException {
         File tmp = File.createTempFile("test", ".zip");
@@ -78,14 +94,6 @@ public class AbstractResourceClientTest extends RunningServerTest {
             }
         }
         return entries;
-    }
-
-    static {
-        ClientConfig config = new DefaultClientConfig();
-        config.getClasses().add(GlobalPermissionSetProvider.class);
-        config.getClasses().add(BundleProvider.class);
-        config.getClasses().add(ImportLogProvider.class);
-        client = Client.create(config);
     }
 
     protected static final ObjectMapper jsonMapper = new ObjectMapper();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
     <packaging>pom</packaging>
-    <version>0.13.5-SNAPSHOT</version>
+    <version>0.13.6-SNAPSHOT</version>
     <name>EHRI Backend</name>
     <description>An API and web service on top of the Blueprints graph database abstraction layer.</description>
     <url>https://github.com/EHRI</url>
@@ -109,6 +109,7 @@
         <module>ehri-definitions</module>
         <module>ehri-cypher</module>
         <module>build</module>
+        <module>ehri-ws-graphql</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This adds a graphql endpoint at /ehri/graphql that is compatible with Relay. Many improvements can be made in better defining the ontology.

Also:

 - Increment version
 - Loosen type contraint on input iterable in Query
 - Add a country code helper