### PR TITLE
Prepare for more index-based querying via Cypher

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -86,10 +86,6 @@
             <artifactId>joda-time</artifactId>
             <version>2.9.4</version>
         </dependency>
-
-        <!-- logging - we include logback as a logging impl, but this means
-             that any other implementations included with e.g. Neo4j must
-             be removed from the classpath. -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/ehri-core/src/main/java/eu/ehri/project/api/impl/EventsApiImpl.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/impl/EventsApiImpl.java
@@ -70,8 +70,8 @@ public class EventsApiImpl implements EventsApi {
     private final Set<String> ids;
     private final Set<EntityClass> entityTypes;
     private final Set<EventTypes> eventTypes;
-    private final Optional<String> from;
-    private final Optional<String> to;
+    private final String from;
+    private final String to;
     private final Set<ShowType> showType;
     private final Aggregation aggregation;
 
@@ -97,8 +97,8 @@ public class EventsApiImpl implements EventsApi {
         private Set<String> ids = Sets.newHashSet();
         private Set<EntityClass> entityTypes = Sets.newHashSet();
         private Set<EventTypes> eventTypes = Sets.newHashSet();
-        private Optional<String> from = Optional.empty();
-        private Optional<String> to = Optional.empty();
+        private String from = null;
+        private String to = null;
         private Set<ShowType> showType = Sets.newHashSet();
         private Aggregation aggregation = Aggregation.strict;
 
@@ -149,12 +149,12 @@ public class EventsApiImpl implements EventsApi {
         }
 
         public Builder from(String from) {
-            this.from = Optional.ofNullable(from);
+            this.from = from;
             return this;
         }
 
         public Builder to(String to) {
-            this.to = Optional.ofNullable(to);
+            this.to = to;
             return this;
         }
 
@@ -195,8 +195,8 @@ public class EventsApiImpl implements EventsApi {
             Collection<String> ids,
             Collection<EntityClass> entityTypes,
             Collection<EventTypes> eventTypes,
-            Optional<String> from,
-            Optional<String> to,
+            String from,
+            String to,
             Collection<ShowType> showType,
             Aggregation aggregation) {
         this.graph = graph;
@@ -224,8 +224,8 @@ public class EventsApiImpl implements EventsApi {
                 Lists.<String>newArrayList(),
                 Lists.<EntityClass>newArrayList(),
                 Lists.<EventTypes>newArrayList(),
-                Optional.empty(),
-                Optional.empty(),
+                null,
+                null,
                 Lists.<ShowType>newArrayList(),
                 Aggregation.strict);
     }
@@ -427,17 +427,17 @@ public class EventsApiImpl implements EventsApi {
         }
 
         // Add from/to filters (depends on timestamp strings comparing the right way!
-        if (from.isPresent()) {
+        if (from != null) {
             pipe = pipe.filter(event -> {
                 String timestamp = event.getTimestamp();
-                return from.get().compareTo(timestamp) >= 0;
+                return from.compareTo(timestamp) >= 0;
             });
         }
 
-        if (to.isPresent()) {
+        if (to != null) {
             pipe = pipe.filter(event -> {
                 String timestamp = event.getTimestamp();
-                return to.get().compareTo(timestamp) <= 0;
+                return to.compareTo(timestamp) <= 0;
             });
         }
 

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/Neo4jGraphManager.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/Neo4jGraphManager.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Map;
@@ -47,7 +48,7 @@ import java.util.NoSuchElementException;
  */
 public final class Neo4jGraphManager<T extends Neo4j2Graph> extends BlueprintsGraphManager<T> {
 
-    private final static Logger logger = org.slf4j.LoggerFactory.getLogger(Neo4jGraphManager.class);
+    private final static Logger logger = LoggerFactory.getLogger(Neo4jGraphManager.class);
 
     public Neo4jGraphManager(FramedGraph<T> graph) {
         super(graph);
@@ -142,12 +143,12 @@ public final class Neo4jGraphManager<T extends Neo4j2Graph> extends BlueprintsGr
                 .on(EntityType.TYPE_KEY)
                 .create();
 
-        // Create an index on each mandatory property and
+        // Create an index on each property and
         // a unique constraint on unique properties.
         for (EntityClass cls : EntityClass.values()) {
-            Collection<String> mandPropertyKeys = ClassUtils.getMandatoryPropertyKeys(cls.getJavaClass());
-            for (String prop : mandPropertyKeys) {
-                logger.trace("Creating index on mandatory property: {} -> {}",
+            Collection<String> propertyKeys = ClassUtils.getPropertyKeys(cls.getJavaClass());
+            for (String prop : propertyKeys) {
+                logger.trace("Creating index on property: {} -> {}",
                         cls.getName(), prop);
                 schema.indexFor(Label.label(cls.getName()))
                         .on(prop)

--- a/ehri-core/src/test/java/eu/ehri/project/core/GraphManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/core/GraphManagerTest.java
@@ -42,11 +42,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Graph Manager tests. These do a bit of funky


### PR DESCRIPTION
 - Add additional getVerticesByQuery method to the
   Neo4j2Graph wrapper
 - Add an index on all (managed) properties, not just
   mandatory ones
 - Some additional tweaks to Query classes