### PR TITLE
GraphQL optimisations and cleanup.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/persistence/DataConverter.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/DataConverter.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
@@ -188,7 +189,7 @@ class DataConverter {
         Preconditions.checkNotNull(inputStream);
         try {
             final JsonParser parser = factory
-                    .createParser(new InputStreamReader(inputStream, "UTF-8"));
+                    .createParser(new InputStreamReader(inputStream, Charsets.UTF_8));
             JsonToken jsonToken = parser.nextValue();
             if (!parser.isExpectedStartArrayToken()) {
                 throw new DeserializationError("Stream should be an array of objects, was: " + jsonToken);

--- a/ehri-core/src/test/java/eu/ehri/project/test/GraphTestBase.java
+++ b/ehri-core/src/test/java/eu/ehri/project/test/GraphTestBase.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.test;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -237,5 +238,11 @@ public abstract class GraphTestBase {
         if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE)
             throw new RuntimeException("Too many edge items in graph to fit into an integer!");
         return (int) l;
+    }
+
+    protected String readResourceFileAsString(String resourceName)
+            throws java.io.IOException {
+        URL url = Resources.getResource(resourceName);
+        return Resources.toString(url, Charsets.UTF_8);
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/AbstractImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/AbstractImporter.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers.base;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -42,7 +43,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
@@ -66,7 +66,7 @@ public abstract class AbstractImporter<T> {
     protected final FramedGraph<?> framedGraph;
     protected final GraphManager manager;
     protected final ImportLog log;
-    protected final List<ImportCallback> callbacks = Lists.newArrayList();
+    private final List<ImportCallback> callbacks = Lists.newArrayList();
 
     private NodeProperties pc;
 
@@ -89,7 +89,7 @@ public abstract class AbstractImporter<T> {
         return actioner;
     }
 
-    public BundleManager getPersister(List<String> scopeIds) {
+    protected BundleManager getPersister(List<String> scopeIds) {
         return new BundleManager(framedGraph,
                 Lists.newArrayList(Iterables.concat(permissionScope.idPath(), scopeIds)));
     }
@@ -142,7 +142,7 @@ public abstract class AbstractImporter<T> {
      * @throws ValidationError when the item representation does not validate
      */
     public abstract Accessible importItem(T itemData,
-                                          List<String> scopeIds) throws ValidationError;
+            List<String> scopeIds) throws ValidationError;
 
     /**
      * Extract a list of DatePeriod bundles from an item's data.
@@ -182,7 +182,7 @@ public abstract class AbstractImporter<T> {
 
     private NodeProperties loadNodeProperties() {
         try (InputStream fis = getClass().getClassLoader().getResourceAsStream(NODE_PROPERTIES);
-             BufferedReader br = new BufferedReader(new InputStreamReader(fis, Charset.forName("UTF-8")))) {
+             BufferedReader br = new BufferedReader(new InputStreamReader(fis, Charsets.UTF_8))) {
             NodeProperties nodeProperties = new NodeProperties();
             String headers = br.readLine();
             nodeProperties.setTitles(headers);

--- a/ehri-io/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
@@ -23,16 +23,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.jena.ontology.OntClass;
-import org.apache.jena.ontology.OntModel;
-import org.apache.jena.ontology.OntResource;
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.util.iterator.ExtendedIterator;
-import org.apache.jena.util.iterator.Filter;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.api.Api;
 import eu.ehri.project.api.ApiFactory;
@@ -59,6 +49,15 @@ import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.persistence.BundleManager;
 import eu.ehri.project.persistence.Mutation;
 import eu.ehri.project.utils.LanguageHelpers;
+import org.apache.jena.ontology.OntClass;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntResource;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.util.iterator.ExtendedIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -336,12 +335,10 @@ public final class JenaSkosImporter implements SkosImporter {
     private List<RDFNode> getObjectWithPredicate(Resource item, final URI propUri) {
         // NB: this should be possible with simply item.listProperties(propUri)
         // but for some reason that doesn't work... I can't grok why.
-        return item.listProperties().filterKeep(new Filter<Statement>() {
-            @Override
-            public boolean accept(Statement statement) {
-                return statement.getPredicate().hasURI(propUri.toString());
-            }
-        }).mapWith(Statement::getObject).toList();
+        return item.listProperties().filterKeep(statement ->
+                statement.getPredicate()
+                        .hasURI(propUri.toString()))
+                .mapWith(Statement::getObject).toList();
     }
 
     private void connectRelation(Concept current, Resource item, Map<Resource, Concept> others,

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -23,20 +23,18 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.exceptions.ValidationError;
-import eu.ehri.project.importers.base.AbstractImporter;
-import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.exceptions.ModeViolation;
 import eu.ehri.project.importers.util.Helpers;
-import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.persistence.ActionManager;
-import eu.ehri.project.persistence.Mutation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,14 +50,14 @@ import java.util.Map;
  */
 public class CsvImportManager extends AbstractImportManager {
 
-    public static final Character VALUE_DELIMITER = ';';
+    private static final Character VALUE_DELIMITER = ';';
 
     private static final Logger logger = LoggerFactory.getLogger(CsvImportManager.class);
 
     public CsvImportManager(FramedGraph<?> framedGraph,
-                            PermissionScope permissionScope, Actioner actioner,
-                            boolean tolerant,
-                            boolean allowUpdates, Class<? extends AbstractImporter> importerClass) {
+            PermissionScope permissionScope, Actioner actioner,
+            boolean tolerant,
+            boolean allowUpdates, Class<? extends AbstractImporter> importerClass) {
         super(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass);
     }
 
@@ -74,7 +72,7 @@ public class CsvImportManager extends AbstractImportManager {
      */
     @Override
     protected void importInputStream(InputStream stream, final ActionManager.EventContext context,
-                                     final ImportLog log) throws IOException, ValidationError, InputParseError {
+            final ImportLog log) throws IOException, ValidationError, InputParseError {
 
         try {
             AbstractImporter importer = importerClass
@@ -108,7 +106,7 @@ public class CsvImportManager extends AbstractImportManager {
             ObjectReader reader = new CsvMapper().readerFor(Map.class).with(schema);
 
             try (MappingIterator<Map<String, String>> valueIterator = reader
-                    .readValues(new InputStreamReader(stream, "UTF-8"))) {
+                    .readValues(new InputStreamReader(stream, Charsets.UTF_8))) {
                 while (valueIterator.hasNext()) {
                     Map<String, String> rawData = valueIterator.next();
                     Map<String, Object> dataMap = Maps.newHashMap();

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/GraphQLImplTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/GraphQLImplTest.java
@@ -1,0 +1,20 @@
+package eu.ehri.project.graphql;
+
+import eu.ehri.project.test.AbstractFixtureTest;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GraphQLImplTest extends AbstractFixtureTest {
+    @Test
+    public void testGetSchema() throws Exception {
+        GraphQLImpl graphQL = new GraphQLImpl(anonApi());
+        GraphQLSchema schema = graphQL.getSchema();
+        String testQuery = readResourceFileAsString("testquery.graphql");
+        ExecutionResult result = new GraphQL(schema).execute(testQuery);
+        assertTrue(result.getErrors().isEmpty());
+    }
+}

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -19,10 +19,10 @@
 
 package eu.ehri.extension;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import org.apache.jena.shared.NoReaderForLangException;
 import eu.ehri.extension.base.AbstractResource;
 import eu.ehri.project.core.Tx;
 import eu.ehri.project.exceptions.DeserializationError;
@@ -54,6 +54,7 @@ import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.jena.shared.NoReaderForLangException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -527,7 +528,7 @@ public class ImportResource extends AbstractResource {
         } else {
             File fileTest = new File(logMessagePathOrText);
             if (fileTest.exists()) {
-                return Optional.of(FileUtils.readFileToString(fileTest, "UTF-8"));
+                return Optional.of(FileUtils.readFileToString(fileTest, Charsets.UTF_8));
             } else {
                 return Optional.of(logMessagePathOrText);
             }

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceResourceClientTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.extension.test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
@@ -398,13 +399,13 @@ public class ImportResourceResourceClientTest extends AbstractResourceClientTest
         }
         String payloadText = Joiner.on("\n").join(paths) + "\n";
         return new ByteArrayInputStream(
-                payloadText.getBytes("UTF-8"));
+                payloadText.getBytes(Charsets.UTF_8));
     }
 
     private String getTestLogFilePath(String text) throws IOException {
         File temp = File.createTempFile("test-log", ".tmp");
         temp.deleteOnExit();
-        FileUtils.writeStringToFile(temp, text);
+        FileUtils.writeStringToFile(temp, text, Charsets.UTF_8);
         return temp.getAbsolutePath();
     }
 }


### PR DESCRIPTION
Eliminate a GraphQL hotspot by loading various (resource-configured) field definitions statically, rather than at schema instantiation.

Various other cleanups and deprecation fixes.