### PR TITLE
Make limit/stream behaviour consistent with the GraphQL API.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/api/QueryApi.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/QueryApi.java
@@ -129,15 +129,15 @@ public interface QueryApi {
      */
     class Page<T> implements Iterable<T> {
         private final Iterable<T> iterable;
-        private final int page;
-        private final int count;
+        private final int offset;
+        private final int limit;
         private final long total;
 
-        public Page(Iterable<T> iterable, int page, int count, long total) {
+        public Page(Iterable<T> iterable, int offset, int limit, long total) {
             this.iterable = iterable;
             this.total = total;
-            this.page = page;
-            this.count = count;
+            this.offset = offset;
+            this.limit = limit;
         }
 
         public Iterable<T> getIterable() {
@@ -149,11 +149,11 @@ public interface QueryApi {
         }
 
         public Integer getOffset() {
-            return page;
+            return offset;
         }
 
         public Integer getLimit() {
-            return count;
+            return limit;
         }
 
         @Override
@@ -163,7 +163,7 @@ public interface QueryApi {
 
         @Override
         public String toString() {
-            return String.format("<Page[...] %d %d (%d)", page, count, total);
+            return String.format("<Page[...] %d %d (%d)", offset, limit, total);
         }
     }
 }

--- a/ehri-ws-oaipmh/src/main/java/eu/ehri/project/oaipmh/OaiPmhState.java
+++ b/ehri-ws-oaipmh/src/main/java/eu/ehri/project/oaipmh/OaiPmhState.java
@@ -148,6 +148,10 @@ public class OaiPmhState {
         return limit;
     }
 
+    boolean hasLimit() {
+        return limit >= 0;
+    }
+
     Verb getVerb() {
         return verb;
     }

--- a/ehri-ws-oaipmh/src/main/resources/reference.conf
+++ b/ehri-ws-oaipmh/src/main/resources/reference.conf
@@ -6,4 +6,5 @@ oaipmh {
   repositoryName: "EHRI"
   adminEmail: "admin@example.com"
   # compression: "gzip"
+  numResponses: 200
 }


### PR DESCRIPTION
Both X-Limit and X-Stream can be given as headers, but the latterwill override the former (disabling paging).

Adjust code for listSets so that it uses a Page, rather than a raw stream.