### PR TITLE
Add tentative support for SKOS-XL labels.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/Concept.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/Concept.java
@@ -78,9 +78,15 @@ public interface Concept extends Described, AuthoritativeItem, ItemHolder {
     void addNarrowerConcept(Concept concept);
 
     @JavaHandler
+    void addBroaderConcept(Concept concept);
+
+    @JavaHandler
     void removeNarrowerConcept(Concept concept);
-    
-    // Related concepts, should be like a symmetric associative link... 
+
+    @JavaHandler
+    void removeBroaderConcept(Concept concept);
+
+    // Related concepts, should be like a symmetric associative link...
     @Adjacency(label = Ontology.CONCEPT_HAS_RELATED)
     Iterable<Concept> getRelatedConcepts();
 
@@ -119,8 +125,22 @@ public interface Concept extends Described, AuthoritativeItem, ItemHolder {
         }
 
         @Override
+        public void addBroaderConcept(Concept concept) {
+            if (!concept.asVertex().equals(it())) {
+                JavaHandlerUtils.addUniqueRelationship(concept.asVertex(),
+                        it(), Ontology.CONCEPT_HAS_NARROWER);
+            }
+        }
+
+        @Override
         public void removeNarrowerConcept(Concept concept) {
             JavaHandlerUtils.removeAllRelationships(it(), concept.asVertex(),
+                    Ontology.CONCEPT_HAS_NARROWER);
+        }
+
+        @Override
+        public void removeBroaderConcept(Concept concept) {
+            JavaHandlerUtils.removeAllRelationships(concept.asVertex(), it(),
                     Ontology.CONCEPT_HAS_NARROWER);
         }
     }

--- a/ehri-core/src/main/java/eu/ehri/project/models/utils/JavaHandlerUtils.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/utils/JavaHandlerUtils.java
@@ -37,7 +37,7 @@ public final class JavaHandlerUtils {
 
     public static final Logger logger = LoggerFactory.getLogger(JavaHandlerUtils.class);
 
-    public static final int LOOP_MAX = 20;
+    private static final int LOOP_MAX = 20;
 
     /**
      * Pipe function that quits after a certain number of loops.
@@ -45,7 +45,7 @@ public final class JavaHandlerUtils {
      * @param maxLoops The number of loops to run
      * @return A pipe function
      */
-    public static <S> PipeFunction<LoopPipe.LoopBundle<S>, Boolean> maxLoopFuncFactory(final int maxLoops) {
+    private static <S> PipeFunction<LoopPipe.LoopBundle<S>, Boolean> maxLoopFuncFactory(final int maxLoops) {
         return vertexLoopBundle -> vertexLoopBundle.getLoops() < maxLoops;
     }
 

--- a/ehri-core/src/test/java/eu/ehri/project/models/cvoc/ConceptTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/cvoc/ConceptTest.java
@@ -19,52 +19,65 @@
 
 package eu.ehri.project.models.cvoc;
 
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
-public class ConceptTest {
-    @Test
-    public void testGetVocabulary() throws Exception {
 
+public class ConceptTest extends AbstractFixtureTest {
+
+    private Vocabulary v;
+    private Concept cv1;
+    private Concept cv2;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        v = manager.getEntity("cvoc1", Vocabulary.class);
+        cv1 = manager.getEntity("cvocc1", Concept.class);
+        cv2 = manager.getEntity("cvocc2", Concept.class);
     }
 
     @Test
-    public void testSetVocabulary() throws Exception {
-
+    public void testGetVocabulary() throws Exception {
+        assertEquals(v, cv1.getVocabulary());
     }
 
     @Test
     public void testGetBroaderConcepts() throws Exception {
-
+        assertEquals(cv1, cv2.getBroaderConcepts().iterator().next());
     }
 
     @Test
     public void testGetNarrowerConcepts() throws Exception {
-
-    }
-
-    @Test
-    public void testAddNarrowerConcept() throws Exception {
-
+        assertEquals(cv2, cv1.getNarrowerConcepts().iterator().next());
     }
 
     @Test
     public void testRemoveNarrowerConcept() throws Exception {
-
+        cv1.removeNarrowerConcept(cv2);
+        assertFalse(cv2.getNarrowerConcepts().iterator().hasNext());
     }
 
     @Test
     public void testGetRelatedConcepts() throws Exception {
-
+        assertEquals(cv1, cv2.getRelatedConcepts().iterator().next());
+        assertEquals(cv2, cv1.getRelatedByConcepts().iterator().next());
     }
 
     @Test
-    public void testAddRelatedConcept() throws Exception {
-
+    public void testRemoveBroaderConcept() throws Exception {
+        cv2.removeBroaderConcept(cv1);
+        assertFalse(cv2.getBroaderConcepts().iterator().hasNext());
     }
 
     @Test
     public void testRemoveRelatedConcept() throws Exception {
-
+        cv2.removeRelatedConcept(cv1);
+        assertFalse(cv2.getRelatedConcepts().iterator().hasNext());
     }
 }

--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -647,6 +647,22 @@
           name: Concept 1
           languageCode: eng
           altLabel: Another Name for Concept 1
+    narrower: cvocc2
+    inAuthoritativeSet: cvoc1
+
+- id: cvocc2
+  type: CvocConcept
+  data:
+    identifier: cvocc2
+  relationships:
+    describes:
+      - id: cvocc2-desc
+        type: CvocConceptDescription
+        data:
+          name: Concept 2
+          languageCode: eng
+          altLabel: Another Name for Concept 2
+    related: cvocc1
     inAuthoritativeSet: cvoc1
 
 --- # Virtual Units

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosTest.java
@@ -40,6 +40,7 @@ public abstract class AbstractSkosTest extends AbstractFixtureTest {
     public static final String FILE4 = "cvoc/camps.rdf";
     public static final String FILE5 = "cvoc/ghettos.rdf";
     public static final String FILE6 = "cvoc/scriptcode.n3";
+    public static final String FILE7 = "cvoc/simple-xl.n3";
 
     protected Actioner actioner;
     protected ActionManager actionManager;

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
@@ -42,7 +42,7 @@ public class JenaSkosImporterTest extends AbstractSkosTest {
                 .importFile(ClassLoader.getSystemResourceAsStream(FILE1), "simple 1");
         assertEquals(1, importLog.getCreated());
     }
-    
+
     @Test
     public void testSetDefaultLang() throws Exception {
         SkosImporter importer = new JenaSkosImporter(graph, actioner, vocabulary);
@@ -66,15 +66,10 @@ public class JenaSkosImporterTest extends AbstractSkosTest {
                 .importFile(ClassLoader.getSystemResourceAsStream(FILE6), "lang test");
         assertEquals(1, importLog.getCreated());
         Accessible concept = actionManager.getLatestGlobalEvent().getFirstSubject();
-        List<Description> descriptions = Ordering.from(new Comparator<Description>() {
-            @Override
-            public int compare(Description d1, Description d2) {
-                return ComparisonChain.start()
-                        .compare(d1.getDescriptionCode(), d2.getDescriptionCode(),
-                                Ordering.natural().nullsLast())
-                        .result();
-            }
-        }).sortedCopy(concept.as(Concept.class).getDescriptions());
+        List<Description> descriptions = Ordering.from((Comparator<Description>) (d1, d2) -> ComparisonChain.start()
+                .compare(d1.getDescriptionCode(), d2.getDescriptionCode(),
+                        Ordering.natural().nullsLast())
+                .result()).sortedCopy(concept.as(Concept.class).getDescriptions());
         assertEquals(2, descriptions.size());
         assertEquals("eng", descriptions.get(0).getLanguageOfDescription());
         assertEquals("latn", descriptions.get(0).getDescriptionCode());
@@ -88,7 +83,7 @@ public class JenaSkosImporterTest extends AbstractSkosTest {
     @Test
     public void testImportFile2() throws Exception {
         SkosImporter importer = new JenaSkosImporter(graph, actioner, vocabulary)
-            .setFormat("N3");
+                .setFormat("N3");
         ImportLog importLog = importer
                 .importFile(ClassLoader.getSystemResourceAsStream(FILE2), "simple 2");
         assertEquals(1, importLog.getCreated());
@@ -127,4 +122,15 @@ public class JenaSkosImporterTest extends AbstractSkosTest {
         assertEquals(2, importLog2.getUnchanged());
     }
 
+    @Test
+    public void testImportFile7SkosXL() throws Exception {
+        SkosImporter importer = new JenaSkosImporter(graph, actioner, vocabulary)
+                .setFormat("N3");
+        ImportLog importLog = importer
+                .importFile(ClassLoader.getSystemResourceAsStream(FILE7), "simple 1");
+        assertEquals(1, importLog.getCreated());
+        ImportLog importLog2 = importer
+                .importFile(ClassLoader.getSystemResourceAsStream(FILE2), "simple 1 XL");
+        assertEquals(1, importLog2.getUnchanged());
+    }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
@@ -127,10 +127,10 @@ public class JenaSkosImporterTest extends AbstractSkosTest {
         SkosImporter importer = new JenaSkosImporter(graph, actioner, vocabulary)
                 .setFormat("N3");
         ImportLog importLog = importer
-                .importFile(ClassLoader.getSystemResourceAsStream(FILE7), "simple 1");
+                .importFile(ClassLoader.getSystemResourceAsStream(FILE7), "simple 1 XL");
         assertEquals(1, importLog.getCreated());
         ImportLog importLog2 = importer
-                .importFile(ClassLoader.getSystemResourceAsStream(FILE2), "simple 1 XL");
+                .importFile(ClassLoader.getSystemResourceAsStream(FILE2), "simple 1");
         assertEquals(1, importLog2.getUnchanged());
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
@@ -45,7 +45,7 @@ public class Wp2KeywordsTest extends AbstractImporterTest {
         Vocabulary vocabulary = manager.getEntity("cvoc1", Vocabulary.class);
 
         int count = getNodeCount(graph);
-        int voccount = toList(vocabulary.getConcepts()).size();
+        int vocCount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
         SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
         importer.setTolerant(true);
@@ -63,7 +63,7 @@ public class Wp2KeywordsTest extends AbstractImporterTest {
 
         int afterNodeCount = count + 1556;
         assertEquals(afterNodeCount, getNodeCount(graph));
-        assertEquals(voccount + 388, toList(vocabulary.getConcepts()).size());
+        assertEquals(vocCount + 388, toList(vocabulary.getConcepts()).size());
 
         Concept concept = graph.frame(getVertexByIdentifier(graph, "KEYWORD.JMP.847"), Concept.class);
         assertEquals("KEYWORD.JMP.847", concept.getIdentifier());
@@ -74,8 +74,11 @@ public class Wp2KeywordsTest extends AbstractImporterTest {
         Concept c103 = graph.frame(getVertexByIdentifier(graph, "KEYWORD.JMP.103"), Concept.class);
         boolean found847 = false;
         for (Concept child : c103.getNarrowerConcepts()) {
-            if (child.<String>getIdentifier().equals("KEYWORD.JMP.847")) {
+            String identifier = child.<String>getIdentifier();
+            System.out.println(identifier);
+            if (identifier.equals("KEYWORD.JMP.847")) {
                 found847 = true;
+                break;
             }
         }
         assertTrue(found847);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomMultiLeveledTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.importers.ead;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.ImportLog;
@@ -85,7 +86,7 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
             assertEquals("Zbirka gradiva za povijest Židova (Collection of material concerning the history of Jews)", d.getName());
 
         assertEquals(2, unit.getChildCount());
-        List<DocumentaryUnit> children = Lists.newArrayList(unit.getChildren());
+        List<DocumentaryUnit> children = Ordering.usingToString().sortedCopy(unit.getChildren());
         DocumentaryUnit child1 = children.get(0);
         DocumentaryUnit child2 = children.get(1);
 
@@ -95,8 +96,8 @@ public class IcaAtomMultiLeveledTest extends AbstractImporterTest {
         assertEquals(unit, child2.getPermissionScope());
 
         // Check child IDs
-        assertEquals(targetUnitId + "-hr_hda_145", child1.getId());
-        assertEquals(targetUnitId + "-hr_hda_223", child2.getId());
+        assertEquals(targetUnitId + "-hr_hda_223", child1.getId());
+        assertEquals(targetUnitId + "-hr_hda_145", child2.getId());
 
         List<SystemEvent> actions = toList(unit.getHistory());
         // Check we've only got one action

--- a/ehri-io/src/test/resources/cvoc/simple-xl.n3
+++ b/ehri-io/src/test/resources/cvoc/simple-xl.n3
@@ -1,0 +1,46 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xl: <http://www.w3.org/2008/05/skos-xl#> .
+
+<http://www.my.com/#label1> a xl:Label ;
+    xl:literalForm "canals" .
+
+<http://www.my.com/#label2> a xl:Label ;
+    xl:literalForm "canal bends" .
+
+<http://www.my.com/#label3> a xl:Label ;
+    xl:literalForm "canalized streams" .
+
+<http://www.my.com/#label4> a xl:Label ;
+    xl:literalForm "ditch mouths" .
+
+<http://www.my.com/#label5> a xl:Label ;
+    xl:literalForm "ditches" .
+
+<http://www.my.com/#label6> a xl:Label ;
+    xl:literalForm "drainage canals" .
+
+<http://www.my.com/#label7> a xl:Label ;
+    xl:literalForm "drainage ditches" .
+
+<http://www.my.com/#canals> a skos:Concept ;
+    xl:prefLabel <http://www.my.com/#label1> ;
+    xl:altLabel <http://www.my.com/#label2> ,
+                <http://www.my.com/#label3> ,
+                <http://www.my.com/#label4> ,
+                <http://www.my.com/#label5> ,
+                <http://www.my.com/#label6> ,
+                <http://www.my.com/#label7> ;
+    skos:broader <http://www.my.com/#hydrographic%20structures> ;
+    skos:definition """A feature type category for places 
+        such as the Erie Canal""";
+    skos:related <http://www.my.com/#channels>,
+        <http://www.my.com/#locks>,
+        <http://www.my.com/#transportation%20features>,
+        <http://www.my.com/#tunnels> ;
+    skos:scopeNote """Manmade waterway used by watercraft
+        or for drainage, irrigation, mining, or water 
+        power""".

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -135,7 +135,7 @@ public class ImportResource extends AbstractResource {
 //    @Consumes({"application/rdf+xml","text/turtle","application/n-triples","application/trig","application/n-quads","application/ld+json"})
     @Produces(MediaType.APPLICATION_JSON)
     @Path("skos")
-    public Response importSkos(
+    public ImportLog importSkos(
             @QueryParam(SCOPE_PARAM) String scopeId,
             @DefaultValue("false") @QueryParam(TOLERANT_PARAM) Boolean tolerant,
             @QueryParam(BASE_URI_PARAM) String baseURI,
@@ -159,7 +159,7 @@ public class ImportResource extends AbstractResource {
                     .importFile(stream, getLogMessage(logMessage).orElse(null));
             logger.debug("Committing SKOS import transaction...");
             tx.success();
-            return Response.ok(jsonMapper.writeValueAsBytes(log.getData())).build();
+            return log;
         } catch (InputParseError e) {
             throw new DeserializationError("Unable to parse input: " + e.getMessage());
         } catch (NoReaderForLangException e) {

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
@@ -111,8 +111,8 @@ public class ToolsResourceClientTest extends AbstractResourceClientTest {
         // 2 Historical agent descriptions
         // 4 Repository descriptions
         // 6 Doc Unit descriptions (total 7, 1 is okay in fixtures)
-        // 1 Concept description
-        assertEquals("13", out);
+        // 2 Concept descriptions
+        assertEquals("14", out);
     }
     
     @Test


### PR DESCRIPTION
This is a bit of a hack: adds RDFS subPropertyOf relations for `skosxl:{pref,alt,hidden}Label` to `skos:{pref,alt,hidden}Label` and looks up the values depending on whether the object is a literal or not.