### PR TITLE
At the expense of more horrid code, make SKOS import more robust.

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/ImportLog.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ImportLog.java
@@ -173,9 +173,13 @@ public class ImportLog {
     }
 
     public void printReport(PrintStream out) {
-        out.println(
-                String.format(
-                        "Created: %d, Updated: %d, Unchanged: %d, Errors: %d",
-                        created, updated, unchanged, errors.size()));
+        out.println(toString());
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Created: %d, Updated: %d, Unchanged: %d, Errors: %d",
+                created, updated, unchanged, errors.size());
     }
 }

--- a/ehri-io/src/test/resources/cvoc/simple-xl.n3
+++ b/ehri-io/src/test/resources/cvoc/simple-xl.n3
@@ -26,6 +26,9 @@
 <http://www.my.com/#label7> a xl:Label ;
     xl:literalForm "drainage ditches" .
 
+<http://www.my.com/#def1> rdf:value """A feature type category for places
+        such as the Erie Canal""" .
+
 <http://www.my.com/#canals> a skos:Concept ;
     xl:prefLabel <http://www.my.com/#label1> ;
     xl:altLabel <http://www.my.com/#label2> ,
@@ -33,10 +36,12 @@
                 <http://www.my.com/#label4> ,
                 <http://www.my.com/#label5> ,
                 <http://www.my.com/#label6> ,
-                <http://www.my.com/#label7> ;
+                <http://www.my.com/#label7> ,
+                <http://www.my.com/#label8-missing-value-test> ;
     skos:broader <http://www.my.com/#hydrographic%20structures> ;
-    skos:definition """A feature type category for places 
-        such as the Erie Canal""";
+    skos:definition <http://www.my.com/#def1> ;
+    skos:definition <http://www.my.com/#def2-missing-value-test> ;
+
     skos:related <http://www.my.com/#channels>,
         <http://www.my.com/#locks>,
         <http://www.my.com/#transportation%20features>,

--- a/ehri-io/src/test/resources/cvoc/simple.n3
+++ b/ehri-io/src/test/resources/cvoc/simple.n3
@@ -12,7 +12,7 @@
         "drainage canals",
         "drainage ditches" ;
     skos:broader <http://www.my.com/#hydrographic%20structures> ;
-    skos:definition """A feature type category for places 
+    skos:definition """A feature type category for places
         such as the Erie Canal""";
     skos:prefLabel "canals" ;
     skos:related <http://www.my.com/#channels>,


### PR DESCRIPTION
In cases where values are reified, e.g. labels or definition nodes, the values can possibly be missing. Handle this case without crashing with a NPE.