### PR TITLE
Fix a bunch of places where we use longs where ints would do just fine.

### DIFF
--- a/ehri-cli/src/test/java/eu/ehri/project/commands/RelationAddTest.java
+++ b/ehri-cli/src/test/java/eu/ehri/project/commands/RelationAddTest.java
@@ -50,45 +50,45 @@ public class RelationAddTest extends GraphTestBase {
 
     @Test
     public void testAddRelationWithDuplicates() throws Exception {
-        assertEquals(0L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(0, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
         CommandLine commandLine = relationAdd.getCmdLine(new String[]{"mike", "knows", "linda", "--allow-duplicates"});
         int retVal = relationAdd.execWithOptions(graph, commandLine);
         assertEquals(0, retVal);
-        assertEquals(1L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
-        assertEquals(1L, Iterables.size(linda.getVertices(Direction.IN, "knows")));
+        assertEquals(1, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(1, Iterables.size(linda.getVertices(Direction.IN, "knows")));
 
         relationAdd.execWithOptions(graph, commandLine);
-        assertEquals(2L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
-        assertEquals(2L, Iterables.size(linda.getVertices(Direction.IN, "knows")));
+        assertEquals(2, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(2, Iterables.size(linda.getVertices(Direction.IN, "knows")));
     }
 
     @Test
     public void testAddRelation() throws Exception {
-        assertEquals(0L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(0, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
         CommandLine commandLine = relationAdd.getCmdLine(new String[]{"mike", "knows", "linda"});
         int retVal = relationAdd.execWithOptions(graph, commandLine);
         assertEquals(0, retVal);
-        assertEquals(1L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
-        assertEquals(1L, Iterables.size(linda.getVertices(Direction.IN, "knows")));
+        assertEquals(1, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(1, Iterables.size(linda.getVertices(Direction.IN, "knows")));
 
         relationAdd.execWithOptions(graph, commandLine);
-        assertEquals(1L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
-        assertEquals(1L, Iterables.size(linda.getVertices(Direction.IN, "knows")));
+        assertEquals(1, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(1, Iterables.size(linda.getVertices(Direction.IN, "knows")));
     }
 
     @Test
     public void testAddSingleRelation() throws Exception {
-        assertEquals(0L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(0, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
         CommandLine commandLine1 = relationAdd.getCmdLine(new String[]{"mike", "knows", "linda"});
         int retVal = relationAdd.execWithOptions(graph, commandLine1);
         assertEquals(0, retVal);
-        assertEquals(1L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
-        assertEquals(1L, Iterables.size(linda.getVertices(Direction.IN, "knows")));
+        assertEquals(1, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(1, Iterables.size(linda.getVertices(Direction.IN, "knows")));
 
         CommandLine commandLine2 = relationAdd.getCmdLine(new String[]{"--single", "mike", "knows", "reto"});
         relationAdd.execWithOptions(graph, commandLine2);
-        assertEquals(1L, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
-        assertEquals(0L, Iterables.size(linda.getVertices(Direction.IN, "knows")));
-        assertEquals(1L, Iterables.size(reto.getVertices(Direction.IN, "knows")));
+        assertEquals(1, Iterables.size(mike.getVertices(Direction.OUT, "knows")));
+        assertEquals(0, Iterables.size(linda.getVertices(Direction.IN, "knows")));
+        assertEquals(1, Iterables.size(reto.getVertices(Direction.IN, "knows")));
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/Country.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Country.java
@@ -42,15 +42,13 @@ import eu.ehri.project.models.utils.JavaHandlerUtils;
 @EntityType(EntityClass.COUNTRY)
 public interface Country extends PermissionScope, ItemHolder, Versioned, Annotatable {
 
-    String COUNTRY_CODE = Ontology.IDENTIFIER_KEY;
-
     /**
      * Alias function for fetching the country code identifier.
      *
      * @return The country code
      */
     @Mandatory
-    @Property(COUNTRY_CODE)
+    @Property(Ontology.IDENTIFIER_KEY)
     String getCode();
 
     /**
@@ -60,7 +58,7 @@ public interface Country extends PermissionScope, ItemHolder, Versioned, Annotat
      */
     @Meta(CHILD_COUNT)
     @JavaHandler
-    long getChildCount();
+    int getChildCount();
 
     /**
      * Fetch all repositories in this country.
@@ -83,10 +81,12 @@ public interface Country extends PermissionScope, ItemHolder, Versioned, Annotat
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, Country {
 
-        public long getChildCount() {
-            return gremlin().inE(Ontology.REPOSITORY_HAS_COUNTRY).count();
+        @Override
+        public int getChildCount() {
+            return Math.toIntExact(gremlin().inE(Ontology.REPOSITORY_HAS_COUNTRY).count());
         }
 
+        @Override
         public void addRepository(Repository repository) {
             JavaHandlerUtils.addSingleRelationship(repository.asVertex(), it(),
                     Ontology.REPOSITORY_HAS_COUNTRY);

--- a/ehri-core/src/main/java/eu/ehri/project/models/DocumentaryUnit.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/DocumentaryUnit.java
@@ -120,7 +120,7 @@ public interface DocumentaryUnit extends AbstractUnit {
      */
     @Meta(CHILD_COUNT)
     @JavaHandler
-    long getChildCount();
+    int getChildCount();
 
     /**
      * Get child documentary units
@@ -152,8 +152,8 @@ public interface DocumentaryUnit extends AbstractUnit {
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, DocumentaryUnit {
 
-        public long getChildCount() {
-            return gremlin().inE(Ontology.DOC_IS_CHILD_OF).count();
+        public int getChildCount() {
+            return Math.toIntExact(gremlin().inE(Ontology.DOC_IS_CHILD_OF).count());
         }
 
         public Iterable<DocumentaryUnit> getChildren() {

--- a/ehri-core/src/main/java/eu/ehri/project/models/Group.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Group.java
@@ -81,7 +81,7 @@ public interface Group extends Accessor, Accessible,
      */
     @Meta(CHILD_COUNT)
     @JavaHandler
-    long getChildCount();
+    int getChildCount();
 
     /**
      * Adds a Accessor as a member to this Group, so it has the permissions of the Group.
@@ -113,8 +113,8 @@ public interface Group extends Accessor, Accessible,
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, Group {
 
-        public long getChildCount() {
-            return gremlin().inE(Ontology.ACCESSOR_BELONGS_TO_GROUP).count();
+        public int getChildCount() {
+            return Math.toIntExact(gremlin().inE(Ontology.ACCESSOR_BELONGS_TO_GROUP).count());
         }
 
         public void addMember(Accessor accessor) {
@@ -129,11 +129,10 @@ public interface Group extends Accessor, Accessible,
 
         public Iterable<Accessible> getAllUserProfileMembers() {
             GremlinPipeline<Vertex,Vertex> pipe = gremlin().as("n").in(Ontology.ACCESSOR_BELONGS_TO_GROUP)
-                    .loop("n", JavaHandlerUtils.defaultMaxLoops, vertexLoopBundle -> {
-                        return vertexLoopBundle.getObject()
+                    .loop("n", JavaHandlerUtils.defaultMaxLoops,
+                            vertexLoopBundle -> vertexLoopBundle.getObject()
                                 .getProperty(EntityType.TYPE_KEY)
-                                .equals(Entities.USER_PROFILE);
-                    });
+                                    .equals(Entities.USER_PROFILE));
             return frameVertices(pipe.dedup());
         }
     }

--- a/ehri-core/src/main/java/eu/ehri/project/models/Repository.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Repository.java
@@ -53,7 +53,7 @@ public interface Repository extends Described, ItemHolder, Watchable, Versioned,
      */
     @Meta(CHILD_COUNT)
     @JavaHandler
-    long getChildCount();
+    int getChildCount();
 
     /**
      * Fetch all top-level documentary unit items within this
@@ -105,8 +105,8 @@ public interface Repository extends Described, ItemHolder, Watchable, Versioned,
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, Repository {
 
-        public long getChildCount() {
-            return gremlin().inE(Ontology.DOC_HELD_BY_REPOSITORY).count();
+        public int getChildCount() {
+            return Math.toIntExact(gremlin().inE(Ontology.DOC_HELD_BY_REPOSITORY).count());
         }
 
         public void addTopLevelDocumentaryUnit(DocumentaryUnit unit) {

--- a/ehri-core/src/main/java/eu/ehri/project/models/UserProfile.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/UserProfile.java
@@ -52,15 +52,15 @@ public interface UserProfile extends Accessor, Actioner, Versioned, Annotatable 
 
     @Meta(FOLLOWER_COUNT)
     @JavaHandler
-    long getFollowerCount();
+    int getFollowerCount();
 
     @Meta(FOLLOWING_COUNT)
     @JavaHandler
-    long getFollowingCount();
+    int getFollowingCount();
 
     @Meta(WATCHING_COUNT)
     @JavaHandler
-    long getWatchingCount();
+    int getWatchingCount();
 
     /**
      * Get the groups to which this user belongs.
@@ -223,18 +223,18 @@ public interface UserProfile extends Accessor, Actioner, Versioned, Annotatable 
     abstract class Impl implements JavaHandlerContext<Vertex>, UserProfile {
 
         @Override
-        public long getFollowerCount() {
-            return gremlin().inE(USER_FOLLOWS_USER).count();
+        public int getFollowerCount() {
+            return Math.toIntExact(gremlin().inE(USER_FOLLOWS_USER).count());
         }
 
         @Override
-        public long getFollowingCount() {
-            return gremlin().outE(USER_FOLLOWS_USER).count();
+        public int getFollowingCount() {
+            return Math.toIntExact(gremlin().outE(USER_FOLLOWS_USER).count());
         }
 
         @Override
-        public long getWatchingCount() {
-            return gremlin().outE(USER_WATCHING_ITEM).count();
+        public int getWatchingCount() {
+            return Math.toIntExact(gremlin().outE(USER_WATCHING_ITEM).count());
         }
 
         @Override

--- a/ehri-core/src/main/java/eu/ehri/project/models/VirtualUnit.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/VirtualUnit.java
@@ -54,7 +54,7 @@ public interface VirtualUnit extends AbstractUnit {
 
     @Meta(CHILD_COUNT)
     @JavaHandler
-    long getChildCount();
+    int getChildCount();
 
     @Fetch(Ontology.VC_IS_PART_OF)
     @Adjacency(label = Ontology.VC_IS_PART_OF)
@@ -166,18 +166,22 @@ public interface VirtualUnit extends AbstractUnit {
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, VirtualUnit {
 
+        @Override
         public void setAuthor(Accessor accessor) {
             addSingleRelationship(it(), accessor.asVertex(), Ontology.VC_HAS_AUTHOR);
         }
 
+        @Override
         public void removeIncludedUnit(DocumentaryUnit unit) {
             removeAllRelationships(it(), unit.asVertex(), Ontology.VC_INCLUDES_UNIT);
         }
 
+        @Override
         public Iterable<VirtualUnit> getChildren() {
             return frameVertices(gremlin().in(Ontology.VC_IS_PART_OF));
         }
 
+        @Override
         public boolean addChild(VirtualUnit child) {
             if (child.asVertex().equals(it())) {
                 // Self-referential.
@@ -193,6 +197,7 @@ public interface VirtualUnit extends AbstractUnit {
             return addUniqueRelationship(child.asVertex(), it(), Ontology.VC_IS_PART_OF);
         }
 
+        @Override
         public boolean removeChild(VirtualUnit child) {
             return removeAllRelationships(child.asVertex(), it(), Ontology.VC_IS_PART_OF);
         }
@@ -203,6 +208,7 @@ public interface VirtualUnit extends AbstractUnit {
                     .loop("n", JavaHandlerUtils.defaultMaxLoops, JavaHandlerUtils.noopLoopFunc);
         }
 
+        @Override
         public Iterable<VirtualUnit> getAllChildren() {
             Pipeline<Vertex, Vertex> otherPipe = gremlin().as("n").in(Ontology.VC_IS_PART_OF)
                     .loop("n", JavaHandlerUtils.noopLoopFunc, JavaHandlerUtils.noopLoopFunc);
@@ -211,18 +217,21 @@ public interface VirtualUnit extends AbstractUnit {
                     .fairMerge().cast(Vertex.class));
         }
 
+        @Override
         public Iterable<VirtualUnit> getAncestors() {
             return frameVertices(traverseAncestors());
         }
 
+        @Override
         public boolean addIncludedUnit(DocumentaryUnit unit) {
             return addUniqueRelationship(it(), unit.asVertex(), Ontology.VC_INCLUDES_UNIT);
         }
 
-        public long getChildCount() {
+        @Override
+        public int getChildCount() {
             long incCount = gremlin().outE(Ontology.VC_INCLUDES_UNIT).count();
             long vcCount = gremlin().inE(Ontology.VC_IS_PART_OF).count();
-            return incCount + vcCount;
+            return Math.toIntExact(incCount + vcCount);
         }
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/ItemHolder.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/ItemHolder.java
@@ -25,5 +25,5 @@ package eu.ehri.project.models.base;
 public interface ItemHolder {
     String CHILD_COUNT = "childCount";
 
-    long getChildCount();
+    int getChildCount();
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Promotable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Promotable.java
@@ -66,58 +66,65 @@ public interface Promotable extends Accessible {
     boolean isPromotable();
 
     @JavaHandler
-    long getPromotionScore();
-
-    @JavaHandler
-    void updatePromotionScoreCache();
+    int getPromotionScore();
 
     /**
      * Implementation of complex methods.
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, Promotable {
 
-        public void updatePromotionScoreCache() {
-            long score = gremlin().out(Ontology.PROMOTED_BY).count() - gremlin().out(Ontology.DEMOTED_BY).count();
+        private void updatePromotionScoreCache() {
+            int score = Math.toIntExact(gremlin().out(Ontology.PROMOTED_BY).count()
+                    - gremlin().out(Ontology.DEMOTED_BY).count());
             it().setProperty(PROMOTION_SCORE, score);
         }
 
+        @Override
         public void addPromotion(UserProfile user) {
             addUniqueRelationship(it(), user.asVertex(), Ontology.PROMOTED_BY);
             removeAllRelationships(it(), user.asVertex(), Ontology.DEMOTED_BY);
             updatePromotionScoreCache();
         }
 
+        @Override
         public void removePromotion(UserProfile user) {
             removeAllRelationships(it(), user.asVertex(), Ontology.PROMOTED_BY);
             updatePromotionScoreCache();
         }
 
+        @Override
         public void addDemotion(UserProfile user) {
             addUniqueRelationship(it(), user.asVertex(), Ontology.DEMOTED_BY);
             removeAllRelationships(it(), user.asVertex(), Ontology.PROMOTED_BY);
             updatePromotionScoreCache();
         }
 
+        @Override
         public void removeDemotion(UserProfile user) {
             removeAllRelationships(it(), user.asVertex(), Ontology.DEMOTED_BY);
             updatePromotionScoreCache();
         }
 
+        @Override
         public boolean isPromoted() {
             return gremlin().out(Ontology.PROMOTED_BY).count() > gremlin().out(Ontology.DEMOTED_BY).count();
         }
 
-        public long getPromotionScore() {
-            Long score = it().getProperty(PROMOTION_SCORE);
+        @Override
+        public int getPromotionScore() {
+            Integer score = it().getProperty(PROMOTION_SCORE);
             return score == null
-                    ?gremlin().out(Ontology.PROMOTED_BY).count() - gremlin().out(Ontology.DEMOTED_BY).count()
+                    ? Math.toIntExact(gremlin().out(Ontology.PROMOTED_BY).count()
+                            - gremlin().out(Ontology.DEMOTED_BY).count())
                     : score;
         }
 
+        @Override
         public boolean isPromotedBy(UserProfile user) {
             return hasRelationship(it(), user.asVertex(), Ontology.PROMOTED_BY);
         }
 
+        @Override
         public boolean isPromotable() {
             Boolean promotable = it().getProperty(Ontology.IS_PROMOTABLE);
             return promotable != null && promotable;

--- a/ehri-core/src/main/java/eu/ehri/project/models/base/Watchable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/base/Watchable.java
@@ -40,13 +40,13 @@ public interface Watchable extends Accessible {
 
     @Meta(WATCHED_COUNT)
     @JavaHandler
-    long getWatchedCount();
+    int getWatchedCount();
 
     abstract class Impl implements JavaHandlerContext<Vertex>, Watchable {
 
         @Override
-        public long getWatchedCount() {
-            return gremlin().inE(USER_WATCHING_ITEM).count();
+        public int getWatchedCount() {
+            return Math.toIntExact(gremlin().inE(USER_WATCHING_ITEM).count());
         }
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
@@ -63,10 +63,12 @@ public interface AuthoritativeSet extends Accessible,
      */
     abstract class Impl implements JavaHandlerContext<Vertex>, AuthoritativeSet {
 
-        public long getChildCount() {
-            return gremlin().inE(Ontology.ITEM_IN_AUTHORITATIVE_SET).count();
+        @Override
+        public int getChildCount() {
+            return Math.toIntExact(gremlin().inE(Ontology.ITEM_IN_AUTHORITATIVE_SET).count());
         }
 
+        @Override
         public void addItem(AuthoritativeItem item) {
             JavaHandlerUtils.addSingleRelationship(item.asVertex(), it(),
                     Ontology.ITEM_IN_AUTHORITATIVE_SET);

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/Concept.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/Concept.java
@@ -60,7 +60,7 @@ public interface Concept extends Described, AuthoritativeItem, ItemHolder {
     void setVocabulary(Vocabulary vocabulary);
 
     @Property(CHILD_COUNT)
-    long getChildCount();
+    int getChildCount();
 
     // relations to other concepts
     
@@ -100,8 +100,8 @@ public interface Concept extends Described, AuthoritativeItem, ItemHolder {
     abstract class Impl  implements JavaHandlerContext<Vertex>, Concept {
 
         @Override
-        public long getChildCount() {
-            return gremlin().outE(Ontology.CONCEPT_HAS_NARROWER).count();
+        public int getChildCount() {
+            return Math.toIntExact(gremlin().outE(Ontology.CONCEPT_HAS_NARROWER).count());
         }
 
         @Override

--- a/ehri-core/src/main/java/eu/ehri/project/models/events/SystemEvent.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/events/SystemEvent.java
@@ -51,7 +51,7 @@ public interface SystemEvent extends Accessible {
 
     @Meta(ItemHolder.CHILD_COUNT)
     @JavaHandler
-    long subjectCount();
+    int subjectCount();
 
     /**
      * Fetch the time stamp of this event.
@@ -148,18 +148,17 @@ public interface SystemEvent extends Accessible {
     abstract class Impl implements JavaHandlerContext<Vertex>, SystemEvent {
 
         @Override
-        public long subjectCount() {
-            return gremlin().inE(Ontology.ENTITY_HAS_EVENT).count();
+        public int subjectCount() {
+            return Math.toIntExact(gremlin().inE(Ontology.ENTITY_HAS_EVENT).count());
         }
 
         @Override
         public Iterable<Accessible> getSubjects() {
             return frameVertices(gremlin().in(Ontology.ENTITY_HAS_EVENT)
                     .as("n").in(Ontology.ENTITY_HAS_LIFECYCLE_EVENT)
-                    .loop("n", JavaHandlerUtils.noopLoopFunc, vertexLoopBundle -> {
-                        return isValidEndpoint(vertexLoopBundle.getObject(),
-                                Ontology.ENTITY_HAS_LIFECYCLE_EVENT);
-                    }));
+                    .loop("n", JavaHandlerUtils.noopLoopFunc,
+                            vertexLoopBundle -> isValidEndpoint(vertexLoopBundle.getObject(),
+                            Ontology.ENTITY_HAS_LIFECYCLE_EVENT)));
         }
 
         @Override
@@ -169,10 +168,9 @@ public interface SystemEvent extends Accessible {
             // with Frames not being thinking it has an iterable???
             GremlinPipeline<Vertex, Vertex> subjects = gremlin().in(Ontology.ENTITY_HAS_EVENT)
                     .as("n").in(Ontology.ENTITY_HAS_LIFECYCLE_EVENT)
-                    .loop("n", JavaHandlerUtils.noopLoopFunc, vertexLoopBundle -> {
-                        return isValidEndpoint(vertexLoopBundle.getObject(),
-                                Ontology.ENTITY_HAS_LIFECYCLE_EVENT);
-                    });
+                    .loop("n", JavaHandlerUtils.noopLoopFunc,
+                            vertexLoopBundle -> isValidEndpoint(vertexLoopBundle.getObject(),
+                            Ontology.ENTITY_HAS_LIFECYCLE_EVENT));
             return (Accessible) (subjects.iterator().hasNext()
                     ? frame(subjects.iterator().next())
                     : null);
@@ -182,10 +180,9 @@ public interface SystemEvent extends Accessible {
         public Actioner getActioner() {
             GremlinPipeline<Vertex, Vertex> actioners = gremlin().in(Ontology.ACTION_HAS_EVENT)
                     .as("n").in(Ontology.ACTIONER_HAS_LIFECYCLE_ACTION)
-                    .loop("n", JavaHandlerUtils.noopLoopFunc, vertexLoopBundle -> {
-                        return isValidEndpoint(vertexLoopBundle.getObject(),
-                                Ontology.ACTIONER_HAS_LIFECYCLE_ACTION);
-                    });
+                    .loop("n", JavaHandlerUtils.noopLoopFunc,
+                            vertexLoopBundle -> isValidEndpoint(vertexLoopBundle.getObject(),
+                            Ontology.ACTIONER_HAS_LIFECYCLE_ACTION));
             return (Actioner) (actioners.iterator().hasNext()
                     ? frame(actioners.iterator().next())
                     : null);

--- a/ehri-core/src/main/java/eu/ehri/project/tools/Linker.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/Linker.java
@@ -109,7 +109,7 @@ public class Linker {
      * @throws ValidationError
      * @throws PermissionDenied
      */
-    public long createAndLinkRepositoryVocabulary(
+    public int createAndLinkRepositoryVocabulary(
             Repository repository,
             Vocabulary vocabulary,
             UserProfile user)
@@ -149,7 +149,7 @@ public class Linker {
         // Abort if we've got no concepts - this avoids creating
         // an event unnecessarily...
         if (!willCreateItems(identifierCount, excludeSingles)) {
-            return 0L;
+            return 0;
         }
 
         // Now create concepts for all the names
@@ -206,7 +206,7 @@ public class Linker {
         // which the concept originally derived.
         ActionManager.EventContext linkEvent = actionManager
                 .newEventContext(user, EventTypes.creation, logMessage);
-        long linkCount = 0L;
+        int linkCount = 0;
         for (DocumentaryUnit doc : repository.getAllDocumentaryUnits()) {
             for (DocumentaryUnitDescription description : doc.getDocumentDescriptions()) {
                 for (AccessPoint relationship : description.getAccessPoints()) {

--- a/ehri-core/src/test/java/eu/ehri/project/acl/AclManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/AclManagerTest.java
@@ -229,7 +229,7 @@ public class AclManagerTest extends GraphTestBase {
         GremlinPipeline<Vertex, Vertex> pipeline = new GremlinPipeline<>(frames);
         List<Vertex> filtered = pipeline
                 .filter(acl.getContentTypeFilterFunction()).toList();
-        assertEquals(2L, filtered.size());
+        assertEquals(2, filtered.size());
         assertFalse(filtered.contains(cd1));
     }
 
@@ -248,7 +248,7 @@ public class AclManagerTest extends GraphTestBase {
         PipeFunction<Vertex,Boolean> aclFilter = AclManager.getAclFilterFunction(user);
         List<Vertex> filtered = new GremlinPipeline<Vertex,Vertex>(
                 Lists.newArrayList(ann3v.asVertex(), ann4v.asVertex())).filter(aclFilter).toList();
-        assertEquals(1L, filtered.size());
+        assertEquals(1, filtered.size());
         assertFalse(filtered.contains(ann3v.asVertex()));
     }
 

--- a/ehri-core/src/test/java/eu/ehri/project/acl/InheritedGlobalPermissionSetTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/InheritedGlobalPermissionSetTest.java
@@ -59,6 +59,6 @@ public class InheritedGlobalPermissionSetTest extends AbstractFixtureTest {
         InheritedGlobalPermissionSet permissions
                 = aclManager.getInheritedGlobalPermissions(invalidUser);
         List<Map<String,GlobalPermissionSet>> list = permissions.serialize();
-        assertEquals(2L, list.size());
+        assertEquals(2, list.size());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/acl/InheritedItemPermissionSetTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/InheritedItemPermissionSetTest.java
@@ -59,6 +59,6 @@ public class InheritedItemPermissionSetTest extends AbstractFixtureTest {
         );
         List<Map<String,List<PermissionType>>> serialized = permissions.serialize();
         // Should contain Reto and Kcl
-        assertEquals(2L, serialized.size());
+        assertEquals(2, serialized.size());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
@@ -61,14 +61,14 @@ public class AclGraphTest extends AbstractFixtureTest {
     public void testGetVerticesAsValidUser() throws Exception {
         Iterable<Vertex> vertices = validUserGraph.getVertices(Ontology.IDENTIFIER_KEY, "c1");
         assertTrue(vertices.iterator().hasNext());
-        assertEquals(1L, Iterables.size(vertices));
+        assertEquals(1, Iterables.size(vertices));
     }
 
     @Test
     public void testGetVerticesAsInvalidUser() throws Exception {
         Iterable<Vertex> vertices = invalidUserGraph.getVertices(Ontology.IDENTIFIER_KEY, "c1");
         assertFalse(vertices.iterator().hasNext());
-        assertEquals(0L, Iterables.size(vertices));
+        assertEquals(0, Iterables.size(vertices));
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiDescriptionsTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiDescriptionsTest.java
@@ -103,7 +103,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
         DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
-        long descCount = Iterables.size(unit.getDocumentDescriptions());
+        int descCount = Iterables.size(unit.getDocumentDescriptions());
         Bundle descBundle = new Serializer(graph).entityToBundle(unit)
                 .getRelations(Ontology.DESCRIPTION_FOR_ENTITY)
                 .get(0).withDataValue(Ontology.NAME_KEY, "some-new-title");
@@ -137,7 +137,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
         DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
-        long descCount = Iterables.size(unit.getDocumentDescriptions());
+        int descCount = Iterables.size(unit.getDocumentDescriptions());
 
         DocumentaryUnitDescription d = Iterables.getFirst(unit.getDocumentDescriptions(), null);
         assertNotNull(d);

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLinkingTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLinkingTest.java
@@ -70,10 +70,10 @@ public class ApiLinkingTest extends AbstractFixtureTest {
         Link link = api(validUser).createLink("c1", "a1", Lists.newArrayList("ur1"),
                 linkBundle, Lists.<Accessor>newArrayList());
         assertEquals(linkDesc, link.getDescription());
-        assertEquals(2L, Iterables.size(link.getLinkTargets()));
+        assertEquals(2, Iterables.size(link.getLinkTargets()));
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
         assertTrue(Iterables.contains(link.getLinkTargets(), dst));
-        assertEquals(1L, Iterables.size(link.getLinkBodies()));
+        assertEquals(1, Iterables.size(link.getLinkBodies()));
         assertTrue(Iterables.contains(link.getLinkBodies(), rel));
         assertTrue(Lists.newArrayList(api(validUser).actionManager()
                 .getLatestGlobalEvent().getSubjects()).contains(link));
@@ -99,10 +99,10 @@ public class ApiLinkingTest extends AbstractFixtureTest {
                 linkDesc, AccessPointType.subject, linkBundle,
                 Lists.<Accessor>newArrayList(validUser, invalidUser));
         assertEquals(linkDesc, link.getDescription());
-        assertEquals(2L, Iterables.size(link.getLinkTargets()));
+        assertEquals(2, Iterables.size(link.getLinkTargets()));
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
         assertTrue(Iterables.contains(link.getLinkTargets(), dst));
-        assertEquals(1L, Iterables.size(link.getLinkBodies()));
+        assertEquals(1, Iterables.size(link.getLinkBodies()));
         AccessPoint rel = link.getLinkBodies().iterator().next().as(AccessPoint.class);
         assertEquals(rel.getName(), linkDesc);
         assertEquals(rel.getRelationshipType(), AccessPointType.subject);

--- a/ehri-core/src/test/java/eu/ehri/project/api/QueryApiTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/QueryApiTest.java
@@ -151,7 +151,7 @@ public class QueryApiTest extends AbstractFixtureTest {
         // Query for document identifier c1.
         QueryApi.Page<DocumentaryUnit> list = query.setLimit(1).page(
                 Ontology.IDENTIFIER_KEY, "c1", DocumentaryUnit.class);
-        assertEquals(-1L, list.getTotal());
+        assertEquals(-1, list.getTotal());
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/CountryTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/CountryTest.java
@@ -37,21 +37,21 @@ public class CountryTest extends AbstractFixtureTest {
                 .create(Bundle.fromData(TestData.getTestAgentBundle()), Repository.class);
         country.addRepository(repo);
         // 2 nl repositories in the fixtures, plus the one we just made...
-        assertEquals(3L, country.getChildCount());
+        assertEquals(3, country.getChildCount());
     }
 
     @Test
     public void testGetChildCountOnDeletion() throws Exception {
         Country country = manager.getEntity("nl", Country.class);
-        assertEquals(2L, country.getChildCount());
+        assertEquals(2, country.getChildCount());
         api(validUser).delete("r1");
-        assertEquals(1L, country.getChildCount());
+        assertEquals(1, country.getChildCount());
     }
 
     @Test
     public void testGetRepositories() throws Exception {
         Country country = manager.getEntity("nl", Country.class);
-        assertEquals(2L, Iterables.size(country.getRepositories()));
+        assertEquals(2, Iterables.size(country.getRepositories()));
     }
 
     @Test
@@ -63,6 +63,6 @@ public class CountryTest extends AbstractFixtureTest {
         // increments the country count...
         repo.setCountry(country);
         // 2 nl repositories in the fixtures, plus the one we just made...
-        assertEquals(3L, country.getChildCount());
+        assertEquals(3, country.getChildCount());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/models/DocumentaryUnitTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/DocumentaryUnitTest.java
@@ -86,17 +86,17 @@ public class DocumentaryUnitTest extends AbstractFixtureTest {
         DocumentaryUnit unit = manager.getEntity("c1", DocumentaryUnit.class);
         DocumentaryUnit child = manager.getEntity("c2", DocumentaryUnit.class);
         assertEquals(unit, child.getParent());
-        assertEquals(1L, unit.getChildCount());
+        assertEquals(1, unit.getChildCount());
         unit.addChild(child);
-        assertEquals(1L, unit.getChildCount());
+        assertEquals(1, unit.getChildCount());
     }
 
     @Test
     public void testCannotAddSelfAsChild() throws Exception {
         DocumentaryUnit unit = manager.getEntity("c1", DocumentaryUnit.class);
-        assertEquals(1L, unit.getChildCount());
+        assertEquals(1, unit.getChildCount());
         unit.addChild(unit);
-        assertEquals(1L, unit.getChildCount());
+        assertEquals(1, unit.getChildCount());
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/GroupTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/GroupTest.java
@@ -48,7 +48,7 @@ public class GroupTest extends AbstractFixtureTest {
         admin.addMember(validUser);
         assertEquals(numMembers, Iterables.size(admin.getMembers()));
         admin.addMember(invalidUser);
-        assertEquals(numMembers + 1L, Iterables.size(admin.getMembers()));
+        assertEquals(numMembers + 1, Iterables.size(admin.getMembers()));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class GroupTest extends AbstractFixtureTest {
         admin.removeMember(invalidUser);
         assertEquals(numMembers, Iterables.size(admin.getMembers()));
         admin.removeMember(validUser);
-        assertEquals(numMembers - 1L, Iterables.size(admin.getMembers()));
+        assertEquals(numMembers - 1, Iterables.size(admin.getMembers()));
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/RepositoryTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/RepositoryTest.java
@@ -32,10 +32,10 @@ public class RepositoryTest extends AbstractFixtureTest {
     @Test
     public void testGetCollections() throws Exception {
         Repository r1 = manager.getEntity("r1", Repository.class);
-        assertEquals(3L, Iterables.size(r1.getTopLevelDocumentaryUnits()));
+        assertEquals(3, Iterables.size(r1.getTopLevelDocumentaryUnits()));
 
         // Check the cached size
-        assertEquals(3L, r1.getChildCount());
+        assertEquals(3, r1.getChildCount());
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/UserProfileTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/UserProfileTest.java
@@ -71,17 +71,17 @@ public class UserProfileTest extends AbstractFixtureTest {
         assertTrue(Iterables.isEmpty(reto.getFollowing()));
 
         reto.addFollowing(mike);
-        assertEquals(1L, Iterables.size(mike.getFollowers()));
-        assertEquals(1L, Iterables.size(reto.getFollowing()));
+        assertEquals(1, Iterables.size(mike.getFollowers()));
+        assertEquals(1, Iterables.size(reto.getFollowing()));
 
         reto.addFollowing(linda);
-        assertEquals(1L, Iterables.size(mike.getFollowers()));
-        assertEquals(2L, Iterables.size(reto.getFollowing()));
+        assertEquals(1, Iterables.size(mike.getFollowers()));
+        assertEquals(2, Iterables.size(reto.getFollowing()));
 
         // Get count caching
-        assertEquals(2L, reto.getFollowingCount());
-        assertEquals(1L, mike.getFollowerCount());
-        assertEquals(1L, linda.getFollowerCount());
+        assertEquals(2, reto.getFollowingCount());
+        assertEquals(1, mike.getFollowerCount());
+        assertEquals(1, linda.getFollowerCount());
 
         assertFalse(Iterables.isEmpty(reto.getFollowing()));
         assertTrue(Iterables.contains(reto.getFollowing(), mike));
@@ -90,8 +90,8 @@ public class UserProfileTest extends AbstractFixtureTest {
         assertTrue(Iterables.isEmpty(mike.getFollowers()));
         assertFalse(Iterables.isEmpty(reto.getFollowing()));
 
-        assertEquals(1L, reto.getFollowingCount());
-        assertEquals(0L, mike.getFollowerCount());
+        assertEquals(1, reto.getFollowingCount());
+        assertEquals(0, mike.getFollowerCount());
     }
 
     @Test
@@ -109,9 +109,9 @@ public class UserProfileTest extends AbstractFixtureTest {
         // Do this twice and ensure the follower count isn't altered...
         reto.addFollowing(mike);
         reto.addFollowing(mike);
-        assertEquals(1L, Iterables.size(reto.getFollowing()));
+        assertEquals(1, Iterables.size(reto.getFollowing()));
         reto.addFollowing(linda);
-        assertEquals(2L, Iterables.size(reto.getFollowing()));
+        assertEquals(2, Iterables.size(reto.getFollowing()));
     }
 
     @Test
@@ -121,20 +121,20 @@ public class UserProfileTest extends AbstractFixtureTest {
         assertFalse(mike.isWatching(c1));
         mike.addWatching(c1);
         assertTrue(mike.isWatching(c1));
-        assertEquals(1L, mike.getWatchingCount());
+        assertEquals(1, mike.getWatchingCount());
         assertTrue(Iterables.contains(c1.getWatchers(), mike));
-        assertEquals(1L, c1.getWatchedCount());
+        assertEquals(1, c1.getWatchedCount());
         assertTrue(Iterables.contains(mike.getWatching(), c1));
 
         mike.addWatching(c2);
-        assertEquals(2L, mike.getWatchingCount());
+        assertEquals(2, mike.getWatchingCount());
         mike.removeWatching(c2);
-        assertEquals(1L, mike.getWatchingCount());
+        assertEquals(1, mike.getWatchingCount());
 
         mike.removeWatching(c1);
         assertFalse(mike.isWatching(c1));
-        assertEquals(0L, mike.getWatchingCount());
-        assertEquals(0L, c1.getWatchedCount());
+        assertEquals(0, mike.getWatchingCount());
+        assertEquals(0, c1.getWatchedCount());
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/VirtualUnitTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/VirtualUnitTest.java
@@ -34,7 +34,7 @@ public class VirtualUnitTest extends AbstractFixtureTest {
     @Test
     public void testGetChildCount() throws Exception {
         VirtualUnit vc1 = manager.getEntity("vc1", VirtualUnit.class);
-        assertEquals(1L, vc1.getChildCount());
+        assertEquals(1, vc1.getChildCount());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class VirtualUnitTest extends AbstractFixtureTest {
     public void testAddChild() throws Exception {
         VirtualUnit vu2 = manager.getEntity("vu2", VirtualUnit.class);
         VirtualUnit vu3 = manager.getEntity("vu3", VirtualUnit.class);
-        Long childCount = vu2.getChildCount();
+        int childCount = vu2.getChildCount();
         assertTrue(vu2.addChild(vu3));
         assertEquals(childCount + 1, vu2.getChildCount());
         // Doing the same thing twice should return false
@@ -80,8 +80,8 @@ public class VirtualUnitTest extends AbstractFixtureTest {
         DocumentaryUnit c4 = manager.getEntity("c4", DocumentaryUnit.class);
         assertTrue(vu1.getAllChildren().iterator().hasNext());
         assertTrue(vu1.getIncludedUnits().iterator().hasNext());
-        long childCount = vu1.getChildCount();
-        assertEquals(2L, childCount);
+        int childCount = vu1.getChildCount();
+        assertEquals(2, childCount);
         vu1.addIncludedUnit(c4);
         assertEquals(childCount + 1, vu1.getChildCount());
         vu1.removeIncludedUnit(c4);
@@ -97,13 +97,13 @@ public class VirtualUnitTest extends AbstractFixtureTest {
     public void testAddIncludedUnit() throws Exception {
         VirtualUnit vu1 = manager.getEntity("vu1", VirtualUnit.class);
         DocumentaryUnit c4 = manager.getEntity("c4", DocumentaryUnit.class);
-        assertEquals(1L, Iterables.size(vu1.getIncludedUnits()));
+        assertEquals(1, Iterables.size(vu1.getIncludedUnits()));
         vu1.addIncludedUnit(c4);
 //        vu1.addReferencedDescription(cd4);
-        assertEquals(2L, Iterables.size(vu1.getIncludedUnits()));
+        assertEquals(2, Iterables.size(vu1.getIncludedUnits()));
         // check we can't add it twice
         vu1.addIncludedUnit(c4);
-        assertEquals(2L, Iterables.size(vu1.getIncludedUnits()));
+        assertEquals(2, Iterables.size(vu1.getIncludedUnits()));
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/base/AccessibleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/base/AccessibleTest.java
@@ -41,7 +41,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         Accessible c1 = manager.getEntity("c1", Accessible.class);
         Accessible admin = manager.getEntity(Group.ADMIN_GROUP_IDENTIFIER, Accessible.class);
         List<Accessor> accessors = Lists.newArrayList(c1.getAccessors());
-        assertEquals(2L, accessors.size());
+        assertEquals(2, accessors.size());
         assertTrue(accessors.contains(validUser)); // mike
         assertTrue(accessors.contains(admin));
     }
@@ -51,11 +51,11 @@ public class AccessibleTest extends AbstractFixtureTest {
         Accessible c1 = manager.getEntity("c1", Accessible.class);
         Accessor admin = manager.getEntity(Group.ADMIN_GROUP_IDENTIFIER, Accessor.class);
         List<Accessor> accessors = Lists.newArrayList(c1.getAccessors());
-        assertEquals(2L, accessors.size());
+        assertEquals(2, accessors.size());
         c1.addAccessor(admin);
-        assertEquals(2L, Iterables.size(c1.getAccessors())); // same size
+        assertEquals(2, Iterables.size(c1.getAccessors())); // same size
         c1.addAccessor(invalidUser);
-        assertEquals(3L, Iterables.size(c1.getAccessors()));
+        assertEquals(3, Iterables.size(c1.getAccessors()));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         Accessor admin = manager.getEntity(Group.ADMIN_GROUP_IDENTIFIER, Accessor.class);
         c1.removeAccessor(admin);
         List<Accessor> accessors = Lists.newArrayList(c1.getAccessors());
-        assertEquals(1L, accessors.size());
+        assertEquals(1, accessors.size());
         assertTrue(accessors.contains(validUser));
     }
 
@@ -93,7 +93,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         PermissionScope nl = manager.getEntity("nl", PermissionScope.class);
         assertEquals(r1, c1.getPermissionScope());
         List<PermissionScope> scopes = Lists.newArrayList(c2.getPermissionScopes());
-        assertEquals(3L, scopes.size());
+        assertEquals(3, scopes.size());
         assertTrue(scopes.contains(c1));
         assertTrue(scopes.contains(r1));
         assertTrue(scopes.contains(nl));
@@ -105,7 +105,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         Mutation<DocumentaryUnit> update = doUpdate(c1);
         assertTrue(update.updated());
         Iterable<SystemEvent> history = c1.getHistory();
-        assertEquals(1L, Iterables.size(history));
+        assertEquals(1, Iterables.size(history));
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/base/PermissionScopeTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/base/PermissionScopeTest.java
@@ -59,7 +59,7 @@ public class PermissionScopeTest extends AbstractFixtureTest {
         PermissionScope c1 = manager.getEntity("c1", PermissionScope.class);
         PermissionScope c2 = manager.getEntity("c2", PermissionScope.class);
         Iterable<Accessible> containedItems = c1.getContainedItems();
-        assertEquals(1L, Iterables.size(containedItems));
+        assertEquals(1, Iterables.size(containedItems));
         assertEquals(c2, containedItems.iterator().next());
     }
 
@@ -71,14 +71,14 @@ public class PermissionScopeTest extends AbstractFixtureTest {
         PermissionScope c3 = manager.getEntity("c3", PermissionScope.class);
         PermissionScope c4 = manager.getEntity("c4", PermissionScope.class);
         List<Accessible> r1contained = Lists.newArrayList(r1.getAllContainedItems());
-        assertEquals(5L, r1contained.size());
+        assertEquals(5, r1contained.size());
         assertTrue(r1contained.contains(c1.as(Accessible.class)));
         assertTrue(r1contained.contains(c2.as(Accessible.class)));
         assertTrue(r1contained.contains(c3.as(Accessible.class)));
         assertTrue(r1contained.contains(c4.as(Accessible.class)));
 
         List<Accessible> c1contained = Lists.newArrayList(c1.getAllContainedItems());
-        assertEquals(2L, c1contained.size());
+        assertEquals(2, c1contained.size());
         assertTrue(c1contained.contains(c2.as(Accessible.class)));
         assertTrue(c1contained.contains(c3.as(Accessible.class)));
     }

--- a/ehri-core/src/test/java/eu/ehri/project/models/base/PromotableTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/base/PromotableTest.java
@@ -58,33 +58,33 @@ public class PromotableTest extends AbstractFixtureTest {
     @Test
     public void testAddPromotion() throws Exception {
         Promotable promotable = manager.getEntity("ann5", Promotable.class);
-        assertEquals(0L, promotable.getPromotionScore());
+        assertEquals(0, promotable.getPromotionScore());
         promotable.addPromotion(user1);
-        assertEquals(1L, promotable.getPromotionScore());
+        assertEquals(1, promotable.getPromotionScore());
     }
 
     @Test
     public void testAddDemotion() throws Exception {
         Promotable promotable = manager.getEntity("ann5", Promotable.class);
-        assertEquals(0L, promotable.getPromotionScore());
+        assertEquals(0, promotable.getPromotionScore());
         promotable.addDemotion(user1);
-        assertEquals(-1L, promotable.getPromotionScore());
+        assertEquals(-1, promotable.getPromotionScore());
     }
 
     @Test
     public void testRemovePromotion() throws Exception {
         Promotable promotable = manager.getEntity("ann6", Promotable.class);
-        assertEquals(0L, promotable.getPromotionScore());
+        assertEquals(0, promotable.getPromotionScore());
         promotable.removePromotion(user1);
-        assertEquals(-1L, promotable.getPromotionScore());
+        assertEquals(-1, promotable.getPromotionScore());
     }
 
     @Test
     public void testRemoveDemotion() throws Exception {
         Promotable promotable = manager.getEntity("ann6", Promotable.class);
-        assertEquals(0L, promotable.getPromotionScore());
+        assertEquals(0, promotable.getPromotionScore());
         promotable.removeDemotion(user2);
-        assertEquals(1L, promotable.getPromotionScore());
+        assertEquals(1, promotable.getPromotionScore());
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/ActionManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/ActionManagerTest.java
@@ -72,7 +72,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         // Check exactly one Event was created
         assertEquals(1, Iterables.size(second.getSubjects()));
         // Check item cache is correct...
-        assertEquals(1L, second.subjectCount());
+        assertEquals(1, second.subjectCount());
         assertNotNull(second.getActioner());
 
         // Check the user is correctly linked

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -244,7 +244,7 @@ public class BundleTest {
     @Test
     public void testGetRelations() throws Exception {
         List<Bundle> relations = bundle.getRelations(Ontology.DESCRIPTION_FOR_ENTITY);
-        assertEquals(1L, relations.size());
+        assertEquals(1, relations.size());
     }
 
     @Test
@@ -255,7 +255,7 @@ public class BundleTest {
         Multimap<String, Bundle> rels = ImmutableListMultimap
                 .of(Ontology.DESCRIPTION_FOR_ENTITY, newDesc);
         Bundle bundle2 = bundle.replaceRelations(rels);
-        assertEquals(1L, bundle2.getRelations(
+        assertEquals(1, bundle2.getRelations(
                 Ontology.DESCRIPTION_FOR_ENTITY).size());
     }
 
@@ -267,7 +267,7 @@ public class BundleTest {
         Multimap<String, Bundle> rels = ImmutableListMultimap
                 .of(Ontology.DESCRIPTION_FOR_ENTITY, newDesc);
         Bundle bundle2 = bundle.withRelations(rels);
-        assertEquals(2L, bundle2.getRelations(
+        assertEquals(2, bundle2.getRelations(
                 Ontology.DESCRIPTION_FOR_ENTITY).size());
     }
 
@@ -278,7 +278,7 @@ public class BundleTest {
                 .withDataValue(Ontology.LANGUAGE, "en");
         Bundle bundle2 = bundle.withRelations(
                 Ontology.DESCRIPTION_FOR_ENTITY, Lists.newArrayList(newDesc));
-        assertEquals(2L, bundle2.getRelations(
+        assertEquals(2, bundle2.getRelations(
                 Ontology.DESCRIPTION_FOR_ENTITY).size());
     }
 
@@ -288,7 +288,7 @@ public class BundleTest {
                 .withDataValue(Ontology.NAME_KEY, "Foobar")
                 .withDataValue(Ontology.LANGUAGE, "en");
         Bundle bundle2 = bundle.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, newDesc);
-        assertEquals(2L, bundle2.getRelations(
+        assertEquals(2, bundle2.getRelations(
                 Ontology.DESCRIPTION_FOR_ENTITY).size());
     }
 
@@ -311,7 +311,7 @@ public class BundleTest {
     @Test
     public void testRemoveRelation() throws Exception {
         List<Bundle> relations = bundle.getRelations(Ontology.DESCRIPTION_FOR_ENTITY);
-        assertEquals(1L, relations.size());
+        assertEquals(1, relations.size());
         Bundle bundle2 = bundle.removeRelation(
                 Ontology.DESCRIPTION_FOR_ENTITY, relations.get(0));
         assertFalse(bundle2.hasRelations(Ontology.DESCRIPTION_FOR_ENTITY));

--- a/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
@@ -50,7 +50,7 @@ public class LinkerTest extends AbstractFixtureTest {
         // The doc c1 contains two access point nodes which should be made
         // into links
         String logMessage = "This is a test!";
-        long newLinkCount = linker
+        int newLinkCount = linker
                 .withExcludeSingles(false)
                 .withLogMessage(logMessage)
                 .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
@@ -68,7 +68,7 @@ public class LinkerTest extends AbstractFixtureTest {
 
         // This won't create any links because the access point type
         // won't match any existing access points.
-        long newLinkCount = linker
+        int newLinkCount = linker
                 .withExcludeSingles(false)
                 .withAccessPointType("IDontExist")
                 .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
@@ -86,7 +86,7 @@ public class LinkerTest extends AbstractFixtureTest {
 
         // This won't create any links because all of the access points only point
         // to single items
-        long newLinkCount = linker.withExcludeSingles(true)
+        int newLinkCount = linker.withExcludeSingles(true)
             .createAndLinkRepositoryVocabulary(repository, vocabulary,
                     validUser);
         assertEquals(0, newLinkCount);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/UkrainianUnitImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/UkrainianUnitImporterTest.java
@@ -44,7 +44,7 @@ public class UkrainianUnitImporterTest extends AbstractImporterTest {
     @Test
     public void testImportItemsT() throws Exception {
         Bundle ukrainianBundle = new Bundle(EntityClass.COUNTRY)
-                                .withDataValue(Country.COUNTRY_CODE, "ua");
+                                .withDataValue(Ontology.IDENTIFIER_KEY, "ua");
         Bundle repoBundle = new Bundle(EntityClass.REPOSITORY).withDataValue(Ontology.IDENTIFIER_KEY, "ua-3311");
         Bundle repoDescBundle = new Bundle(EntityClass.REPOSITORY_DESCRIPTION)
                 .withDataValue(Ontology.NAME_KEY, "Центральний державний архів вищих органів влади і управління України")

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAATest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/CegesomaAATest.java
@@ -134,7 +134,7 @@ public class CegesomaAATest extends AbstractImporterTest {
         /**
          * Test hierarchy
          */
-        assertEquals(1L, archdesc.getChildCount());
+        assertEquals(1, archdesc.getChildCount());
         for (DocumentaryUnit du : archdesc.getChildren()) {
             assertEquals(C01, du.getIdentifier());
         }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
@@ -84,7 +84,7 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
         for (Description d : unit.getDocumentDescriptions())
             assertEquals("Zbirka gradiva za povijest Židova (Collection of material concerning the history of Jews)", d.getName());
 
-        assertEquals(2L, unit.getChildCount());
+        assertEquals(2, unit.getChildCount());
         List<DocumentaryUnit> children = Lists.newArrayList(unit.getChildren());
         DocumentaryUnit child1 = children.get(0);
         DocumentaryUnit child2 = children.get(1);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IfzTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IfzTest.java
@@ -126,7 +126,7 @@ public class IfzTest extends AbstractImporterTest {
         /**
          * Test hierarchy
          */
-        assertEquals(1L, archdesc.getChildCount());
+        assertEquals(1, archdesc.getChildCount());
         for (DocumentaryUnit du : archdesc.getChildren()) {
             assertEquals(C01, du.getIdentifier());
         }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IpnTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IpnTest.java
@@ -88,7 +88,7 @@ public class IpnTest extends AbstractImporterTest {
                 getVertexByIdentifier(graph, "ipn vc"),
                 VirtualUnit.class);
 
-        assertEquals(2L, archdesc.getChildCount());
+        assertEquals(2, archdesc.getChildCount());
 
 
     }
@@ -163,7 +163,7 @@ public class IpnTest extends AbstractImporterTest {
             assertFalse(desc.getPropertyKeys().contains("unitDates"));
         }
         //test hierarchy
-        assertEquals(2L, archdesc.getChildCount());
+        assertEquals(2, archdesc.getChildCount());
 
         //test level-of-desc
         for (DocumentaryUnitDescription d : c1_1.getDocumentDescriptions()) {
@@ -246,7 +246,7 @@ public class IpnTest extends AbstractImporterTest {
             assertEquals("Areszt Śledczy Sądowy w Poznaniu [Untersuchungshaftanstalt Posen]", desc.getName());
         }
         //test hierarchy
-        assertEquals(2L, archdesc.getChildCount());
+        assertEquals(2, archdesc.getChildCount());
 
         //test level-of-desc
         for (DocumentaryUnitDescription d : c1_1.getDocumentDescriptions()) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
@@ -123,7 +123,7 @@ public class ItsTest extends AbstractImporterTest {
 
         assertEquals("nl-r1-de_its_ous_1_1_7", unit.getId());
 
-        assertEquals(1L, unit.getChildCount());
+        assertEquals(1, unit.getChildCount());
 
         for (Description d : unit.getDocumentDescriptions()) {
             Iterable<DatePeriod> datePeriods = d.as(DocumentaryUnitDescription.class).getDatePeriods();

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
@@ -149,7 +149,7 @@ public class NiodEadXsdTest extends AbstractImporterTest {
             assertEquals("Manuscripten, lezingen en onderzoeksmateriaal", desc.getName());
         }
         //test hierarchy
-        assertEquals(1L, archdesc.getChildCount());
+        assertEquals(1, archdesc.getChildCount());
         for (DocumentaryUnit d : archdesc.getChildren()) {
             assertEquals(C01, d.getIdentifier());
         }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
@@ -141,7 +141,7 @@ public class StadsarchiefAdamTest extends AbstractImporterTest {
             assertEquals("Documentaire foto's door Bart de Kok", desc.getName());
         }
         //test hierarchy
-        assertEquals(1L, archdesc.getChildCount());
+        assertEquals(1, archdesc.getChildCount());
         for (DocumentaryUnit d : archdesc.getChildren()) {
             assertEquals(C01, d.getIdentifier());
         }

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/AdminResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/AdminResourceClientTest.java
@@ -107,13 +107,13 @@ public class AdminResourceClientTest extends AbstractResourceClientTest {
         Bundle bundle2 = response.getEntity(Bundle.class);
         String ident2 = (String) bundle2.getData().get(
                 Ontology.IDENTIFIER_KEY);
-        assertEquals(parseUserId(ident) + 1L, parseUserId(ident2));
+        assertEquals(parseUserId(ident) + 1, parseUserId(ident2));
         assertTrue(ident.startsWith(AdminResource.DEFAULT_USER_ID_PREFIX));
     }
 
     // Helpers
-    private long parseUserId(String ident) {
-        return Long.parseLong(ident.replace(
+    private int parseUserId(String ident) {
+        return Integer.parseInt(ident.replace(
                 AdminResource.DEFAULT_USER_ID_PREFIX, ""));
     }
 }


### PR DESCRIPTION
Mostly because Gremlin uses longs to count things. Of course, of we ever end up with more than Integer.MAX_VALUE of something the joke's on me.