### PR TITLE
Refactor ingest-time link resolution.

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/links/LinkResolver.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/links/LinkResolver.java
@@ -1,0 +1,143 @@
+package eu.ehri.project.importers.links;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.tinkerpop.frames.FramedGraph;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import eu.ehri.project.api.Api;
+import eu.ehri.project.api.ApiFactory;
+import eu.ehri.project.core.GraphManager;
+import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.exceptions.DeserializationError;
+import eu.ehri.project.exceptions.PermissionDenied;
+import eu.ehri.project.exceptions.SerializationError;
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.util.ImportHelpers;
+import eu.ehri.project.models.AccessPoint;
+import eu.ehri.project.models.EntityClass;
+import eu.ehri.project.models.Link;
+import eu.ehri.project.models.base.Accessor;
+import eu.ehri.project.models.base.Described;
+import eu.ehri.project.models.base.Description;
+import eu.ehri.project.models.base.Linkable;
+import eu.ehri.project.models.cvoc.AuthoritativeItem;
+import eu.ehri.project.models.cvoc.AuthoritativeSet;
+import eu.ehri.project.persistence.Bundle;
+import eu.ehri.project.persistence.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+public class LinkResolver {
+
+    private final GraphManager manager;
+    private final Api api;
+    private final Serializer mergeSerializer;
+
+    private static final Logger logger = LoggerFactory.getLogger(LinkResolver.class);
+    private static final Config config = ConfigFactory.load();
+
+    private final Bundle linkTemplate = Bundle.of(EntityClass.LINK)
+            // TODO: allow overriding link type and text here
+            .withDataValue(Ontology.LINK_HAS_DESCRIPTION, config.getString("io.import.defaultLinkText"))
+            .withDataValue(Ontology.LINK_HAS_TYPE, config.getString("io.import.defaultLinkType"));
+
+
+    private final LoadingCache<String, AuthoritativeSet> setCache = CacheBuilder.newBuilder()
+            .build(new CacheLoader<String, AuthoritativeSet>() {
+                @Override
+                public AuthoritativeSet load(String key) throws Exception {
+                    return manager.getEntity(key, AuthoritativeSet.class);
+                }
+            });
+
+    public LinkResolver(FramedGraph<?> graph, Accessor accessor) {
+        api = ApiFactory.noLogging(graph, accessor);
+        manager = GraphManagerFactory.getInstance(graph);
+        mergeSerializer = new Serializer.Builder(graph).dependentOnly().build();
+    }
+
+
+    public int solveUndeterminedRelationships(Described unit) throws ValidationError {
+        logger.debug("Resolving relationships for {}", unit.getId());
+        int created = 0;
+
+        for (Description desc : unit.getDescriptions()) {
+            // Put the set of relationships into a HashSet to remove duplicates.
+            for (AccessPoint rel : Sets.newHashSet(desc.getAccessPoints())) {
+                // the wp2 undetermined relationship that can be resolved have a 'cvoc' and a 'concept' attribute.
+                // they need to be found in the vocabularies that are in the graph
+                Set<String> relDataKeys = rel.getPropertyKeys();
+                if (relDataKeys.contains("cvoc")
+                        && (relDataKeys.contains("concept") || relDataKeys.contains("target"))) {
+                    String setId = rel.getProperty("cvoc");
+                    String targetId = Optional
+                            .ofNullable(rel.<String>getProperty("concept"))
+                            .orElseGet(() -> rel.getProperty("target"));
+
+                    logger.debug(" - found link references: cvoc: {}, concept: {}", setId, targetId);
+                    try {
+                        AuthoritativeSet set = setCache.get(setId);
+                        Optional<AuthoritativeItem> targetOpt = findTarget(set, targetId);
+                        if (targetOpt.isPresent()) {
+                            AuthoritativeItem target = targetOpt.get();
+                            try {
+                                Optional<Link> linkOpt = findLink(unit, target, rel, linkTemplate);
+                                if (linkOpt.isPresent()) {
+                                    logger.debug(" - found existing link created between {} and {}", targetId, target.getId());
+                                } else {
+                                    Link link = api.create(linkTemplate, Link.class);
+                                    unit.addLink(link);
+                                    target.addLink(link);
+                                    link.addLinkBody(rel);
+                                    logger.debug(" - new link created between {} and {}", targetId, target.getId());
+                                    created++;
+                                }
+                            } catch (PermissionDenied | DeserializationError | SerializationError ex) {
+                                logger.error("Unexpected error resolving link for " + setId + "/" + targetId, ex);
+                            }
+                        } else {
+                            logger.warn(" - unable to find link target with id: {}", targetId);
+                        }
+                    } catch (ExecutionException ex) {
+                        logger.warn(" - unable to find link set with id: {}", setId);
+                    }
+                }
+            }
+        }
+        return created;
+    }
+
+
+    private Optional<AuthoritativeItem> findTarget(AuthoritativeSet set, String itemId) {
+        for (AuthoritativeItem item : set.getAuthoritativeItems()) {
+            if (Objects.equals(item.getIdentifier(), itemId)) {
+                return Optional.of(item);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Link> findLink(Described unit, Linkable target, AccessPoint body, Bundle data)
+            throws SerializationError {
+        for (Link link : unit.getLinks()) {
+            for (Linkable connected : link.getLinkTargets()) {
+                if (target.equals(connected)
+                        && Iterables.contains(link.getLinkBodies(), body)
+                        && mergeSerializer.entityToBundle(link).equals(data)) {
+                    return Optional.of(link);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
@@ -57,7 +57,6 @@ import java.util.regex.Pattern;
  */
 public class ImportHelpers {
 
-    public static final String RESOLVED_LINK_DESC = "Link provided by data provider.";
     public static final String LINK_TARGET = "target";
     public static final String OBJECT_IDENTIFIER = "objectIdentifier";
 

--- a/ehri-io/src/main/resources/reference.conf
+++ b/ehri-io/src/main/resources/reference.conf
@@ -2,6 +2,11 @@
 # by an "application.conf" file in the Neo4j conf directory.
 
 io {
+  import {
+    defaultLinkType = "associative"
+    defaultLinkText = "Link provided by data provider."
+  }
+
   export {
     ead {
       includeRevisions = false

--- a/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkResolverTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkResolverTest.java
@@ -1,0 +1,28 @@
+package eu.ehri.project.importers.links;
+
+import eu.ehri.project.models.base.Described;
+import eu.ehri.project.test.AbstractFixtureTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LinkResolverTest extends AbstractFixtureTest {
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        helper.setInitializing(false).loadTestData("fixtures/link-resolver.yaml");
+    }
+
+    @Test
+    public void solveUndeterminedRelationships() throws Exception {
+        Described unit = manager.getEntity("c5", Described.class);
+        LinkResolver linkResolver = new LinkResolver(graph, validUser);
+        int created = linkResolver.solveUndeterminedRelationships(unit);
+        assertEquals(2, created);
+
+        // running the same op again shouldn't create more links
+        int created2 = linkResolver.solveUndeterminedRelationships(unit);
+        assertEquals(0, created2);
+    }
+}

--- a/ehri-io/src/test/resources/fixtures/link-resolver.yaml
+++ b/ehri-io/src/test/resources/fixtures/link-resolver.yaml
@@ -1,0 +1,36 @@
+
+# Test data for import link resolution. The 2 access points
+# provide the bodies for links between this unit and a1+a2
+- id: c5
+  type: DocumentaryUnit
+  data:
+    identifier: c5
+  relationships:
+    describes:
+      - id: cd5
+        type: DocumentaryUnitDescription
+        data:
+          identifier: c5-desc
+          name: Documentary Unit 5
+          languageCode: eng
+          scopeAndContent: Some description text for c5
+        relationships:
+          relatesTo:
+            - id: ur3
+              type: AccessPoint
+              data:
+                name: Unresolved 1
+                type: person
+                cvoc: auths
+                target: a1
+            - id: ur4
+              type: AccessPoint
+              data:
+                name: Unresolved 2
+                type: person
+                cvoc: auths
+                target: a2
+
+    heldBy: r1
+    hasPermissionScope: r1
+


### PR DESCRIPTION
 - Extracted logic into a more testable single class
 - Made behaviour idempotent on update, so resolution is no longer
   just run if the item is newly-created
 - Extracted some magic strings to config