### PR TITLE
Move non-language-specific properties from concept description to item.

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
@@ -307,6 +307,24 @@ public final class JenaSkosImporter implements SkosImporter {
                 .addDataValue(Ontology.IDENTIFIER_KEY, getId(URI.create(item.getURI())))
                 .addDataValue(Ontology.URI_KEY, item.getURI());
 
+        for (Map.Entry<String, URI> prop : SkosRDFVocabulary.GENERAL_PROPS.entrySet()) {
+            for (RDFNode target : getObjectWithPredicate(item, prop.getValue())) {
+                if (target.isLiteral()) {
+                    if (prop.getKey().equals("latitude/longitude")) {
+                        String[] latLon = target.asLiteral().getString().split(",");
+                        if (latLon.length > 1) {
+                            builder.addDataValue("latitude", latLon[0]);
+                            builder.addDataValue("longitude", latLon[1]);
+                        }
+                    } else {
+                        builder.addDataMultiValue(prop.getKey(), target.asLiteral().getString());
+                    }
+                } else {
+                    builder.addDataMultiValue(prop.getKey(), target.toString());
+                }
+            }
+        }
+
         Map<AuthoritativeItem, String> linkedConcepts = Maps.newHashMap();
 
         List<Bundle> unknown = getAdditionalRelations(item, linkedConcepts);
@@ -461,25 +479,6 @@ public final class JenaSkosImporter implements SkosImporter {
             builder.addDataValue(Ontology.NAME_KEY, property.getValue())
                     .addDataValue(Ontology.LANGUAGE, langCode3Letter);
             descCode.ifPresent(code -> builder.addDataValue(Ontology.IDENTIFIER_KEY, code));
-
-            for (Map.Entry<String, URI> prop : SkosRDFVocabulary.GENERAL_PROPS.entrySet()) {
-
-                for (RDFNode target : getObjectWithPredicate(item, prop.getValue())) {
-                    if (target.isLiteral()) {
-                        if (prop.getKey().equals("latitude/longitude")) {
-                            String[] latLon = target.asLiteral().getString().split(",");
-                            if (latLon.length > 1) {
-                                builder.addDataValue("latitude", latLon[0]);
-                                builder.addDataValue("longitude", latLon[1]);
-                            }
-                        } else {
-                            builder.addDataMultiValue(prop.getKey(), target.asLiteral().getString());
-                        }
-                    } else {
-                        builder.addDataMultiValue(prop.getKey(), target.toString());
-                    }
-                }
-            }
 
             for (Map.Entry<String, List<URI>> prop : SkosRDFVocabulary.LANGUAGE_PROPS.entrySet()) {
                 List<String> values = Lists.newArrayList();

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/EventsSkosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/EventsSkosImporterTest.java
@@ -108,13 +108,8 @@ public class EventsSkosImporterTest extends AbstractImporterTest {
             assertTrue(desc.getPropertyKeys().contains("scopeNote"));
         }
         Concept teheranChildren = manager.getEntity("cvoc1-2", Concept.class);
-        for(Description desc : teheranChildren.getDescriptions()){
-//            for(String k : desc.getPropertyKeys())
-//                System.out.println(k+"-"+desc.getProperty(k));
-            assertTrue(desc.getPropertyKeys().contains(AccessPointType.person.name()));
-        }
-        
-        AuthoritativeItem ad1 = manager.getEntity("ad1", AuthoritativeItem.class);
+        assertTrue(teheranChildren.getPropertyKeys().contains(AccessPointType.person.name()));
+
         boolean found=false;
         for(Link desc : teheranChildren.getLinks()){
             found=true;

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterTest.java
@@ -73,11 +73,8 @@ public class GhettosImporterTest extends AbstractImporterTest {
         Concept ghetto0 = list.get(0);
         //  <geo:lat>52.43333333333333</geo:lat>
         //	<geo:long>20.716666666666665</geo:long>
-        Iterable<Description> ghetto0desc = ghetto0.getDescriptions();
-        for (Description d : ghetto0desc) {
-            assertEquals("52.43333333333333", d.getProperty("latitude"));
-            assertEquals("20.716666666666665", d.getProperty("longitude"));
-        }
+        assertEquals("52.43333333333333", ghetto0.getProperty("latitude"));
+        assertEquals("20.716666666666665", ghetto0.getProperty("longitude"));
 
         // and print the tree
         printConceptTree(System.out, list.get(0));

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
@@ -74,11 +74,8 @@ public class GhettosImporterV20140831Test extends AbstractImporterTest {
         Concept ghetto0 = manager.getEntity("cvoc1-0", Concept.class);
         //  <geo:lat>52.43333333333333</geo:lat>
         //	<geo:long>20.716666666666665</geo:long>
-        Iterable<Description> ghetto0desc = ghetto0.getDescriptions();
-        for (Description d : ghetto0desc) {
-            assertEquals("52.43333333333333", d.getProperty("latitude"));
-            assertEquals("20.716666666666665", d.getProperty("longitude"));
-        }
+        assertEquals("52.43333333333333", ghetto0.getProperty("latitude"));
+        assertEquals("20.716666666666665", ghetto0.getProperty("longitude"));
 
         // and print the tree
 //        printConceptTree(System.out, list.get(0));
@@ -110,10 +107,7 @@ public class GhettosImporterV20140831Test extends AbstractImporterTest {
         
         Concept ghetto0v2 = manager.getEntity("cvoc1-0", Concept.class);
         assertEquals(ghetto0, ghetto0v2);
-        
-        for(Description d : ghetto0v2.getDescriptions()){
-            assertEquals("48.6666666667", d.getProperty("latitude"));
-            assertEquals("26.5666666667", d.getProperty("longitude"));
-        }
+        assertEquals("48.6666666667", ghetto0v2.getProperty("latitude"));
+        assertEquals("26.5666666667", ghetto0v2.getProperty("longitude"));
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JenaSkosImporterTest.java
@@ -152,12 +152,11 @@ public class JenaSkosImporterTest extends AbstractSkosTest {
         Iterable<Concept> concepts = graph.getVertices(Ontology.IDENTIFIER_KEY, "125605", Concept.class);
         assertTrue(concepts.iterator().hasNext());
         Concept larestan = concepts.iterator().next();
+        List<String> seeAlso = larestan.<List<String>>getProperty("seeAlso");
+        assertEquals(3, seeAlso.size());
         // Check all the altLabels are present...
         List<String> altLabels = larestan.getDescriptions().iterator().next()
                 .<List<String>>getProperty(Skos.altLabel.toString());
         assertEquals(15, altLabels.size());
-        List<String> seeAlso = larestan.getDescriptions().iterator().next()
-                .<List<String>>getProperty("seeAlso");
-        assertEquals(3, seeAlso.size());
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2PlacesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2PlacesImporterTest.java
@@ -72,11 +72,8 @@ public class Wp2PlacesImporterTest extends AbstractImporterTest {
         Concept location = list.get(0);
         //  <geo:lat>52.43333333333333</geo:lat>
         //	<geo:long>20.716666666666665</geo:long>
-        Iterable<Description> ghetto0desc = location.getDescriptions();
-        for (Description d : ghetto0desc) {
-            assertEquals("48.9756578", d.getProperty("latitude"));
-            assertEquals("14.480255", d.getProperty("longitude"));
-        }
+        assertEquals("48.9756578", location.getProperty("latitude"));
+        assertEquals("14.480255", location.getProperty("longitude"));
 
         // and print the tree
         printConceptTree(System.out, list.get(0));


### PR DESCRIPTION
Migration script:

```
MATCH (c:CvocConcept)<-[:describes]-(cd:CvocConceptDescription)
WHERE exists(cd.longitude) OR
	exists(cd.latitude) OR 
	exists(cd.url) OR 
	exists(cd.seeAlso)
SET 
	c.longitude = cd.longitude,
	c.latitude = cd.latitude,
	c.url = cd.url,
	c.seeAlso = cd.seeAlso
REMOVE 
	cd.longitude, cd.latitude, cd.url, cd.seeAlso
RETURN COUNT(c)
```