### PR TITLE
Throw a validation error if (unsaved) parent item has a missing ID

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
@@ -40,11 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -212,6 +208,7 @@ public class EadHandler extends SaxXmlHandler {
             Map<String, Object> currentGraph = currentGraphPath.pop();
 
             if (isUnitDelimiter(qName)) {
+                List<String> pathIds = pathIds();
                 try {
                     //add any mandatory fields not yet there:
                     // First: identifier(s),
@@ -238,7 +235,7 @@ public class EadHandler extends SaxXmlHandler {
                         currentGraph.put(Entities.MAINTENANCE_EVENT, globalMaintenanceEvents);
                     }
 
-                    DocumentaryUnit current = (DocumentaryUnit) importer.importItem(currentGraph, pathIds());
+                    DocumentaryUnit current = (DocumentaryUnit) importer.importItem(currentGraph, pathIds);
 
                     logger.trace("importer used: {}", importer.getClass());
                     if (depth > 0) { // if not on root level
@@ -259,7 +256,7 @@ public class EadHandler extends SaxXmlHandler {
                     if (bundle.getId() == null) {
                         // In order to indicate what has errored here if there's no
                         // ID we need to create one with the line number reference.
-                        String path = pathIds().isEmpty() ? null : Joiner.on("/").join(pathIds());
+                    String path = pathIds.isEmpty() ? null : Joiner.on("/").useForNull("[null]").join(pathIds);
                         String ref = String.format("[Item completed prior to line: %d]",
                                 locator.getLineNumber());
                         String id = Joiner.on(" ").skipNulls().join(path, locator.getSystemId(), ref);

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
@@ -102,14 +102,11 @@ public class ImportHelpers {
     /**
      * Extract DocumentaryUnit properties from the itemData and return them as a new Map.
      * This implementation only extracts the objectIdentifier.
-     * <p>
-     * This implementation does not throw ValidationErrors.
      *
      * @param itemData a Map containing raw properties of a DocumentaryUnit
      * @return a new Map containing the objectIdentifier property
-     * @throws ValidationError never
      */
-    public static Map<String, Object> extractIdentifiers(Map<String, Object> itemData) throws ValidationError {
+    public static Map<String, Object> extractIdentifiers(Map<String, Object> itemData) {
         Map<String, Object> unit = Maps.newHashMap();
         unit.put(Ontology.IDENTIFIER_KEY, itemData.get(OBJECT_IDENTIFIER));
         if (itemData.get(Ontology.OTHER_IDENTIFIERS) != null) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/MissingParentUnitIdEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/MissingParentUnitIdEadTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.importers.ead;
+
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.base.AbstractImporterTest;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+
+public class MissingParentUnitIdEadTest extends AbstractImporterTest {
+
+    @Test
+    public void testImportItems() throws Exception {
+        String ead = "missing-parent-unitid-ead.xml";
+        InputStream ios = ClassLoader.getSystemResourceAsStream(ead);
+        try {
+            saxImportManager(EadImporter.class, EadHandler.class).importInputStream(ios, "Test");
+            fail("Import with " + ead + " should have thrown a validation error");
+        } catch (ValidationError ex) {
+            assertThat(ex.getMessage(), containsString("Parent item has missing identifier"));
+        }
+    }
+}

--- a/ehri-io/src/test/resources/missing-parent-unitid-ead.xml
+++ b/ehri-io/src/test/resources/missing-parent-unitid-ead.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN" "http://lcweb2.loc.gov/xmlcommon/dtds/ead2002/ead.dtd">
+
+<ead>
+	<eadheader>
+		<eadid>C00001</eadid>
+		<filedesc>
+			<titlestmt>
+				<titleproper encodinganalog="Title">Test EAD Item</titleproper>
+			</titlestmt>
+		</filedesc>
+	</eadheader>
+	<archdesc level="collection" relatedencoding="ISAD(G)v2">
+		<did>
+            <unittitle>Parent</unittitle>
+		</did>
+		<dsc type="combined">
+            <c01>
+				<did>
+					<unitid>c1</unitid>
+				</did>
+			</c01>
+		</dsc>
+	</archdesc>
+</ead>


### PR DESCRIPTION
This prevents NPE on id generation.

Fixes #414 