### PR TITLE
Ensure temp test DBs are always closed and don't contend for the lock file

### DIFF
--- a/ehri-core/src/test/java/eu/ehri/project/core/GraphManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/core/GraphManagerTest.java
@@ -85,15 +85,15 @@ public class GraphManagerTest {
                 if (annotation != null && ignore == null) {
                     Class<? extends Throwable> expected = annotation.expected();
                     System.err.println(" --- " + cls.getSimpleName() + " invoking test: " + method.getName());
+                    setUp();
                     try {
-                        setUp();
                         method.invoke(this);
-                        tearDown();
                     } catch (InvocationTargetException e) {
-                        if (expected == null
-                                || !e.getTargetException().getClass().equals(expected)) {
+                        if (!e.getTargetException().getClass().equals(expected)) {
                             throw e.getCause();
                         }
+                    } finally {
+                        tearDown();
                     }
                 }
             }

--- a/ehri-core/src/test/java/eu/ehri/project/core/impl/Neo4jGraphManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/core/impl/Neo4jGraphManagerTest.java
@@ -8,6 +8,7 @@ import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.impl.neo4j.Neo4j2Graph;
 import eu.ehri.project.core.impl.neo4j.Neo4j2Vertex;
 import eu.ehri.project.models.EntityClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -23,15 +24,20 @@ import static org.junit.Assert.*;
 public class Neo4jGraphManagerTest {
 
     private GraphManager manager;
+    private FramedGraph<Neo4j2Graph> graph;
 
     @Before
     public void setUp() throws Exception {
-        FramedGraph<Neo4j2Graph> graph = new FramedGraphFactory().create(new Neo4j2Graph(
+        graph = new FramedGraphFactory().create(new Neo4j2Graph(
                 new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
                         .newGraphDatabase()));
         manager = new Neo4jGraphManager<>(graph);
     }
 
+    @After
+    public void tearDown() throws Exception {
+        graph.shutdown();
+    }
 
     @Test
     public void testCreateVertex() throws Exception {

--- a/ehri-core/src/test/java/eu/ehri/project/test/GraphTestBase.java
+++ b/ehri-core/src/test/java/eu/ehri/project/test/GraphTestBase.java
@@ -31,20 +31,22 @@ import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.frames.FramedGraphFactory;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerModule;
 import eu.ehri.project.acl.AnonymousAccessor;
+import eu.ehri.project.api.Api;
+import eu.ehri.project.api.ApiFactory;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
 import eu.ehri.project.core.impl.Neo4jGraphManager;
 import eu.ehri.project.core.impl.neo4j.Neo4j2Graph;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Accessor;
-import eu.ehri.project.api.Api;
-import eu.ehri.project.api.ApiFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -108,8 +110,11 @@ public abstract class GraphTestBase {
         manager = GraphManagerFactory.getInstance(graph);
     }
 
-    protected FramedGraph<? extends TransactionalGraph> getFramedGraph() {
-        GraphDatabaseService rawGraph = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+    protected FramedGraph<? extends TransactionalGraph> getFramedGraph() throws IOException {
+        File tempFile = File.createTempFile("neo4j-tmp", ".db");
+        tempFile.deleteOnExit();
+        GraphDatabaseService rawGraph = new TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder(tempFile)
                 .newGraphDatabase();
         try (Transaction tx = rawGraph.beginTx()) {
             Neo4jGraphManager.createIndicesAndConstraints(rawGraph);


### PR DESCRIPTION
This fixes test issues with Neo4j 3.3.0.