### PR TITLE
An another integrity check to the bundle to prevent internal dup ids

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Bundle.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -609,6 +610,18 @@ public final class Bundle implements NestableData<Bundle> {
      */
     public boolean forAny(Predicate<Bundle> f) {
         return find(f).isPresent();
+    }
+
+    /**
+     * Run a function for every item in the bundle, including the top level.
+     *
+     * @param f a consumer function
+     */
+    public void forEach(Consumer<Bundle> f) {
+        f.accept(this);
+        for (Map.Entry<String, Bundle> rel : getRelations().entries()) {
+            rel.getValue().forEach(f);
+        }
     }
 
     public Optional<Bundle> find(Predicate<Bundle> f) {

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/messages.properties
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/messages.properties
@@ -25,3 +25,4 @@ BundleValidator.missingIdForUpdate=No identifier given for update operation
 BundleValidator.missingTypeAnnotation=No EntityType annotation: {0}
 BundleValidator.uniquenessError=Property already exists and must be unique: ''{0}''
 BundleValidator.invalidFieldValue=Property value must be one of {0}, was: {1}
+BundleValidator.duplicateId=Duplicate ID: {0}

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/messages_en_GB.properties
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/messages_en_GB.properties
@@ -24,3 +24,5 @@ BundleValidator.missingIdForCreate=No identifier given for create operation.
 BundleValidator.missingIdForUpdate=No identifier given for update operation.
 BundleValidator.missingTypeAnnotation=No EntityType annotation: {0}
 BundleValidator.uniquenessError=Property already exists and must be unique: ''{0}''
+BundleValidator.duplicateId=Duplicate ID: {0}
+

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/BundleTest.java
@@ -36,10 +36,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiPredicate;
 
 import static org.junit.Assert.*;
@@ -397,7 +394,7 @@ public class BundleTest {
     }
 
     @Test
-    public void testMapData() throws Exception {
+    public void testMap() throws Exception {
         Bundle n = bundle.map(d -> {
            Map<String,Object> nd = Maps.newHashMap();
            for (Map.Entry<String,Object> e : d.getData().entrySet()) {
@@ -410,14 +407,21 @@ public class BundleTest {
     }
 
     @Test
-    public void testForAnyData() throws Exception {
+    public void testForAny() throws Exception {
         assertTrue(bundle.forAny(d -> d.getDataValue(Ontology.LANGUAGE) != null));
         assertTrue(bundle.forAny(d -> "foobar".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))));
         assertFalse(bundle.forAny(d -> "test".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))));
     }
 
     @Test
-    public void testFindData() throws Exception {
+    public void testForEach() throws Exception {
+        List<String> ids = Lists.newArrayList();
+        bundle.generateIds(Collections.emptyList()).forEach(d -> ids.add(d.getId()));
+        assertEquals(Lists.newArrayList("foobar", "foobar.en"), ids);
+    }
+
+    @Test
+    public void testFind() throws Exception {
         assertTrue(bundle.find(d -> d.getDataValue(Ontology.LANGUAGE) != null).isPresent());
         assertTrue(bundle.find(d -> "foobar".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))).isPresent());
         assertFalse(bundle.find(d -> "test".equals(d.getDataValue(Ontology.IDENTIFIER_KEY))).isPresent());


### PR DESCRIPTION
This could happen if, e.g., two descriptions had the same identifier.