### PR TITLE
Allow importing multiple doc units via JSON.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -741,6 +741,25 @@ public final class Bundle implements NestableData<Bundle> {
     }
 
     /**
+     * Return a bundle consisting of only dependent relations.
+     *
+     * @return a new bundle with non-dependent relations removed
+     */
+    public Bundle dependentsOnly() {
+        Map<String, Direction> dependents = ClassUtils
+                .getDependentRelations(type.getJavaClass());
+        Multimap<String, Bundle> tmp = ArrayListMultimap.create();
+        for (String relation : relations.keySet()) {
+            if (dependents.containsKey(relation)) {
+                for (Bundle bundle : relations.get(relation)) {
+                    tmp.put(relation, bundle.dependentsOnly());
+                }
+            }
+        }
+        return new Bundle(id, type, data, tmp, meta, temp);
+    }
+
+    /**
      * Generate missing IDs for the subtree.
      *
      * @param scopes A set of parent scopes.

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/BundleManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/BundleManager.java
@@ -200,13 +200,14 @@ public final class BundleManager {
     private Mutation<Vertex> updateInner(Bundle bundle) throws ItemNotFound {
         Vertex node = manager.getVertex(bundle.getId());
         try {
-            Bundle nodeBundle = serializer.vertexToBundle(node);
-            if (!nodeBundle.equals(bundle)) {
-                logger.trace("Bundles differ\nnew:\n{}\nold:\n{}", bundle.toJson(), nodeBundle.toJson());
+            Bundle currentBundle = serializer.vertexToBundle(node);
+            Bundle newBundle = bundle.dependentsOnly();
+            if (!currentBundle.equals(newBundle)) {
+                logger.trace("Bundles differ\nnew:\n{}\nold:\n{}", newBundle.toJson(), currentBundle.toJson());
                 node = manager.updateVertex(bundle.getId(), bundle.getType(),
                         bundle.getData());
                 updateDependents(node, bundle.getBundleJavaClass(), bundle.getRelations());
-                return new Mutation<>(node, MutationState.UPDATED, nodeBundle);
+                return new Mutation<>(node, MutationState.UPDATED, currentBundle);
             } else {
                 logger.debug("Not updating equivalent bundle {}", bundle.getId());
                 return new Mutation<>(node, MutationState.UNCHANGED);

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -293,6 +293,18 @@ public class BundleTest {
     }
 
     @Test
+    public void testDependentsOnly() throws Exception {
+        assertEquals(bundle, bundle.dependentsOnly());
+        Bundle withNonDeps = bundle.withRelation("someRel",
+                Bundle.Builder.withClass(EntityClass.REPOSITORY)
+                        .addDataValue("key", "value")
+                        .build());
+        assertFalse(withNonDeps.dependentsOnly().hasRelations("key"));
+        assertNotEquals(withNonDeps, bundle);
+        assertEquals(withNonDeps.dependentsOnly(), bundle);
+    }
+
+    @Test
     public void testWithMetaData() throws Exception {
         Bundle newDesc = Bundle.of(EntityClass.DOCUMENTARY_UNIT_DESCRIPTION)
                 .withDataValue(Ontology.NAME_KEY, "Foobar")

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -63,6 +63,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -72,6 +73,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
@@ -317,6 +319,7 @@ public class ImportResource extends AbstractResource {
     @POST
     @Consumes({MediaType.TEXT_PLAIN, CSV_MEDIA_TYPE,
             MediaType.APPLICATION_OCTET_STREAM})
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("csv")
     public ImportLog importCsv(
             @QueryParam(SCOPE_PARAM) String scopeId,
@@ -368,6 +371,7 @@ public class ImportResource extends AbstractResource {
      */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("batch")
     public ImportLog batchUpdate(
             @QueryParam(SCOPE_PARAM) String scopeId,
@@ -380,7 +384,7 @@ public class ImportResource extends AbstractResource {
             PermissionScope scope = scopeId != null
                     ? manager.getEntity(scopeId, PermissionScope.class)
                     : null;
-            ImportLog log = new BatchOperations(graph, scope, version, tolerant)
+            ImportLog log = new BatchOperations(graph, scope, version, tolerant, Collections.emptyList())
                     .batchUpdate(inputStream, user, getLogMessage(logMessage));
             logger.debug("Committing batch update transaction...");
             tx.success();
@@ -409,7 +413,7 @@ public class ImportResource extends AbstractResource {
             PermissionScope scope = scopeId != null
                     ? manager.getEntity(scopeId, PermissionScope.class)
                     : null;
-            new BatchOperations(graph, scope, version, false)
+            new BatchOperations(graph, scope, version, false, Collections.emptyList())
                     .batchDelete(ids, user, getLogMessage(logMessage));
             logger.debug("Committing delete transaction...");
             tx.success();


### PR DESCRIPTION
 - fix an issue with bundle updating that meant non-dependent data
   would break idempotency checks
 - add a POST /{id}/list endpoint to the repository resource for
   importing sets of doc units. Ideally this functionality would
   be generic somehow or able to be shared across multiple resources
   that have child items.