### PR TITLE
Update Jackson versions

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -166,12 +166,17 @@
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>
             <artifactId>zjsonpatch</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.6</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
             <artifactId>ehri-definitions</artifactId>
             <version>${project.parent.version} </version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
-            <version>2.8.3</version>
+            <version>2.9.7</version>
         </dependency>
 
         <dependency>

--- a/ehri-ws-graphql/pom.xml
+++ b/ehri-ws-graphql/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.7.4</version>
+            <version>2.9.7</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Should prevent a binary incompatibility w/ some later versions of Neo4j.