### PR TITLE
Make renegerating specific IDs more flexible by accepting JSON/CSV.

### DIFF
--- a/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -229,15 +229,22 @@ public class ToolsResource extends AbstractResource {
      */
     @POST
     @Produces({MediaType.APPLICATION_JSON, "text/csv"})
+    @Consumes({MediaType.APPLICATION_JSON, "text/csv"})
     @Path("regenerate-ids")
     public Table regenerateIds(
             @QueryParam("id") List<String> ids,
             @QueryParam("collisions") @DefaultValue("false") boolean collisions,
             @QueryParam("tolerant") @DefaultValue("false") boolean tolerant,
-            @QueryParam("commit") @DefaultValue("false") boolean commit)
+            @QueryParam("commit") @DefaultValue("false") boolean commit,
+            Table data)
             throws ItemNotFound, IOException, IdRegenerator.IdCollisionError {
         try (final Tx tx = beginTx()) {
-            List<Accessible> items = ids.stream().map(id -> {
+            List<String> allIds = Lists.newArrayList(ids);
+            data.data().stream()
+                .filter(row -> row.size() == 1)
+                .forEach(row -> allIds.add(row.get(0)));
+
+            List<Accessible> items = allIds.stream().map(id -> {
                 try {
                     return manager.getEntity(id, Accessible.class);
                 } catch (ItemNotFound e) {

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 
 import javax.ws.rs.core.MultivaluedMap;
 
+import java.util.Collections;
+
 import static com.sun.jersey.api.client.ClientResponse.Status.OK;
 import static eu.ehri.extension.ToolsResource.ENDPOINT;
 import static org.junit.Assert.assertEquals;
@@ -68,9 +70,9 @@ public class ToolsResourceClientTest extends AbstractResourceClientTest {
     public void testRegenerateIds() throws Exception {
         WebResource resource = client.resource(ehriUri(ENDPOINT, "regenerate-ids"))
                 .queryParam("id", "c1")
-                .queryParam("id", "c4")
                 .queryParam("commit", "true");
-        ClientResponse response = resource.post(ClientResponse.class);
+        Table data = Table.of(Collections.singletonList(Collections.singletonList("c4")));
+        ClientResponse response = resource.post(ClientResponse.class, data);
         Table out = response.getEntity(Table.class);
         assertStatus(OK, response);
         assertEquals(2, out.data().size());


### PR DESCRIPTION
This prevents 414 (url too long) errors with lots of items.