### PR TITLE
Deprecate GraphQL topLevelDocumentaryUnits field

### DIFF
--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/messages.properties
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/messages.properties
@@ -57,6 +57,7 @@ graphl.field.description.description=Fetch the description at given the given in
 
 graphql.argument.after.description=Fetch items after this cursor
 graphql.argument.all=Fetch all lower level items, not just those at the next level
+graphql.argument.topLevel=Fetch only top-level items, not items at all levels
 graphql.argument.at.description=The description's 1-based index index (default: 1)
 graphql.argument.first.description=The number of items to fetch
 graphql.argument.from.description=Fetch items from this cursor
@@ -128,6 +129,7 @@ root.connection.cvocConcept.description=A page of concept items
 root.connection.cvocVocabulary.description=A page of vocabulary items
 root.connection.documentaryUnit.description=A page of documentary unit items
 root.connection.documentaryUnit.topLevel.description=A page of top level documentary unit items
+root.connection.documentaryUnit.topLevel.deprecationReason=Use 'topLevel' argument to 'documentaryUnits' field instead
 root.connection.historicalAgent.description=A page of historical agents
 root.connection.link.description=A page of links
 root.connection.repository.description=A page of repositories

--- a/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
@@ -120,6 +120,12 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
                 .path("annotations").path(0).path("field").textValue());
         assertEquals("Mike", data.path("data").path("c3")
                 .path("annotations").path(0).path("by").textValue());
+        assertFalse(data.path("data").path("topLevelOnly")
+                .path("items").path(0).path("id").isMissingNode());
+        assertEquals(3, data.path("data").path("topLevelOnly")
+                .path("items").size());
+        assertEquals(5, data.path("data").path("allLevels")
+                .path("items").size());
         assertFalse(data.path("data").path("topLevelDocumentaryUnits")
                 .path("items").path(0).path("id").isMissingNode());
         assertFalse(data.path("data").path("wrongType").isMissingNode());

--- a/ehri-ws-graphql/src/test/resources/logback-test.xml
+++ b/ehri-ws-graphql/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="eu.ehri" level="${ehri.log.level:-info}" />
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -132,6 +132,18 @@ query test {
         }
     }
 
+    topLevelOnly: documentaryUnits(topLevel: true) {
+        items {
+            id
+        }
+    }
+
+    allLevels: documentaryUnits(topLevel: false) {
+        items {
+            id
+        }
+    }
+
     documentaryUnits(first: 10) {
         items {
             parent {


### PR DESCRIPTION
Henceforth should use topLevel param on documentaryUnits fieldinstead.

Fixes #368