### PR TITLE
Add a utility function for remapping link targets from one item to another

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/models/Link.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Link.java
@@ -53,6 +53,9 @@ public interface Link extends Promotable, Temporal, Annotatable {
     @Adjacency(label = Ontology.LINK_HAS_TARGET)
     void addLinkTarget(Linkable entity);
 
+    @Adjacency(label = Ontology.LINK_HAS_TARGET)
+    void removeLinkTarget(Linkable entity);
+
     @Fetch(Ontology.LINK_HAS_BODY)
     @Adjacency(label = Ontology.LINK_HAS_BODY)
     Iterable<Accessible> getLinkBodies();

--- a/ehri-core/src/test/java/eu/ehri/project/models/LinkTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/LinkTest.java
@@ -24,6 +24,7 @@ import eu.ehri.project.test.AbstractFixtureTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -41,6 +42,15 @@ public class LinkTest extends AbstractFixtureTest {
         DocumentaryUnit c4 = manager.getEntity("c4", DocumentaryUnit.class);
         assertTrue(Iterables.contains(link.getLinkTargets(), c1));
         assertTrue(Iterables.contains(link.getLinkTargets(), c4));
+    }
+
+    @Test
+    public void testRemoveLinkTarget() throws Exception {
+        Link link = manager.getEntity("link1", Link.class);
+        DocumentaryUnit c1 = manager.getEntity("c1", DocumentaryUnit.class);
+        assertTrue(Iterables.contains(link.getLinkTargets(), c1));
+        link.removeLinkTarget(c1);
+        assertFalse(Iterables.contains(link.getLinkTargets(), c1));
     }
 
     @Test

--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -533,41 +533,40 @@
       - moderators
 
 --- # Links
- - id: link1
-   type: Link
-   data:
-     type: associative
-     body: Test link
-   relationships:
-     hasLinkTarget:
-      - c1
-      - c4
-     hasLinker: mike
+- id: link1
+  type: Link
+  data:
+    type: associative
+    body: Test link
+  relationships:
+    hasLinkTarget:
+     - c1
+     - c4
+    hasLinker: mike
 
- - id: link2
-   type: Link
-   data:
-     type: associative
-     body: Test access point link
-   relationships:
-     hasLinkTarget:
-      - c1
-      - a1
-     hasLinkBody: ur1
-     hasLinker: mike
+- id: link2
+  type: Link
+  data:
+    type: associative
+    body: Test access point link
+  relationships:
+    hasLinkTarget:
+     - c1
+     - a1
+    hasLinkBody: ur1
+    hasLinker: mike
 
- - id: link3
-   type: Link
-   data:
-     type: associative
-     body: Test access point link
-   relationships:
-     hasLinkTarget:
-      - c3
-      - a1
-     hasLinkBody: ur1
-     hasLinker: mike
-
+- id: link3
+  type: Link
+  data:
+    type: associative
+    body: Test access point link
+  relationships:
+    hasLinkTarget:
+     - c3
+     - a1
+    hasLinkBody: ur1
+    hasLinker: mike
 
 --- # Permission grants
 

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
@@ -85,4 +85,14 @@ public class ToolsResourceClientTest extends AbstractResourceClientTest {
         // 1 Concept description
         assertEquals("13", out);
     }
+    
+    @Test
+    public void testRelinking() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "relink-targets"));
+        String data = "from,to,label\na1,a2,Test\n";
+        ClientResponse response = resource.entity(data).post(ClientResponse.class);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertEquals("a1,a2,2\n", out);
+    }
 }


### PR DESCRIPTION
This is useful for some of the data cleanup we're doing with concepts.

Also fix indentation in the fixture file.