### PR TITLE
Not-especially satisfactory fix for broken streaming.

### DIFF
--- a/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
@@ -231,6 +231,7 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
         assertEquals("chunked", response.getHeaders().getFirst("Transfer-Encoding"));
         JsonNode data = response.getEntity(JsonNode.class);
         assertEquals("c1", data.path("data").path("c1").path("id").textValue());
+        assertFalse(data.path("data").path("topLevelDocumentaryUnits").path("items").path(0).isMissingNode());
     }
 
     @Test

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/StreamingGraphQLTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/StreamingGraphQLTest.java
@@ -41,12 +41,15 @@ public class StreamingGraphQLTest extends AbstractFixtureTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonGenerator generator = mapper.getFactory().createGenerator(out)
                 .useDefaultPrettyPrinter()) {
-            GraphQLSchema schema = new GraphQLImpl(api(validUser)).getSchema();
+            GraphQLSchema schema = new GraphQLImpl(api(validUser), true).getSchema();
             StreamingGraphQL ql = new StreamingGraphQL(schema);
             ql.execute(generator, testQuery, null, null, Collections.emptyMap());
         }
         JsonNode json = mapper.readTree(out.toByteArray());
+        //System.out.println(json);
         assertEquals("c1", json.path("firstTwo").path("items")
+                .path(0).path("id").textValue());
+        assertEquals("c4", json.path("topLevelDocumentaryUnits").path("items")
                 .path(0).path("id").textValue());
     }
 }

--- a/ehri-ws-graphql/src/test/resources/testquery-connection.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery-connection.graphql
@@ -111,4 +111,9 @@
         }
     }
 
+    topLevelDocumentaryUnits {
+        items {
+            id
+        }
+    }
 }


### PR DESCRIPTION
We have to reinitialise the schema after validation in order that
iterables run in the right TX, otherwise they yield nothing.

This could be better.

Fixes #370.