### PR TITLE
Add a find-and-replace tool which handles updating the audit log.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
@@ -1,0 +1,161 @@
+package eu.ehri.project.tools;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.frames.FramedGraph;
+import eu.ehri.project.core.GraphManager;
+import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.definitions.EventTypes;
+import eu.ehri.project.exceptions.ItemNotFound;
+import eu.ehri.project.exceptions.SerializationError;
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Actioner;
+import eu.ehri.project.persistence.ActionManager;
+import eu.ehri.project.persistence.Bundle;
+import eu.ehri.project.persistence.BundleManager;
+import eu.ehri.project.persistence.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Find and replace text in item properties.
+ * <p>
+ * Unlike a Cypher query, this class takes care of managing
+ * the audit log to record changes, and also tries to prevent
+ * accidental misuse.
+ */
+public class FindReplace {
+
+    private static final Logger logger = LoggerFactory.getLogger(FindReplace.class);
+
+    private final FramedGraph<?> graph;
+    private final boolean commit;
+    private final int maxItems;
+    private final GraphManager manager;
+    private final ActionManager actionManager;
+    private final Serializer depSerializer;
+    private final BundleManager dao;
+
+    public FindReplace(FramedGraph<?> graph, boolean commit, int maxItems) {
+        this.graph = graph;
+        this.commit = commit;
+        this.maxItems = maxItems;
+        this.manager = GraphManagerFactory.getInstance(graph);
+        this.actionManager = new ActionManager(graph);
+        this.depSerializer = new Serializer.Builder(graph).dependentOnly().build();
+        this.dao = new BundleManager(graph);
+    }
+
+    /**
+     * Find and replace a string
+     *
+     * @param contentType the content type of the top-level item
+     * @param entityType  the entity type of the property-holding node
+     * @param property    the name of the property to search
+     * @param textToFind  the text to find
+     * @param replacement the replacement text
+     * @param actioner    the current user
+     * @param logMessage  a mandatory log message
+     * @return the number of items found, or those modified when running
+     * with commit enabled
+     */
+    public List<Accessible> findAndReplace(
+            EntityClass contentType, EntityClass entityType,
+            String property, String textToFind, String replacement,
+            Actioner actioner, String logMessage) throws ValidationError {
+
+        Preconditions.checkNotNull(entityType, "Entity type cannot be null.");
+        Preconditions.checkNotNull(property, "Property name cannot be null.");
+        Preconditions.checkNotNull(textToFind, "Text to find cannot be null.");
+        Preconditions.checkArgument(!commit || replacement != null,
+                "Replacement text cannot be null if committing a replacement value.");
+        Preconditions.checkNotNull(logMessage, "Log message cannot be null.");
+
+        logger.info("Find:    '{}'", textToFind);
+        logger.info("Replace: '{}'", replacement);
+
+        List<Accessible> todo = Lists.newArrayList();
+
+        EventTypes eventType = contentType.equals(entityType)
+                ? EventTypes.modification
+                : EventTypes.modifyDependent;
+        ActionManager.EventContext context = actionManager
+                .newEventContext(actioner, eventType, Optional.of(logMessage));
+
+        try (CloseableIterable<Accessible> entities = manager.getEntities(contentType, Accessible.class)) {
+            for (Accessible entity : entities) {
+                if (todo.size() >= maxItems) {
+                    break;
+                }
+
+                Bundle bundle = depSerializer.entityToBundle(entity);
+                boolean hasMatch = bundle.forAny(d ->
+                        d.getType().equals(entityType) && find(textToFind, d.getDataValue(property)));
+
+                if (hasMatch) {
+                    todo.add(entity);
+                    logger.info("Found in {}", entity.getId());
+
+                    if (commit) {
+                        context.createVersion(entity);
+                        context.addSubjects(entity);
+
+                        Bundle newBundle = bundle.map(d -> {
+                            if (d.getType().equals(entityType)) {
+                                Object newValue = replace(textToFind, replacement, d.getDataValue(property));
+                                return d.withDataValue(property, newValue);
+                            }
+                            return d;
+                        });
+                        dao.update(newBundle, Accessible.class);
+                    }
+                }
+            }
+        } catch (SerializationError | ItemNotFound e) {
+            throw new RuntimeException(e);
+        }
+
+        if (commit && !context.getSubjects().isEmpty()) {
+            context.commit();
+        }
+
+        return todo;
+    }
+
+    private boolean find(String needle, Object data) {
+        if (data != null) {
+            if (data instanceof List) {
+                for (Object v : ((List) data)) {
+                    if (find(needle, v)) {
+                        return true;
+                    }
+                }
+                return false;
+            } else if (data instanceof String) {
+                return ((String) data).contains(needle);
+            }
+        }
+        return false;
+    }
+
+    private Object replace(String original, String replacement, Object data) {
+        if (data != null) {
+            if (data instanceof List) {
+                List<Object> newList = Lists.newArrayListWithExpectedSize(((List) data).size());
+                for (Object v : ((List) data)) {
+                    newList.add(replace(original, replacement, v));
+                }
+                return newList;
+            } else if (data instanceof String) {
+                return ((String) data).replace(original, replacement);
+            }
+        }
+        return data;
+    }
+}

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -381,4 +381,24 @@ public class BundleTest {
         assertNotNull(desc.getId());
         assertEquals("test-foobar.en", desc.getId());
     }
+
+    @Test
+    public void testMapData() throws Exception {
+        Bundle n = bundle.map(d -> {
+           Map<String,Object> nd = Maps.newHashMap();
+           for (Map.Entry<String,Object> e : d.getData().entrySet()) {
+               nd.put(e.getKey() + "!", e.getValue());
+           }
+           return d.withData(nd);
+        });
+        assertEquals("foobar", DataUtils.get(n, "identifier!"));
+        assertEquals("Foobar", DataUtils.get(n, "describes[0]/name!"));
+    }
+
+    @Test
+    public void testForAnyData() throws Exception {
+        assertTrue(bundle.forAny(d -> d.getDataValue(Ontology.LANGUAGE) != null));
+        assertTrue(bundle.forAny(d -> "foobar".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))));
+        assertFalse(bundle.forAny(d -> "test".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))));
+    }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
@@ -1,0 +1,86 @@
+package eu.ehri.project.tools;
+
+import com.google.common.collect.Lists;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Described;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class FindReplaceTest extends AbstractFixtureTest {
+
+    @Test
+    public void testFindAndReplace() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, true, 100);
+        List<VertexProxy> before = getGraphState(graph);
+        List<Accessible> done = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
+                "name", "Description",
+                "Test", validUser, "This is a test");
+        List<VertexProxy> after = getGraphState(graph);
+        GraphDiff diff = diffGraph(before, after);
+        assertEquals(10, diff.added.size());
+        assertEquals(0, diff.removed.size());
+
+        List<String> names = done.stream()
+                .flatMap(p -> StreamSupport
+                        .stream(p.as(Described.class).getDescriptions().spliterator(), false)
+                        .map(d -> d.<String>getProperty(Ontology.NAME_KEY)))
+                .sorted()
+                .collect(Collectors.toList());
+        assertThat(names, equalTo(Lists.newArrayList("DANS Test",
+                "KCL Test", "NIOD Test", "SOMA Test")));
+        assertThat(api(validUser)
+                .actionManager().getLatestGlobalEvent().getLogMessage(),
+                        equalTo("This is a test"));
+    }
+
+    @Test
+    public void testFindAndReplaceMaxItems() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, true, 2);
+        List<VertexProxy> before = getGraphState(graph);
+        List<Accessible> done = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
+                "name", "Description",
+                "Test", validUser, "This is a test");
+        List<VertexProxy> after = getGraphState(graph);
+        GraphDiff diff = diffGraph(before, after);
+        assertEquals(6, diff.added.size());
+        assertEquals(0, diff.removed.size());
+        assertEquals(2, done.size());
+    }
+
+    @Test
+    public void testFindAndReplaceDryRun() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, false, 100);
+        List<VertexProxy> before = getGraphState(graph);
+        List<Accessible> todo = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
+                "name", "Description",
+                "Test", validUser, "This is a test");
+        List<VertexProxy> after = getGraphState(graph);
+        GraphDiff diff = diffGraph(before, after);
+        assertEquals(0, diff.added.size());
+        assertEquals(0, diff.removed.size());
+        assertEquals(4, todo.size());
+    }
+
+    @Test
+    public void testFindAndReplaceNoneFound() throws Exception {
+        FindReplace findReplace = new FindReplace(graph, false, 100);
+        List<Accessible> todo = findReplace.findAndReplace(
+                EntityClass.REPOSITORY, EntityClass.ADDRESS,
+                "name", "Description",
+                "Test", validUser, "This is a test");
+        assertEquals(0, todo.size());
+    }
+}

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
@@ -21,8 +21,12 @@ package eu.ehri.extension.test;
 
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+import eu.ehri.extension.base.AbstractResource;
 import eu.ehri.project.definitions.Entities;
 import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedMap;
 
 import static com.sun.jersey.api.client.ClientResponse.Status.OK;
 import static eu.ehri.extension.ToolsResource.ENDPOINT;
@@ -33,6 +37,28 @@ import static org.junit.Assert.assertTrue;
  * Test web service miscellaneous functions.
  */
 public class ToolsResourceClientTest extends AbstractResourceClientTest {
+    @Test
+    public void testFindReplace() throws Exception {
+        WebResource resource = client.resource(ehriUri(ENDPOINT, "find-replace"))
+                .queryParam("type", Entities.REPOSITORY)
+                .queryParam("subtype", Entities.REPOSITORY_DESCRIPTION)
+                .queryParam("property", "name")
+                .queryParam("commit", "true");
+        MultivaluedMap<String,String> data = new MultivaluedMapImpl();
+        data.putSingle("from", "KCL Description");
+        data.putSingle("to", "NEW VALUE");
+        ClientResponse response = resource
+                .header(AbstractResource.AUTH_HEADER_NAME,
+                        getAdminUserProfileId())
+                .header(AbstractResource.LOG_MESSAGE_HEADER_NAME,
+                        "This is a test!")
+                .post(ClientResponse.class, data);
+        String out = response.getEntity(String.class);
+        assertStatus(OK, response);
+        assertEquals(1, out.split("\r\n|\r|\n").length);
+        assertTrue(out.contains("r2"));
+    }
+
     @Test
     public void testRegenerateIds() throws Exception {
         WebResource resource = client.resource(ehriUri(ENDPOINT, "regenerate-ids"))


### PR DESCRIPTION
This is a less blunt alternative to going behind-the-scenes of the DB and doing find/replace with Cypher. It also has some ways to prevent accidental mis-use, such as only doing a certain number of items at a time.