### PR TITLE
Use a thunk for streaming responses instead of the iterator itself.

### DIFF
--- a/ehri-ws/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
@@ -101,8 +101,8 @@ public class AuthoritativeSetResource extends
 
         try (final Tx tx = beginTx()) {
             AuthoritativeSet set = api().detail(id, cls);
-            Response response = streamingPage(getQuery().page(set.getAuthoritativeItems(),
-                    AuthoritativeItem.class));
+            Response response = streamingPage(() ->
+                    getQuery().page(set.getAuthoritativeItems(), AuthoritativeItem.class));
             tx.success();
             return response;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/CountryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CountryResource.java
@@ -92,7 +92,7 @@ public class CountryResource
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Country country = api().detail(id, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(country.getRepositories(), Repository.class));
             tx.success();
             return response;

--- a/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
@@ -115,7 +115,7 @@ public class CvocConceptResource
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(concept.getNarrowerConcepts(), Concept.class));
             tx.success();
             return response;
@@ -195,7 +195,7 @@ public class CvocConceptResource
             throws ItemNotFound, AccessDenied {
         try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            Response response = streamingList(concept.getBroaderConcepts());
+            Response response = streamingList(concept::getBroaderConcepts);
             tx.success();
             return response;
         }
@@ -213,7 +213,7 @@ public class CvocConceptResource
     public Response getCvocRelatedConcepts(@PathParam("id") String id) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            Response response = streamingList(concept.getRelatedConcepts());
+            Response response = streamingList(concept::getRelatedConcepts);
             tx.success();
             return response;
         }
@@ -233,7 +233,7 @@ public class CvocConceptResource
     public Response getCvocRelatedByConcepts(@PathParam("id") String id) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Concept concept = api().detail(id, cls);
-            Response response = streamingList(concept.getRelatedByConcepts());
+            Response response = streamingList(concept::getRelatedByConcepts);
             tx.success();
             return response;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
@@ -92,10 +92,12 @@ public class DocumentaryUnitResource
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             DocumentaryUnit parent = manager.getEntity(id, DocumentaryUnit.class);
-            Iterable<DocumentaryUnit> units = all
-                    ? parent.getAllChildren()
-                    : parent.getChildren();
-            Response response = streamingPage(getQuery().page(units, cls));
+            Response response = streamingPage(() -> {
+                Iterable<DocumentaryUnit> units = all
+                        ? parent.getAllChildren()
+                        : parent.getChildren();
+                return getQuery().page(units, cls);
+            });
             tx.success();
             return response;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/GenericResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/GenericResource.java
@@ -115,7 +115,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             Iterable<Vertex> byGid = Iterables.transform(gids, graph::getVertex);
             Iterable<Vertex> byId = manager.getVertices(ids);
             Iterable<Vertex> all = Iterables.concat(byGid, byId);
-            Response response = streamingVertexList(Iterables.transform(all, filter::apply));
+            Response response = streamingVertexList(() -> Iterables.transform(all, filter::apply));
             tx.success();
             return response;
         }
@@ -182,7 +182,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
         try (final Tx tx = beginTx()) {
             Accessible item = manager.getEntity(id, Accessible.class);
             Iterable<Accessor> accessors = item.getAccessors();
-            Response response = streamingList(accessors);
+            Response response = streamingList(() -> accessors);
             tx.success();
             return response;
         }
@@ -309,7 +309,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             Accessible item = api().detail(id, Accessible.class);
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            Response response = streamingListOfLists(eventsApi.aggregateForItem(item));
+            Response response = streamingListOfLists(() -> eventsApi.aggregateForItem(item));
             tx.success();
             return response;
         }
@@ -328,7 +328,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             @PathParam("id") String id) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Annotatable entity = manager.getEntity(id, Annotatable.class);
-            Response response = streamingPage(getQuery().page(
+            Response response = streamingPage(() -> getQuery().page(
                     entity.getAnnotations(),
                     Annotation.class));
             tx.success();
@@ -348,7 +348,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
     public Response links(@PathParam("id") String id) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Linkable entity = manager.getEntity(id, Linkable.class);
-            Response response = streamingPage(getQuery().page(
+            Response response = streamingPage(() -> getQuery().page(
                     entity.getLinks(),
                     Link.class));
             tx.success();
@@ -368,7 +368,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             throws PermissionDenied, ItemNotFound {
         try (final Tx tx = beginTx()) {
             PermissionGrantTarget target = manager.getEntity(id, PermissionGrantTarget.class);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(target.getPermissionGrants(),
                             PermissionGrant.class));
             tx.success();
@@ -388,7 +388,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
             throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             PermissionScope scope = manager.getEntity(id, PermissionScope.class);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(scope.getPermissionGrants(),
                             PermissionGrant.class));
             tx.success();
@@ -529,7 +529,7 @@ public class GenericResource extends AbstractAccessibleResource<Accessible> {
     public Response listVersions(@PathParam("id") String id) throws ItemNotFound, AccessDenied {
         try (final Tx tx = beginTx()) {
             Versioned item = api().detail(id, Versioned.class);
-            Response response = streamingPage(getQuery().setStream(true)
+            Response response = streamingPage(() -> getQuery().setStream(true)
                     .page(item.getAllPriorVersions(), Version.class));
             tx.success();
             return response;

--- a/ehri-ws/src/main/java/eu/ehri/extension/GroupResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/GroupResource.java
@@ -168,11 +168,12 @@ public class GroupResource
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Group group = manager.getEntity(id, EntityClass.GROUP, Group.class);
-            Iterable<Accessible> members = all
-                    ? group.getAllUserProfileMembers()
-                    : group.getMembersAsEntities();
-            Response response = streamingPage(getQuery()
-                    .page(members, Accessible.class));
+            Response response = streamingPage(() -> {
+                Iterable<Accessible> members = all
+                        ? group.getAllUserProfileMembers()
+                        : group.getMembersAsEntities();
+                return getQuery().page(members, Accessible.class);
+            });
             tx.success();
             return response;
         }
@@ -209,7 +210,7 @@ public class GroupResource
             Actioner group = manager.getEntity(userId, Actioner.class);
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            Response response = streamingListOfLists(eventsApi.aggregateActions(group));
+            Response response = streamingListOfLists(() -> eventsApi.aggregateActions(group));
             tx.success();
             return response;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/PermissionsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/PermissionsResource.java
@@ -242,7 +242,7 @@ public class PermissionsResource extends AbstractResource {
     public Response listPermissionGrants(@PathParam("userOrGroup") String id) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Accessor user = manager.getEntity(id, Accessor.class);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getPermissionGrants(), PermissionGrant.class));
             tx.success();
             return response;

--- a/ehri-ws/src/main/java/eu/ehri/extension/RepositoryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/RepositoryResource.java
@@ -101,10 +101,12 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Repository repository = api().detail(id, cls);
-            Iterable<DocumentaryUnit> units = all
-                    ? repository.getAllDocumentaryUnits()
-                    : repository.getTopLevelDocumentaryUnits();
-            Response response = streamingPage(getQuery().page(units, DocumentaryUnit.class));
+            Response response = streamingPage(() -> {
+                Iterable<DocumentaryUnit> units = all
+                        ? repository.getAllDocumentaryUnits()
+                        : repository.getTopLevelDocumentaryUnits();
+                return getQuery().page(units, DocumentaryUnit.class);
+            });
             tx.success();
             return response;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/SystemEventResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/SystemEventResource.java
@@ -112,7 +112,7 @@ public class SystemEventResource extends AbstractAccessibleResource<SystemEvent>
         try (final Tx tx = beginTx()) {
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            Response response = streamingListOfLists(eventsApi.aggregate());
+            Response response = streamingListOfLists(eventsApi::aggregate);
             tx.success();
             return response;
         }
@@ -132,7 +132,7 @@ public class SystemEventResource extends AbstractAccessibleResource<SystemEvent>
         try (final Tx tx = beginTx()) {
             SystemEvent event = api().detail(id, cls);
             // Subjects are only serialized to depth 1 for efficiency...
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                             .page(event.getSubjects(), Accessible.class),
                     getSerializer().withDepth(1).withCache());
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/extension/UserProfileResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/UserProfileResource.java
@@ -145,7 +145,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response listFollowers(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getFollowers(), UserProfile.class));
             tx.success();
             return response;
@@ -158,7 +158,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response listFollowing(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getFollowing(), UserProfile.class));
             tx.success();
             return response;
@@ -226,7 +226,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response listBlocked(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getBlocked(), UserProfile.class));
             tx.success();
             return response;
@@ -278,7 +278,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response listWatching(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getWatching(), Watchable.class));
             tx.success();
             return response;
@@ -330,7 +330,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response listAnnotations(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getAnnotations(), Annotation.class));
             tx.success();
             return response;
@@ -343,7 +343,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response pageLinks(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getLinks(), Link.class));
             tx.success();
             return response;
@@ -356,7 +356,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
     public Response pageVirtualUnits(@PathParam("id") String userId) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             UserProfile user = api().detail(userId, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(user.getVirtualUnits(), VirtualUnit.class));
             tx.success();
             return response;
@@ -383,7 +383,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             UserProfile user = manager.getEntity(userId, UserProfile.class);
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            Response response = streamingListOfLists(eventsApi.aggregateActions(user));
+            Response response = streamingListOfLists(() -> eventsApi.aggregateActions(user));
             tx.success();
             return response;
         }
@@ -410,7 +410,7 @@ public class UserProfileResource extends AbstractAccessibleResource<UserProfile>
             UserProfile asUser = manager.getEntity(userId, UserProfile.class);
             EventsApi eventsApi = getEventsApi()
                     .withAggregation(aggregation);
-            Response response = streamingListOfLists(eventsApi.aggregateAsUser(asUser));
+            Response response = streamingListOfLists(() -> eventsApi.aggregateAsUser(asUser));
             tx.success();
             return response;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/VirtualUnitResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VirtualUnitResource.java
@@ -97,10 +97,12 @@ public final class VirtualUnitResource extends
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             VirtualUnit parent = manager.getEntity(id, VirtualUnit.class);
-            Iterable<VirtualUnit> units = all
-                    ? parent.getAllChildren()
-                    : parent.getChildren();
-            Response response = streamingPage(getQuery().page(units, cls));
+            Response response = streamingPage(() -> {
+                Iterable<VirtualUnit> units = all
+                        ? parent.getAllChildren()
+                        : parent.getChildren();
+                return getQuery().page(units, cls);
+            });
             tx.success();
             return response;
         }
@@ -108,12 +110,12 @@ public final class VirtualUnitResource extends
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("{id:[^/]+}/" + INCLUDED)
+    @Path("{id:[^/]+}/includes")
     public Response listIncludedVirtualUnits(
             @PathParam("id") String id) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             VirtualUnit parent = manager.getEntity(id, VirtualUnit.class);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(parent.getIncludedUnits(), DocumentaryUnit.class));
             tx.success();
             return response;
@@ -121,7 +123,7 @@ public final class VirtualUnitResource extends
     }
 
     @POST
-    @Path("{id:[^/]+}/" + INCLUDED)
+    @Path("{id:[^/]+}/includes")
     public Response addIncludedVirtualUnits(
             @PathParam("id") String id, @QueryParam(ID_PARAM) List<String> includedIds)
             throws ItemNotFound, PermissionDenied {
@@ -136,7 +138,7 @@ public final class VirtualUnitResource extends
     }
 
     @DELETE
-    @Path("{id:[^/]+}/" + INCLUDED)
+    @Path("{id:[^/]+}/includes")
     public Response removeIncludedVirtualUnits(
             @PathParam("id") String id, @QueryParam(ID_PARAM) List<String> includedIds)
             throws ItemNotFound, PermissionDenied {
@@ -151,7 +153,7 @@ public final class VirtualUnitResource extends
     }
 
     @POST
-    @Path("{from:[^/]+}/" + INCLUDED + "/{to:[^/]+}")
+    @Path("{from:[^/]+}/includes/{to:[^/]+}")
     public void moveIncludedVirtualUnits(
             @PathParam("from") String fromId, @PathParam("to") String toId,
             @QueryParam(ID_PARAM) List<String> includedIds)

--- a/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -100,7 +100,7 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
             @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all) throws ItemNotFound {
         try (final Tx tx = beginTx()) {
             Vocabulary vocabulary = api().detail(id, cls);
-            Response response = streamingPage(getQuery()
+            Response response = streamingPage(() -> getQuery()
                     .page(vocabulary.getConcepts(), Concept.class));
             tx.success();
             return response;

--- a/ehri-ws/src/main/java/eu/ehri/extension/base/AbstractAccessibleResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/base/AbstractAccessibleResource.java
@@ -118,7 +118,7 @@ public class AbstractAccessibleResource<E extends Accessible> extends AbstractRe
      */
     public Response listItems() {
         try (final Tx tx = beginTx()) {
-            Response response = streamingPage(getQuery().page(cls));
+            Response response = streamingPage(() -> getQuery().page(cls));
             tx.success();
             return response;
         }


### PR DESCRIPTION
This means we don't create the iterator in a different transaction to the one it will (potentially) be run under, which breaks in Neo4j 3.1+.

Fixes #349.