### PR TITLE
Add WS find/replace function to tool resource

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -42,9 +42,12 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -323,7 +326,7 @@ public final class Bundle implements NestableData<Bundle> {
      * @return The full data map
      */
     public Map<String, Object> getData() {
-        return ImmutableMap.copyOf(Maps.filterValues(data, value -> value != null));
+        return ImmutableMap.copyOf(Maps.filterValues(data, Objects::nonNull));
     }
 
     /**
@@ -555,17 +558,49 @@ public final class Bundle implements NestableData<Bundle> {
      * @return a bundle with relations matching the given predicate function removed.
      */
     public Bundle filterRelations(BiPredicate<String, Bundle> filter) {
-        Builder builder = new Builder(type)
-                .addData(data)
-                .addMetaData(meta)
-                .setId(id);
+        final Multimap<String, Bundle> newRels = ArrayListMultimap.create();
         for (Map.Entry<String, Bundle> rel : relations.entries()) {
             if (!filter.test(rel.getKey(), rel.getValue())) {
-                builder.addRelation(rel.getKey(), rel.getValue()
+                newRels.put(rel.getKey(), rel.getValue()
                         .filterRelations(filter));
             }
         }
-        return builder.build();
+        return replaceRelations(newRels);
+    }
+
+    /**
+     * Run a function a top-level bundle
+     * and its relations.
+     *
+     * @param f A (pure) function transforming the bundle
+     * @return A new bundle
+     */
+    public Bundle map(Function<Bundle, Bundle> f) {
+        Bundle me = f.apply(this);
+        final Multimap<String, Bundle> newRels = ArrayListMultimap.create();
+        for (Map.Entry<String, Bundle> rel : me.getRelations().entries()) {
+            newRels.put(rel.getKey(), rel.getValue().map(f));
+        }
+        return me.replaceRelations(newRels);
+    }
+
+    /**
+     * Test if a predicate function passes for the data of the
+     * top-level bundle or its relations.
+     *
+     * @param f A predicate function
+     * @return If the predicate tested true
+     */
+    public boolean forAny(Predicate<Bundle> f) {
+        if (f.test(this)) {
+            return true;
+        }
+        for (Map.Entry<String, Bundle> rel : relations.entries()) {
+            if (rel.getValue().forAny(f)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -569,8 +569,8 @@ public final class Bundle implements NestableData<Bundle> {
     }
 
     /**
-     * Run a function a top-level bundle
-     * and its relations.
+     * Run a function transforming all items in the bundle, including the top level,
+     * returning a new bundle.
      *
      * @param f A (pure) function transforming the bundle
      * @return A new bundle
@@ -585,8 +585,8 @@ public final class Bundle implements NestableData<Bundle> {
     }
 
     /**
-     * Test if a predicate function passes for the data of the
-     * top-level bundle or its relations.
+     * Test if a predicate function holds true for any item in the
+     * bundle, including the top level.
      *
      * @param f A predicate function
      * @return If the predicate tested true

--- a/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
@@ -1,5 +1,6 @@
 package eu.ehri.project.tools;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.CloseableIterable;
 import com.tinkerpop.frames.FramedGraph;
@@ -34,16 +35,16 @@ public class FindReplace {
     private static final Logger logger = LoggerFactory.getLogger(FindReplace.class);
 
     private final FramedGraph<?> graph;
-    private final boolean dryrun;
+    private final boolean commit;
     private final int maxItems;
     private final GraphManager manager;
     private final ActionManager actionManager;
     private final Serializer depSerializer;
     private final BundleManager dao;
 
-    FindReplace(FramedGraph<?> graph, boolean dryrun, int maxItems) {
+    public FindReplace(FramedGraph<?> graph, boolean commit, int maxItems) {
         this.graph = graph;
-        this.dryrun = dryrun;
+        this.commit = commit;
         this.maxItems = maxItems;
         this.manager = GraphManagerFactory.getInstance(graph);
         this.actionManager = new ActionManager(graph);
@@ -51,26 +52,43 @@ public class FindReplace {
         this.dao = new BundleManager(graph);
     }
 
-    public FindReplace(FramedGraph<?> graph, int maxItems) {
-        this(graph, true, maxItems);
-    }
-
-    public FindReplace withActualRename(boolean commit) {
-        return new FindReplace(graph, !commit, maxItems);
-    }
-
+    /**
+     * Find and replace a string
+     *
+     * @param contentType the content type of the top-level item
+     * @param entityType  the entity type of the property-holding node
+     * @param property    the name of the property to search
+     * @param textToFind  the text to find
+     * @param replacement the replacement text
+     * @param actioner    the current user
+     * @param logMessage  a mandatory log message
+     * @return the number of items found, or those modified when running
+     * with commit enabled
+     */
     public List<Accessible> findAndReplace(
-            EntityClass parentType, EntityClass subType, String property,
-            String find, String replace, Actioner actioner, String logMessage) {
+            EntityClass contentType, EntityClass entityType,
+            String property, String textToFind, String replacement,
+            Actioner actioner, String logMessage) throws ValidationError {
 
-        logger.info("Find: '{}'", find);
-        logger.info("Replace: '{}'", replace);
+        Preconditions.checkNotNull(entityType, "Entity type cannot be null.");
+        Preconditions.checkNotNull(property, "Property name cannot be null.");
+        Preconditions.checkNotNull(textToFind, "Text to find cannot be null.");
+        Preconditions.checkArgument(!commit || replacement != null,
+                "Replacement text cannot be null if committing a replacement value.");
+        Preconditions.checkNotNull(logMessage, "Log message cannot be null.");
+
+        logger.info("Find:    '{}'", textToFind);
+        logger.info("Replace: '{}'", replacement);
 
         List<Accessible> todo = Lists.newArrayList();
-        ActionManager.EventContext context = actionManager
-                .newEventContext(actioner, EventTypes.modification, Optional.of(logMessage));
 
-        try (CloseableIterable<Accessible> entities = manager.getEntities(parentType, Accessible.class)) {
+        EventTypes eventType = contentType.equals(entityType)
+                ? EventTypes.modification
+                : EventTypes.modifyDependent;
+        ActionManager.EventContext context = actionManager
+                .newEventContext(actioner, eventType, Optional.of(logMessage));
+
+        try (CloseableIterable<Accessible> entities = manager.getEntities(contentType, Accessible.class)) {
             for (Accessible entity : entities) {
                 if (todo.size() >= maxItems) {
                     break;
@@ -78,19 +96,19 @@ public class FindReplace {
 
                 Bundle bundle = depSerializer.entityToBundle(entity);
                 boolean hasMatch = bundle.forAny(d ->
-                        d.getType().equals(subType) && find(find, d.getDataValue(property)));
+                        d.getType().equals(entityType) && find(textToFind, d.getDataValue(property)));
 
                 if (hasMatch) {
                     todo.add(entity);
                     logger.info("Found in {}", entity.getId());
 
-                    if (!dryrun) {
+                    if (commit) {
                         context.createVersion(entity);
                         context.addSubjects(entity);
 
                         Bundle newBundle = bundle.map(d -> {
-                            if (d.getType().equals(subType)) {
-                                Object newValue = replace(find, replace, d.getDataValue(property));
+                            if (d.getType().equals(entityType)) {
+                                Object newValue = replace(textToFind, replacement, d.getDataValue(property));
                                 return d.withDataValue(property, newValue);
                             }
                             return d;
@@ -99,11 +117,11 @@ public class FindReplace {
                     }
                 }
             }
-        } catch (SerializationError | ItemNotFound | ValidationError e) {
+        } catch (SerializationError | ItemNotFound e) {
             throw new RuntimeException(e);
         }
 
-        if (!dryrun && !context.getSubjects().isEmpty()) {
+        if (commit && !context.getSubjects().isEmpty()) {
             context.commit();
         }
 

--- a/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
@@ -1,0 +1,126 @@
+package eu.ehri.project.tools;
+
+import com.google.common.collect.Lists;
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.frames.FramedGraph;
+import eu.ehri.project.core.GraphManager;
+import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.definitions.EventTypes;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Actioner;
+import eu.ehri.project.models.base.Described;
+import eu.ehri.project.models.base.Description;
+import eu.ehri.project.models.base.Entity;
+import eu.ehri.project.persistence.ActionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.security.krb5.internal.crypto.Des;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Find and replace text in item properties.
+ * <p>
+ * Unlike a Cypher query, this class takes care of managing
+ * the audit log to record changes, and also tries to prevent
+ * accidental misuse.
+ */
+public class FindReplace {
+
+    private static final Logger logger = LoggerFactory.getLogger(FindReplace.class);
+
+    private final FramedGraph<?> graph;
+    private final boolean dryrun;
+    private final int maxItems;
+    private final GraphManager manager;
+    private final ActionManager actionManager;
+
+    public FindReplace(FramedGraph<?> graph, boolean dryrun, int maxItems) {
+        this.graph = graph;
+        this.dryrun = dryrun;
+        this.maxItems = maxItems;
+        this.manager = GraphManagerFactory.getInstance(graph);
+        this.actionManager = new ActionManager(graph);
+    }
+
+    public FindReplace(FramedGraph<?> graph, int maxItems) {
+        this(graph, true, maxItems);
+    }
+
+    public FindReplace withActualRename(boolean commit) {
+        return new FindReplace(graph, !commit, maxItems);
+    }
+
+    public List<Described> findAndReplaceInDescription(
+            EntityClass entityClass, String property,
+            String find, String replace, Actioner actioner, String logMessage) {
+
+        logger.info("Find: '{}'", find);
+        logger.info("Replace: '{}'", replace);
+
+        List<Described> todo = Lists.newArrayList();
+        ActionManager.EventContext context = actionManager
+                .newEventContext(actioner, EventTypes.modification, Optional.of(logMessage));
+
+        try (CloseableIterable<Described> entities = manager.getEntities(entityClass, Described.class)) {
+            for (Described entity : entities) {
+                if (todo.size() >= maxItems) {
+                    break;
+                }
+
+                for (Description description : entity.getDescriptions()) {
+                    Object value = description.getProperty(property);
+                    if (find(find, value)) {
+                        todo.add(entity);
+                        logger.info("Found in {}: {}", entity.getId(), description.getLanguageOfDescription());
+
+                        if (!dryrun) {
+                            context.createVersion(entity);
+                            context.addSubjects(entity);
+                            description.asVertex().setProperty(property, replace(find, replace, value));
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!dryrun && !context.getSubjects().isEmpty()) {
+            context.commit();
+        }
+
+        return todo;
+    }
+
+    private boolean find(String needle, Object data) {
+        if (data != null) {
+            if (data instanceof List) {
+                for (Object v : ((List) data)) {
+                    if (find(needle, v)) {
+                        return true;
+                    }
+                }
+                return false;
+            } else if (data instanceof String) {
+                return ((String) data).contains(needle);
+            }
+        }
+        return false;
+    }
+
+    private Object replace(String original, String replacement, Object data) {
+        if (data != null) {
+            if (data instanceof List) {
+                List<Object> newList = Lists.newArrayListWithExpectedSize(((List) data).size());
+                for (Object v : ((List) data)) {
+                    newList.add(replace(original, replacement, v));
+                }
+                return newList;
+            } else if (data instanceof String) {
+                return ((String) data).replace(original, replacement);
+            }
+        }
+        return data;
+    }
+}

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -381,4 +381,24 @@ public class BundleTest {
         assertNotNull(desc.getId());
         assertEquals("test-foobar.en", desc.getId());
     }
+
+    @Test
+    public void testMapData() throws Exception {
+        Bundle n = bundle.map(d -> {
+           Map<String,Object> nd = Maps.newHashMap();
+           for (Map.Entry<String,Object> e : d.getData().entrySet()) {
+               nd.put(e.getKey() + "!", e.getValue());
+           }
+           return d.withData(nd);
+        });
+        assertEquals("foobar", DataUtils.get(n, "identifier!"));
+        assertEquals("Foobar", DataUtils.get(n, "describes[0]/name!"));
+    }
+
+    @Test
+    public void testForAnyData() throws Exception {
+        assertTrue(bundle.forAny(d -> d.getDataValue(Ontology.LANGUAGE) != null));
+        assertTrue(bundle.forAny(d -> "foobar".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))));
+        assertFalse(bundle.forAny(d -> "test".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))));
+    }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
@@ -22,8 +22,10 @@ public class FindReplaceTest extends AbstractFixtureTest {
     public void testFindAndReplace() throws Exception {
         FindReplace findReplace = new FindReplace(graph, false, 100);
         List<VertexProxy> before = getGraphState(graph);
-        List<Accessible> done = findReplace.findAndReplace(EntityClass.REPOSITORY,
-                "name", "Description", "Test", validUser, "This is a test");
+        List<Accessible> done = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
+                "name", "Description",
+                "Test", validUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
         assertEquals(10, diff.added.size());
@@ -46,8 +48,10 @@ public class FindReplaceTest extends AbstractFixtureTest {
     public void testFindAndReplaceMaxItems() throws Exception {
         FindReplace findReplace = new FindReplace(graph, false, 2);
         List<VertexProxy> before = getGraphState(graph);
-        List<Accessible> done = findReplace.findAndReplace(EntityClass.REPOSITORY,
-                "name", "Description", "Test", validUser, "This is a test");
+        List<Accessible> done = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
+                "name", "Description",
+                "Test", validUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
         assertEquals(6, diff.added.size());
@@ -59,12 +63,24 @@ public class FindReplaceTest extends AbstractFixtureTest {
     public void testFindAndReplaceDryRun() throws Exception {
         FindReplace findReplace = new FindReplace(graph, true, 100);
         List<VertexProxy> before = getGraphState(graph);
-        List<Accessible> todo = findReplace.findAndReplace(EntityClass.REPOSITORY,
-                "name", "Description", "Test", validUser, "This is a test");
+        List<Accessible> todo = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
+                "name", "Description",
+                "Test", validUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
-        assertEquals(00, diff.added.size());
+        assertEquals(0, diff.added.size());
         assertEquals(0, diff.removed.size());
         assertEquals(4, todo.size());
+    }
+
+    @Test
+    public void testFindAndReplaceNoneFound() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, true, 100);
+        List<Accessible> todo = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.ADDRESS,
+                "name", "Description",
+                "Test", validUser, "This is a test");
+        assertEquals(0, todo.size());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
@@ -22,7 +22,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
     public void testFindAndReplace() throws Exception {
         FindReplace findReplace = new FindReplace(graph, false, 100);
         List<VertexProxy> before = getGraphState(graph);
-        List<Described> done = findReplace.findAndReplaceInDescription(EntityClass.REPOSITORY,
+        List<Accessible> done = findReplace.findAndReplace(EntityClass.REPOSITORY,
                 "name", "Description", "Test", validUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
@@ -31,7 +31,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
 
         List<String> names = done.stream()
                 .flatMap(p -> StreamSupport
-                        .stream(p.getDescriptions().spliterator(), false)
+                        .stream(p.as(Described.class).getDescriptions().spliterator(), false)
                         .map(d -> d.<String>getProperty(Ontology.NAME_KEY)))
                 .sorted()
                 .collect(Collectors.toList());
@@ -46,7 +46,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
     public void testFindAndReplaceMaxItems() throws Exception {
         FindReplace findReplace = new FindReplace(graph, false, 2);
         List<VertexProxy> before = getGraphState(graph);
-        List<Described> done = findReplace.findAndReplaceInDescription(EntityClass.REPOSITORY,
+        List<Accessible> done = findReplace.findAndReplace(EntityClass.REPOSITORY,
                 "name", "Description", "Test", validUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
@@ -59,7 +59,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
     public void testFindAndReplaceDryRun() throws Exception {
         FindReplace findReplace = new FindReplace(graph, true, 100);
         List<VertexProxy> before = getGraphState(graph);
-        List<Described> todo = findReplace.findAndReplaceInDescription(EntityClass.REPOSITORY,
+        List<Accessible> todo = findReplace.findAndReplace(EntityClass.REPOSITORY,
                 "name", "Description", "Test", validUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);

--- a/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
@@ -1,0 +1,70 @@
+package eu.ehri.project.tools;
+
+import com.google.common.collect.Lists;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Described;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class FindReplaceTest extends AbstractFixtureTest {
+
+    @Test
+    public void testFindAndReplace() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, false, 100);
+        List<VertexProxy> before = getGraphState(graph);
+        List<Described> done = findReplace.findAndReplaceInDescription(EntityClass.REPOSITORY,
+                "name", "Description", "Test", validUser, "This is a test");
+        List<VertexProxy> after = getGraphState(graph);
+        GraphDiff diff = diffGraph(before, after);
+        assertEquals(10, diff.added.size());
+        assertEquals(0, diff.removed.size());
+
+        List<String> names = done.stream()
+                .flatMap(p -> StreamSupport
+                        .stream(p.getDescriptions().spliterator(), false)
+                        .map(d -> d.<String>getProperty(Ontology.NAME_KEY)))
+                .sorted()
+                .collect(Collectors.toList());
+        assertThat(names, equalTo(Lists.newArrayList("DANS Test",
+                "KCL Test", "NIOD Test", "SOMA Test")));
+        assertThat(api(validUser)
+                .actionManager().getLatestGlobalEvent().getLogMessage(),
+                        equalTo("This is a test"));
+    }
+
+    @Test
+    public void testFindAndReplaceMaxItems() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, false, 2);
+        List<VertexProxy> before = getGraphState(graph);
+        List<Described> done = findReplace.findAndReplaceInDescription(EntityClass.REPOSITORY,
+                "name", "Description", "Test", validUser, "This is a test");
+        List<VertexProxy> after = getGraphState(graph);
+        GraphDiff diff = diffGraph(before, after);
+        assertEquals(6, diff.added.size());
+        assertEquals(0, diff.removed.size());
+        assertEquals(2, done.size());
+    }
+
+    @Test
+    public void testFindAndReplaceDryRun() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, true, 100);
+        List<VertexProxy> before = getGraphState(graph);
+        List<Described> todo = findReplace.findAndReplaceInDescription(EntityClass.REPOSITORY,
+                "name", "Description", "Test", validUser, "This is a test");
+        List<VertexProxy> after = getGraphState(graph);
+        GraphDiff diff = diffGraph(before, after);
+        assertEquals(00, diff.added.size());
+        assertEquals(0, diff.removed.size());
+        assertEquals(4, todo.size());
+    }
+}

--- a/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
@@ -20,7 +20,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
 
     @Test
     public void testFindAndReplace() throws Exception {
-        FindReplace findReplace = new FindReplace(graph, false, 100);
+        FindReplace findReplace = new FindReplace(graph, true, 100);
         List<VertexProxy> before = getGraphState(graph);
         List<Accessible> done = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
@@ -46,7 +46,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
 
     @Test
     public void testFindAndReplaceMaxItems() throws Exception {
-        FindReplace findReplace = new FindReplace(graph, false, 2);
+        FindReplace findReplace = new FindReplace(graph, true, 2);
         List<VertexProxy> before = getGraphState(graph);
         List<Accessible> done = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
@@ -61,7 +61,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
 
     @Test
     public void testFindAndReplaceDryRun() throws Exception {
-        FindReplace findReplace = new FindReplace(graph, true, 100);
+        FindReplace findReplace = new FindReplace(graph, false, 100);
         List<VertexProxy> before = getGraphState(graph);
         List<Accessible> todo = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
@@ -76,7 +76,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
 
     @Test
     public void testFindAndReplaceNoneFound() throws Exception {
-        FindReplace findReplace = new FindReplace(graph, true, 100);
+        FindReplace findReplace = new FindReplace(graph, false, 100);
         List<Accessible> todo = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.ADDRESS,
                 "name", "Description",

--- a/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -104,10 +104,11 @@ public class ToolsResource extends AbstractResource {
     /**
      * Find and replace text in descriptions for a given item type
      * and description property name.
-     *
+     * <p>
      * Changes will be logged to the audit log.
      *
-     * @param type     the type of entity
+     * @param type     the parent entity type
+     * @param subType  the specific node type
      * @param property the property name
      * @param from     the original text
      * @param to       the replacement text
@@ -122,6 +123,7 @@ public class ToolsResource extends AbstractResource {
             final @FormParam("from") String from,
             final @FormParam("to") String to,
             final @QueryParam("type") String type,
+            final @QueryParam("subtype") String subType,
             final @QueryParam("property") String property,
             final @FormParam("max") @DefaultValue("100") int maxItems,
             final @QueryParam("commit") @DefaultValue("false") boolean commit) throws IOException {
@@ -134,8 +136,9 @@ public class ToolsResource extends AbstractResource {
 
         try (final Tx tx = beginTx()) {
             FindReplace fr = new FindReplace(graph, maxItems).withActualRename(commit);
-            List<Accessible> list = fr.findAndReplace(EntityClass.withName(type), property, from, to,
-                    getCurrentUser(), getLogMessage()
+            List<Accessible> list = fr.findAndReplace(EntityClass.withName(type),
+                        EntityClass.withName(subType), property, from, to,
+                        getCurrentUser(), getLogMessage()
                             .orElseThrow(() -> new RuntimeException("A log message is required")));
 
             List<List<String>> rows = list.stream()

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
@@ -21,8 +21,12 @@ package eu.ehri.extension.test;
 
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+import eu.ehri.extension.base.AbstractResource;
 import eu.ehri.project.definitions.Entities;
 import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedMap;
 
 import static com.sun.jersey.api.client.ClientResponse.Status.OK;
 import static eu.ehri.extension.ToolsResource.ENDPOINT;
@@ -33,6 +37,28 @@ import static org.junit.Assert.assertTrue;
  * Test web service miscellaneous functions.
  */
 public class ToolsResourceClientTest extends AbstractResourceClientTest {
+    @Test
+    public void testFindReplace() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "find-replace"))
+                .queryParam("type", Entities.REPOSITORY)
+                .queryParam("subtype", Entities.REPOSITORY_DESCRIPTION)
+                .queryParam("property", "name")
+                .queryParam("commit", "true");
+        MultivaluedMap<String,String> data = new MultivaluedMapImpl();
+        data.putSingle("from", "KCL Description");
+        data.putSingle("to", "NEW VALUE");
+        ClientResponse response = resource
+                .header(AbstractResource.AUTH_HEADER_NAME,
+                        getAdminUserProfileId())
+                .header(AbstractResource.LOG_MESSAGE_HEADER_NAME,
+                        "This is a test!")
+                .post(ClientResponse.class, data);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertEquals(1, out.split("\r\n|\r|\n").length);
+        assertTrue(out.contains("r2"));
+    }
+
     @Test
     public void testRegenerateIds() throws Exception {
         WebResource resource = client.resource(ehriUri(ENDPOINT, "regenerate-ids"))


### PR DESCRIPTION
While not intended for end-user use, this allows us to change values in bulk whilst maintaining the audit log. For sneakier uses, Cypher should be used.

To prevent accidental use, a limit of 100 items at a time is enforced.