### PR TITLE
Type boilerplate to prevent raw types warnings.

### DIFF
--- a/ehri-cli/src/main/java/eu/ehri/project/commands/EadImport.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/EadImport.java
@@ -19,11 +19,10 @@
 
 package eu.ehri.project.commands;
 
-import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.base.ItemImporter;
+import eu.ehri.project.importers.base.SaxXmlHandler;
 import eu.ehri.project.importers.ead.EadHandler;
 import eu.ehri.project.importers.ead.EadImporter;
-import eu.ehri.project.importers.base.SaxXmlHandler;
 
 /**
  * Import EAD from the command line.
@@ -42,7 +41,7 @@ public class EadImport extends ImportCommand {
      * @param handler  The Handler class to be used for import
      * @param importer The Importer class to be used. If null, IcaAtomEadImporter is used.
      */
-    public EadImport(Class<? extends SaxXmlHandler> handler, Class<? extends ItemImporter> importer) {
+    public EadImport(Class<? extends SaxXmlHandler> handler, Class<? extends ItemImporter<?, ?>> importer) {
         super(handler, importer);
     }
 

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/GraphSON.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/GraphSON.java
@@ -151,7 +151,7 @@ public class GraphSON extends BaseCommand {
                     // safe, due to the above instanceof
                     @SuppressWarnings("unchecked")
                     FramedGraph<Neo4j2Graph> neo4j2Graph = ((FramedGraph<Neo4j2Graph>) graph);
-                    Neo4jGraphManager manager = new Neo4jGraphManager<>(neo4j2Graph);
+                    Neo4jGraphManager<?> manager = new Neo4jGraphManager<>(neo4j2Graph);
                     int i = 0;
                     for (Vertex v : graph.getVertices()) {
                         manager.setLabels(v);

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -50,9 +50,9 @@ import java.util.Map;
  */
 public abstract class ImportCommand extends BaseCommand {
     private final Class<? extends SaxXmlHandler> handler;
-    private final Class<? extends ItemImporter> importer;
+    private final Class<? extends ItemImporter<?, ?>> importer;
 
-    public ImportCommand(Class<? extends SaxXmlHandler> handler, Class<? extends ItemImporter> importer) {
+    public ImportCommand(Class<? extends SaxXmlHandler> handler, Class<? extends ItemImporter<?, ?>> importer) {
         this.handler = handler;
         this.importer = importer;
     }

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
@@ -41,9 +41,9 @@ import java.util.Map;
  * to manipulate the graph.
  */
 public abstract class ImportCsvCommand extends BaseCommand {
-    private final Class<? extends ItemImporter> importer;
+    private final Class<? extends ItemImporter<?, ?>> importer;
 
-    public ImportCsvCommand(Class<? extends ItemImporter> importer) {
+    public ImportCsvCommand(Class<? extends ItemImporter<?, ?>> importer) {
         this.importer = importer;
     }
 

--- a/ehri-core/src/main/java/eu/ehri/project/acl/AccessorPermissions.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/AccessorPermissions.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * A pairing of an accessor and their non-inherited permissions.
  */
 class AccessorPermissions<T> {
-    final String accessorId;
+    private final String accessorId;
     final T permissionSet;
 
     public AccessorPermissions(String accessorId, T permissionSet) {
@@ -46,7 +46,7 @@ class AccessorPermissions<T> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        AccessorPermissions that = (AccessorPermissions) o;
+        AccessorPermissions<?> that = (AccessorPermissions<?>) o;
 
         return accessorId.equals(that.accessorId)
                 && permissionSet.equals(that.permissionSet);

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclEdgeIterable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclEdgeIterable.java
@@ -20,8 +20,8 @@ public class AclEdgeIterable implements CloseableIterable<Edge> {
 
     @Override
     public void close() {
-        if (this.iterable instanceof CloseableIterable) {
-            ((CloseableIterable) iterable).close();
+        if (this.iterable instanceof CloseableIterable<?>) {
+            ((CloseableIterable<?>) iterable).close();
         }
     }
 

--- a/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertexIterable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/acl/wrapper/AclVertexIterable.java
@@ -18,8 +18,8 @@ public class AclVertexIterable implements CloseableIterable<Vertex> {
 
     @Override
     public void close() {
-        if (this.iterable instanceof CloseableIterable) {
-            ((CloseableIterable) iterable).close();
+        if (this.iterable instanceof CloseableIterable<?>) {
+            ((CloseableIterable<?>) iterable).close();
         }
     }
 

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2EdgeIterable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2EdgeIterable.java
@@ -51,7 +51,7 @@ public class Neo4j2EdgeIterable<T extends Edge> implements CloseableIterable<Neo
 
     public void close() {
         if (this.relationships instanceof IndexHits) {
-            ((IndexHits) this.relationships).close();
+            ((IndexHits<?>) this.relationships).close();
         }
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2VertexIterable.java
+++ b/ehri-core/src/main/java/eu/ehri/project/core/impl/neo4j/Neo4j2VertexIterable.java
@@ -42,7 +42,7 @@ public class Neo4j2VertexIterable<T extends Neo4j2Vertex> implements CloseableIt
 
     public void close() {
         if (this.nodes instanceof IndexHits) {
-            ((IndexHits) this.nodes).close();
+            ((IndexHits<?>) this.nodes).close();
         }
     }
 

--- a/ehri-core/src/main/java/eu/ehri/project/models/utils/UniqueAdjacencyAnnotationHandler.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/utils/UniqueAdjacencyAnnotationHandler.java
@@ -23,7 +23,7 @@ public class UniqueAdjacencyAnnotationHandler implements MethodHandler<UniqueAdj
     }
 
     @Override
-    public Object processElement(final Object frame, final Method method, final Object[] arguments, final UniqueAdjacency annotation, final FramedGraph framedGraph,
+    public Object processElement(final Object frame, final Method method, final Object[] arguments, final UniqueAdjacency annotation, final FramedGraph<?> framedGraph,
             final Element element) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
@@ -85,7 +85,7 @@ public class UniqueAdjacencyAnnotationHandler implements MethodHandler<UniqueAdj
         } else if (ClassUtilities.isSetMethod(method)) {
             removeEdges(adjacency.direction(), adjacency.label(), vertex, null, framedGraph);
             if (ClassUtilities.acceptsIterable(method)) {
-                for (Object o : (Iterable) arguments[0]) {
+                for (Object o : (Iterable<?>) arguments[0]) {
                     Vertex v = ((VertexFrame) o).asVertex();
                     addEdges(adjacency, vertex, v);
                 }
@@ -123,7 +123,7 @@ public class UniqueAdjacencyAnnotationHandler implements MethodHandler<UniqueAdj
         }
     }
 
-    private void removeEdges(final Direction direction, final String label, final Vertex element, final Vertex otherVertex, final FramedGraph framedGraph) {
+    private void removeEdges(final Direction direction, final String label, final Vertex element, final Vertex otherVertex, final FramedGraph<?> framedGraph) {
         for (final Edge edge : element.getEdges(direction, label)) {
             if (null == otherVertex || edge.getVertex(direction.opposite()).equals(otherVertex)) {
                 framedGraph.removeEdge(edge);

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -143,7 +143,7 @@ public final class Bundle implements NestableData<Bundle> {
             } else {
                 Object current = data.get(key);
                 if (current instanceof List) {
-                    ((List)current).add(value);
+                    ((List<Object>)current).add(value);
                     data.put(key, current);
                 } else {
                     data.put(key, Lists.newArrayList(current, value));
@@ -827,7 +827,7 @@ public final class Bundle implements NestableData<Bundle> {
         for (Map.Entry<? extends String, Object> entry : data.entrySet()) {
             Object value = entry.getValue();
             if (value instanceof Enum<?>) {
-                value = ((Enum) value).name();
+                value = ((Enum<?>) value).name();
             }
             filtered.put(entry.getKey(), value);
         }

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/DataConverter.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/DataConverter.java
@@ -362,9 +362,9 @@ class DataConverter {
         } else if (value instanceof Object[]) {
             return ((Object[]) value).length == 0;
         } else if (value instanceof Collection<?>) {
-            return ((Collection) value).isEmpty();
+            return ((Collection<?>) value).isEmpty();
         } else if (value instanceof Iterable<?>) {
-            return !((Iterable) value).iterator().hasNext();
+            return !((Iterable<?>) value).iterator().hasNext();
         }
         return false;
     }

--- a/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
+++ b/ehri-core/src/main/java/eu/ehri/project/tools/FindReplace.java
@@ -141,7 +141,7 @@ public class FindReplace {
     private boolean find(String needle, Object data) {
         if (data != null) {
             if (data instanceof List) {
-                for (Object v : ((List) data)) {
+                for (Object v : ((List<?>) data)) {
                     if (find(needle, v)) {
                         return true;
                     }
@@ -157,8 +157,8 @@ public class FindReplace {
     private Object replace(String original, String replacement, Object data) {
         if (data != null) {
             if (data instanceof List) {
-                List<Object> newList = Lists.newArrayListWithExpectedSize(((List) data).size());
-                for (Object v : ((List) data)) {
+                List<Object> newList = Lists.newArrayListWithExpectedSize(((List<?>) data).size());
+                for (Object v : ((List<?>) data)) {
                     newList.add(replace(original, replacement, v));
                 }
                 return newList;

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/cvoc/JenaSkosExporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/cvoc/JenaSkosExporter.java
@@ -178,7 +178,7 @@ public class JenaSkosExporter implements SkosExporter {
     private void writeListOrScalar(Model model, Resource resource,
             Property property, Object listOrScalar, String lang) {
         if (listOrScalar instanceof List) {
-            List<?> list = (List) listOrScalar;
+            List<?> list = (List<?>) listOrScalar;
             for (Object obj : list) {
                 logger.trace("Writing list property: {} -> {}", property, obj);
                 writeObject(model, resource, property, obj, lang);

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/eac/Eac2010Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/eac/Eac2010Exporter.java
@@ -213,7 +213,7 @@ public final class Eac2010Exporter extends AbstractStreamingXmlExporter<Historic
             }
 
             Optional.ofNullable(desc.getProperty(Isaar.otherFormsOfName)).ifPresent(parNames -> {
-                List values = coerceList(parNames);
+                List<?> values = coerceList(parNames);
                 if (!values.isEmpty()) {
                     for (Object value : values) {
                         tag(sw, "nameEntry", () -> {
@@ -225,7 +225,7 @@ public final class Eac2010Exporter extends AbstractStreamingXmlExporter<Historic
             });
 
             Optional.ofNullable(desc.getProperty(Isaar.parallelFormsOfName)).ifPresent(parNames -> {
-                List values = coerceList(parNames);
+                List<?> values = coerceList(parNames);
                 if (!values.isEmpty()) {
                     tag(sw, "nameEntryParallel", () -> {
                         tag(sw, "nameEntry", () -> {
@@ -262,7 +262,7 @@ public final class Eac2010Exporter extends AbstractStreamingXmlExporter<Historic
             addRevisionDesc(sw, agent, desc);
 
             Optional.ofNullable(desc.getProperty(Isaar.source)).ifPresent(sources -> {
-                List sourceValues = coerceList(sources);
+                List<?> sourceValues = coerceList(sources);
                 tag(sw, "sources", () -> {
                     for (Object value : sourceValues) {
                         tag(sw, "source", () -> tag(sw, "sourceEntry", value.toString()));

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/eag/Eag2012Exporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/eag/Eag2012Exporter.java
@@ -197,13 +197,13 @@ public final class Eag2012Exporter extends AbstractStreamingXmlExporter<Reposito
             tag(sw, "autform", desc.getName(), attrs("xml:lang", desc.getLanguageOfDescription()));
 
             Optional.ofNullable(desc.getProperty(Isdiah.parallelFormsOfName)).ifPresent(parNames -> {
-                List values = parNames instanceof List ? (List) parNames : ImmutableList.of(parNames);
+                List<?> values = parNames instanceof List ? (List<?>) parNames : ImmutableList.of(parNames);
                 for (Object value : values) {
                     tag(sw, "parform", value.toString());
                 }
             });
             Optional.ofNullable(desc.getProperty(Isdiah.otherFormsOfName)).ifPresent(parNames -> {
-                List values = parNames instanceof List ? (List) parNames : ImmutableList.of(parNames);
+                List<?> values = parNames instanceof List ? (List<?>) parNames : ImmutableList.of(parNames);
                 for (Object value : values) {
                     tag(sw, "parform", value.toString());
                 }

--- a/ehri-io/src/main/java/eu/ehri/project/exporters/xml/AbstractStreamingXmlExporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/exporters/xml/AbstractStreamingXmlExporter.java
@@ -50,7 +50,7 @@ public abstract class AbstractStreamingXmlExporter<E extends Entity>
 
     protected List<Object> coerceList(Object value) {
         return value == null ? ImmutableList.of()
-                : (value instanceof List ? (List) value : ImmutableList.of(value));
+                : (value instanceof List ? (List<Object>) value : ImmutableList.of(value));
     }
 
     protected String resourceAsString(String resourceName) {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacHandler.java
@@ -122,16 +122,16 @@ public class EacHandler extends SaxXmlHandler {
         if (names instanceof String) {
             nameValue = names.toString();
         } else if (names instanceof List) {
-            Object firstName = ((List) names).get(0);
+            Object firstName = ((List<?>) names).get(0);
             if (firstName instanceof String) {
                 nameValue = firstName.toString();
             } else {
-                Map nameMap = (Map) firstName;
+                Map<?,?> nameMap = (Map<?,?>) firstName;
                 if (nameMap.get("namePart") instanceof String) {
                     nameValue = nameMap.get("namePart").toString();
                 } else if (nameMap.get("namePart") instanceof List) {
                     nameValue = "";
-                    for (Object p : (List) nameMap.get("namePart")) {
+                    for (Object p : (List<?>) nameMap.get("namePart")) {
                         nameValue += p + " ";
                     }
 
@@ -141,8 +141,8 @@ public class EacHandler extends SaxXmlHandler {
             }
 
             Set<String> otherNames = Sets.newHashSet();
-            for (int i = 1; i < ((List) names).size(); i++) {
-                Map m = (Map) ((List) names).get(i);
+            for (int i = 1; i < ((List<?>) names).size(); i++) {
+                Map<?,?> m = (Map<?,?>) ((List<?>) names).get(i);
                 Object namePart = m.get("namePart");
                 if (namePart != null && !namePart.toString().trim().equalsIgnoreCase(nameValue)) {
                     otherNames.add(namePart.toString().trim());

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
@@ -164,7 +164,7 @@ public class EadHandler extends SaxXmlHandler {
     private String getCurrentTopIdentifier() {
         Object current = currentGraphPath.peek().get(ImportHelpers.OBJECT_IDENTIFIER);
         if (current instanceof List<?>) {
-            return (String) ((List) current).get(0);
+            return (String) ((List<?>) current).get(0);
         } else {
             return (String) current;
         }
@@ -365,7 +365,7 @@ public class EadHandler extends SaxXmlHandler {
         if (currentGraph.containsKey(ImportHelpers.OBJECT_IDENTIFIER)) {
             Object idents = currentGraph.get(ImportHelpers.OBJECT_IDENTIFIER);
             if (idents instanceof List) {
-                List identList = (List) idents;
+                List<?> identList = (List<?>) idents;
                 currentGraph.put(ImportHelpers.OBJECT_IDENTIFIER, identList.get(0));
                 for (Object item : identList.subList(1, identList.size())) {
                     addOtherIdentifier(currentGraph, ((String) item));

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadHandler.java
@@ -145,7 +145,7 @@ public class VirtualEadHandler extends SaxXmlHandler {
     private String getCurrentTopIdentifier() {
         Object current = currentGraphPath.peek().get(ImportHelpers.OBJECT_IDENTIFIER);
         if (current instanceof List<?>) {
-            return (String) ((List) current).get(0);
+            return (String) ((List<?>) current).get(0);
         } else {
             return (String) current;
         }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -61,7 +61,7 @@ public abstract class AbstractImportManager implements ImportManager {
     // and reporting errors usefully...
     private String currentFile;
     protected Integer currentPosition;
-    protected final Class<? extends ItemImporter> importerClass;
+    protected final Class<? extends ItemImporter<?,?>> importerClass;
 
     /**
      * Constructor.
@@ -80,7 +80,7 @@ public abstract class AbstractImportManager implements ImportManager {
             PermissionScope scope, Actioner actioner,
             boolean tolerant,
             boolean allowUpdates,
-            Class<? extends ItemImporter> importerClass) {
+            Class<? extends ItemImporter<?,?>> importerClass) {
         Preconditions.checkNotNull(scope, "Scope cannot be null");
         this.framedGraph = graph;
         this.permissionScope = scope;

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -56,7 +56,7 @@ public class CsvImportManager extends AbstractImportManager {
     public CsvImportManager(FramedGraph<?> framedGraph,
             PermissionScope permissionScope, Actioner actioner,
             boolean tolerant,
-            boolean allowUpdates, Class<? extends ItemImporter> importerClass) {
+            boolean allowUpdates, Class<? extends ItemImporter<?,?>> importerClass) {
         super(framedGraph, permissionScope, actioner, tolerant, allowUpdates, importerClass);
     }
 
@@ -72,7 +72,7 @@ public class CsvImportManager extends AbstractImportManager {
             final ImportLog log) throws IOException, ValidationError, InputParseError {
 
         try {
-            ItemImporter importer = importerClass
+            ItemImporter<?,?> importer = importerClass
                     .getConstructor(FramedGraph.class, PermissionScope.class, Actioner.class, ImportLog.class)
                     .newInstance(framedGraph, permissionScope, actioner, log);
             logger.debug("importer of class " + importer.getClass());
@@ -93,7 +93,7 @@ public class CsvImportManager extends AbstractImportManager {
                                 entry.getKey().replaceAll("\\s", ""), entry.getValue());
                     }
                     try {
-                        importer.importItem(dataMap);
+                        ((ItemImporter<Map<String, Object>, ?>)importer).importItem(dataMap);
                     } catch (ValidationError e) {
                         if (isTolerant()) {
                             logger.error("Validation error importing item: {}", e);
@@ -104,7 +104,8 @@ public class CsvImportManager extends AbstractImportManager {
                 }
             }
         } catch (IllegalAccessException | InvocationTargetException |
-                InstantiationException | NoSuchMethodException e) {
+                InstantiationException | NoSuchMethodException |
+                ClassCastException e) {
             throw new RuntimeException(e);
         }
     }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Class that provides a front-end for importing XML files like EAD and EAC and
@@ -69,7 +68,7 @@ public class SaxImportManager extends AbstractImportManager {
             Actioner actioner,
             boolean tolerant,
             boolean allowUpdates,
-            Class<? extends ItemImporter> importerClass,
+            Class<? extends ItemImporter<?,?>> importerClass,
             Class<? extends SaxXmlHandler> handlerClass,
             XmlImportProperties properties,
             List<ImportCallback> callbacks) {
@@ -92,7 +91,7 @@ public class SaxImportManager extends AbstractImportManager {
             PermissionScope scope, Actioner actioner,
             boolean tolerant,
             boolean allowUpdates,
-            Class<? extends ItemImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
+            Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             List<ImportCallback> callbacks) {
         this(graph, scope, actioner, tolerant, allowUpdates, importerClass, handlerClass, null,
                 callbacks);
@@ -109,7 +108,7 @@ public class SaxImportManager extends AbstractImportManager {
             PermissionScope scope, Actioner actioner,
             boolean tolerant,
             boolean allowUpdates,
-            Class<? extends ItemImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass,
+            Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass,
             XmlImportProperties properties) {
         this(graph, scope, actioner, tolerant, allowUpdates, importerClass, handlerClass,
                 properties,
@@ -125,7 +124,7 @@ public class SaxImportManager extends AbstractImportManager {
      */
     public SaxImportManager(FramedGraph<?> graph,
             PermissionScope scope, Actioner actioner,
-            Class<? extends ItemImporter> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
+            Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
         this(graph, scope, actioner, false, false, importerClass, handlerClass, Lists
                 .<ImportCallback>newArrayList());
     }
@@ -141,7 +140,7 @@ public class SaxImportManager extends AbstractImportManager {
     protected void importInputStream(final InputStream stream, final String tag, final ActionManager.EventContext context,
             final ImportLog log) throws IOException, ValidationError, InputParseError {
         try {
-            ItemImporter<Map<String, Object>, ?> importer = importerClass
+            ItemImporter<?, ?> importer = importerClass
                     .getConstructor(FramedGraph.class, PermissionScope.class,
                             Actioner.class, ImportLog.class)
                     .newInstance(framedGraph, permissionScope, actioner, log);

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
@@ -93,7 +93,7 @@ public class ImportHelpers {
                 && !(nodeProperties.hasProperty(entity.getName(), key)
                 && nodeProperties.isMultivaluedProperty(entity.getName(), key))) {
             logger.trace("Flattening array property value: {}: {}", key, value);
-            return stringJoiner.join((List) value);
+            return stringJoiner.join((List<?>) value);
         } else {
             return value;
         }
@@ -230,7 +230,7 @@ public class ImportHelpers {
         if (c.containsKey(property)) {
             Object currentValue = c.get(property);
             if (currentValue instanceof List) {
-                ((List) currentValue).add(normValue);
+                ((List<Object>) currentValue).add(normValue);
             } else {
                 c.put(property, Lists.newArrayList(currentValue, normValue));
             }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
@@ -60,12 +60,12 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
     /**
      * Convenience method for creating a Sax import manager.
      */
-    protected SaxImportManager saxImportManager(Class<? extends ItemImporter> importerClass, Class<? extends
+    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends
             SaxXmlHandler> handlerClass) {
         return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass);
     }
 
-    protected SaxImportManager saxImportManager(Class<? extends ItemImporter> importerClass, Class<? extends
+    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends
             SaxXmlHandler> handlerClass, String propertiesResource) {
         return saxImportManager(importerClass, handlerClass).withProperties(propertiesResource);
     }
@@ -97,14 +97,14 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
         for (Vertex v : graph.getVertices()) {
             logger.debug(++vcount + " -------------------------");
             for (String key : v.getPropertyKeys()) {
-                String value = "";
+                StringBuilder value = new StringBuilder();
                 if (v.getProperty(key) instanceof String[]) {
                     String[] list = v.getProperty(key);
                     for (String o : list) {
-                        value += "[" + o + "] ";
+                        value.append("[").append(o).append("] ");
                     }
                 } else {
-                    value = v.getProperty(key).toString();
+                    value = new StringBuilder(v.getProperty(key).toString());
                 }
                 logger.debug(key + ": " + value);
             }
@@ -116,11 +116,11 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
     }
 
     // Print a Concept Tree from a 'top' concept down into all narrower concepts
-    public void printConceptTree(final PrintStream out, Concept c) {
+    protected void printConceptTree(final PrintStream out, Concept c) {
         printConceptTree(out, c, 0, "");
     }
 
-    public void printConceptTree(final PrintStream out, Concept c, int depth, String indent) {
+    private void printConceptTree(final PrintStream out, Concept c, int depth, String indent) {
         if (depth > 100) {
             out.println("STOP RECURSION, possibly cyclic 'tree'");
             return;
@@ -157,7 +157,6 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
      * @param identifier the Vertex's 'human readable' identifier
      * @return the first Vertex with the given identifier
      * @throws NoSuchElementException when there are no vertices with this identifier
-     * @see {@link eu.ehri.project.definitions.Ontology#IDENTIFIER_KEY}
      */
     protected Vertex getVertexByIdentifier(FramedGraph<?> graph, String identifier) {
         Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY, identifier);
@@ -171,7 +170,6 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
      * @param id    the Vertex's generated, slugified identifier
      * @return the first Vertex with the given identifier
      * @throws NoSuchElementException when there are no vertices with this identifier
-     * @see {@link eu.ehri.project.models.annotations.EntityType#ID_KEY}
      */
     protected Vertex getVertexById(FramedGraph<?> graph, String id) {
         Iterable<Vertex> docs = graph.getVertices(EntityType.ID_KEY, id);

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
@@ -392,13 +392,13 @@ public class GraphQLImpl {
         return source.getProperty(name);
     };
 
-    private static DataFetcher<List> listDataFetcher(DataFetcher<Object> fetcher) {
+    private static DataFetcher<List<?>> listDataFetcher(DataFetcher<?> fetcher) {
         return env -> {
             Object obj = fetcher.get(env);
             if (obj == null) {
                 return Collections.emptyList();
             } else if (obj instanceof List) {
-                return (List)obj;
+                return (List<?>)obj;
             } else {
                 return Lists.newArrayList(obj);
             }
@@ -449,7 +449,7 @@ public class GraphQLImpl {
         }).filter(Objects::nonNull).collect(Collectors.toList());
     };
 
-    private static DataFetcher<Object> transformingDataFetcher(DataFetcher fetcher, Function<Object, Object> transformer) {
+    private static <S, T> DataFetcher<T> transformingDataFetcher(DataFetcher<S> fetcher, Function<S, T> transformer) {
         return env -> transformer.apply(fetcher.get(env));
     }
 
@@ -565,7 +565,7 @@ public class GraphQLImpl {
     }
 
     private static GraphQLFieldDefinition.Builder listFieldDefinition(String name, String description,
-            GraphQLOutputType type, DataFetcher dataFetcher) {
+            GraphQLOutputType type, DataFetcher<Iterable<Entity>> dataFetcher) {
         return newFieldDefinition()
                 .name(name)
                 .type(new GraphQLList(type))
@@ -582,7 +582,7 @@ public class GraphQLImpl {
     }
 
     private static GraphQLFieldDefinition.Builder connectionFieldDefinition(String name, String description,
-            GraphQLOutputType type, DataFetcher dataFetcher, GraphQLArgument... arguments) {
+            GraphQLOutputType type, DataFetcher<Map<String, Object>> dataFetcher, GraphQLArgument... arguments) {
         return newFieldDefinition()
                 .name(name)
                 .description(description)
@@ -675,8 +675,8 @@ public class GraphQLImpl {
                 new GraphQLTypeReference(Entities.DATE_PERIOD),
                 oneToManyRelationshipFetcher(d -> d.as(Temporal.class).getDatePeriods()));
 
-    private GraphQLFieldDefinition.Builder itemFieldDefinition(String name, String description,
-            GraphQLOutputType type, DataFetcher dataFetcher, GraphQLArgument... arguments) {
+    private <T> GraphQLFieldDefinition.Builder itemFieldDefinition(String name, String description,
+            GraphQLOutputType type, DataFetcher<T> dataFetcher, GraphQLArgument... arguments) {
         return newFieldDefinition()
                 .name(name)
                 .type(type)

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -238,7 +238,7 @@ public class ImportResource extends AbstractResource {
             checkPropertyFile(propertyFile);
             Class<? extends SaxXmlHandler> handler
                     = getHandlerCls(handlerClass, DEFAULT_EAD_HANDLER);
-            Class<? extends ItemImporter> importer
+            Class<? extends ItemImporter<?, ?>> importer
                     = getImporterCls(importerClass, DEFAULT_EAD_IMPORTER);
 
             // Get the current user from the Authorization header and the scope
@@ -300,7 +300,7 @@ public class ImportResource extends AbstractResource {
             checkPropertyFile(propertyFile);
             Class<? extends SaxXmlHandler> handler
                     = getHandlerCls(handlerClass, DEFAULT_EAD_HANDLER);
-            Class<? extends ItemImporter> importer
+            Class<? extends ItemImporter<?, ?>> importer
                     = getImporterCls(importerClass, DEFAULT_EAD_IMPORTER);
 
             Actioner user = getCurrentActioner();
@@ -402,7 +402,7 @@ public class ImportResource extends AbstractResource {
             InputStream data)
             throws ItemNotFound, ValidationError, IOException, DeserializationError {
         try (final Tx tx = beginTx()) {
-            Class<? extends ItemImporter> importer
+            Class<? extends ItemImporter<?, ?>> importer
                     = getImporterCls(importerClass, DEFAULT_EAD_IMPORTER);
 
             // Get the current user from the Authorization header and the scope
@@ -553,7 +553,7 @@ public class ImportResource extends AbstractResource {
     }
 
     @SuppressWarnings("unchecked")
-    private static Class<? extends ItemImporter> getImporterCls(String importerName, String defaultImporter)
+    private static Class<? extends ItemImporter<?, ?>> getImporterCls(String importerName, String defaultImporter)
             throws DeserializationError {
         String name = nameOrDefault(importerName, defaultImporter);
         try {
@@ -562,7 +562,7 @@ public class ImportResource extends AbstractResource {
                 throw new DeserializationError("Class '" + importerName + "' is" +
                         " not an instance of " + ItemImporter.class.getSimpleName());
             }
-            return (Class<? extends ItemImporter>) importer;
+            return (Class<? extends ItemImporter<?, ?>>) importer;
         } catch (ClassNotFoundException e) {
             throw new DeserializationError("Class not found: " + e.getMessage());
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ToolsResource.java
@@ -416,7 +416,7 @@ public class ToolsResource extends AbstractResource {
         try (final Tx tx = beginTx()) {
             for (Vertex v : graph.getVertices()) {
                 try {
-                    ((Neo4jGraphManager) manager).setLabels(v);
+                    ((Neo4jGraphManager<?>) manager).setLabels(v);
                     done++;
                 } catch (org.neo4j.graphdb.ConstraintViolationException e) {
                     logger.error("Error setting labels on {} ({})", manager.getId(v), v.getId());


### PR DESCRIPTION
This doesn't actually fix any of the underlying type unsoundness but fixes #44.