### PR TITLE
Add (optional) hasLinkSource relationship for directional links.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/api/Api.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/Api.java
@@ -202,7 +202,7 @@ public interface Api {
      * @return the dependent item frame
      */
     <T extends Accessible> T createDependent(String parentId, Bundle data,
-            Class<T> cls, Optional<String> logMessage)
+                                             Class<T> cls, Optional<String> logMessage)
             throws ItemNotFound, PermissionDenied, ValidationError;
 
     /**
@@ -216,31 +216,37 @@ public interface Api {
      * @return the dependent item frame
      */
     <T extends Accessible> Mutation<T> updateDependent(String parentId, Bundle data,
-            Class<T> cls, Optional<String> logMessage)
+                                                       Class<T> cls, Optional<String> logMessage)
             throws ItemNotFound, PermissionDenied, ValidationError, SerializationError;
 
     /**
      * Create a link between two items.
      *
-     * @param targetId1 the identifier of a Accessible target of this Annotation
-     * @param targetId2 the identifier of a Annotator source of this Annotation
-     * @param bundle    the annotation itself
+     * @param source      the identifier of a Accessible source of this Annotation
+     * @param target      the identifier of a Annotator target of this Annotation
+     * @param bundle      the annotation itself
+     * @param directional whether the link is directional or not
      * @return a new link
      */
-    Link createLink(String targetId1, String targetId2, List<String> bodies, Bundle bundle,
-            Collection<Accessor> accessibleTo, Optional<String> logMessage) throws ItemNotFound, ValidationError,
+    Link createLink(String source,
+                    String target,
+                    List<String> bodies,
+                    Bundle bundle,
+                    boolean directional,
+                    Collection<Accessor> accessibleTo,
+                    Optional<String> logMessage) throws ItemNotFound, ValidationError,
             PermissionDenied;
 
     /**
      * Create a link between two items, along with an access point on the given description.
      *
-     * @param targetId1 the identifier of a Accessible target of this Annotation
-     * @param targetId2 the identifier of a Annotator source of this Annotation
+     * @param source the identifier of a Accessible target of this Annotation
+     * @param target the identifier of a Annotator source of this Annotation
      * @param bundle    the annotation itself
      * @return a new link
      */
-    Link createAccessPointLink(String targetId1, String targetId2, String descriptionId, String bodyName,
-            AccessPointType bodyType, Bundle bundle, Collection<Accessor> accessibleTo, Optional<String> logMessage)
+    Link createAccessPointLink(String source, String target, String descriptionId, String bodyName,
+                               AccessPointType bodyType, Bundle bundle, Collection<Accessor> accessibleTo, Optional<String> logMessage)
             throws ItemNotFound, ValidationError, PermissionDenied;
 
     /**
@@ -255,7 +261,7 @@ public interface Api {
      */
 
     Annotation createAnnotation(String id, String did, Bundle bundle,
-            Collection<Accessor> accessibleTo, Optional<String> logMessage)
+                                Collection<Accessor> accessibleTo, Optional<String> logMessage)
             throws PermissionDenied, AccessDenied, ValidationError, ItemNotFound;
 
     /**
@@ -308,7 +314,7 @@ public interface Api {
          * @param permissionSet the new permissions
          */
         InheritedGlobalPermissionSet setGlobalPermissionMatrix(Accessor userOrGroup,
-                GlobalPermissionSet permissionSet) throws PermissionDenied;
+                                                               GlobalPermissionSet permissionSet) throws PermissionDenied;
 
 
         void setAccessors(Accessible entity, Set<Accessor> accessors) throws PermissionDenied;
@@ -322,7 +328,7 @@ public interface Api {
          * @return the new inherited item permission set
          */
         InheritedItemPermissionSet setItemPermissions(Accessible item, Accessor accessor,
-                Set<PermissionType> permissionList)
+                                                      Set<PermissionType> permissionList)
                 throws PermissionDenied;
 
         /**

--- a/ehri-core/src/main/java/eu/ehri/project/models/Link.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Link.java
@@ -19,13 +19,14 @@
 
 package eu.ehri.project.models;
 
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.modules.javahandler.JavaHandler;
+import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import eu.ehri.project.definitions.Ontology;
-import eu.ehri.project.models.annotations.EntityType;
-import eu.ehri.project.models.annotations.Fetch;
-import eu.ehri.project.models.annotations.Indexed;
-import eu.ehri.project.models.annotations.Mandatory;
+import eu.ehri.project.models.annotations.*;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Annotatable;
@@ -44,14 +45,42 @@ public interface Link extends Promotable, Temporal, Annotatable {
     @Adjacency(label = Ontology.LINK_HAS_LINKER)
     UserProfile getLinker();
 
-    @Adjacency(label = Ontology.LINK_HAS_LINKER)
+    @UniqueAdjacency(label = Ontology.LINK_HAS_LINKER)
     void setLinker(Accessor accessor);
 
+    /**
+     * Fetch the source of this link, or null if the link
+     * is not directional.
+     *
+     * @return a linkable item, or null
+     */
+    @Fetch(value = Ontology.LINK_HAS_SOURCE, ifLevel = 0, numLevels = 1)
+    @Adjacency(label = Ontology.LINK_HAS_SOURCE)
+    Linkable getLinkSource();
+
+    /**
+     * Set the source of this link if it is directional.
+     *
+     * @param entity a linkable item
+     */
+    @UniqueAdjacency(label = Ontology.LINK_HAS_SOURCE)
+    void setLinkSource(Linkable entity);
+
+    /**
+     * Fetch the targets attached to this link.
+     *
+     * @return an iterable of linkable items
+     */
     @Fetch(value = Ontology.LINK_HAS_TARGET, ifLevel = 0, numLevels = 1)
     @Adjacency(label = Ontology.LINK_HAS_TARGET)
     Iterable<Linkable> getLinkTargets();
 
-    @Adjacency(label = Ontology.LINK_HAS_TARGET)
+    /**
+     * Add a target to this link.
+     *
+     * @param entity a linkable item
+     */
+    @UniqueAdjacency(label = Ontology.LINK_HAS_TARGET)
     void addLinkTarget(Linkable entity);
 
     @Adjacency(label = Ontology.LINK_HAS_TARGET)
@@ -61,7 +90,7 @@ public interface Link extends Promotable, Temporal, Annotatable {
     @Adjacency(label = Ontology.LINK_HAS_BODY)
     Iterable<Accessible> getLinkBodies();
 
-    @Adjacency(label = Ontology.LINK_HAS_BODY)
+    @UniqueAdjacency(label = Ontology.LINK_HAS_BODY)
     void addLinkBody(Accessible entity);
 
     @Mandatory

--- a/ehri-definitions/src/main/java/eu/ehri/project/definitions/Ontology.java
+++ b/ehri-definitions/src/main/java/eu/ehri/project/definitions/Ontology.java
@@ -45,6 +45,7 @@ public class Ontology {
     // Links
     public static final String LINK_HAS_BODY = "hasLinkBody";
     public static final String LINK_HAS_TARGET = "hasLinkTarget";
+    public static final String LINK_HAS_SOURCE = "hasLinkSource";
     public static final String LINK_HAS_LINKER = "hasLinker";
     public static final String LINK_HAS_TYPE = "type";
     public static final String LINK_HAS_FIELD = "field";

--- a/ehri-io/src/main/java/eu/ehri/project/importers/links/LinkResolver.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/links/LinkResolver.java
@@ -17,7 +17,6 @@ import eu.ehri.project.exceptions.DeserializationError;
 import eu.ehri.project.exceptions.PermissionDenied;
 import eu.ehri.project.exceptions.SerializationError;
 import eu.ehri.project.exceptions.ValidationError;
-import eu.ehri.project.importers.util.ImportHelpers;
 import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
@@ -27,7 +27,6 @@ import eu.ehri.project.models.AccessPointType;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
 import eu.ehri.project.models.Link;
-import eu.ehri.project.models.UnknownProperty;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.Linkable;
 import eu.ehri.project.models.cvoc.Concept;

--- a/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/LinkResource.java
@@ -36,15 +36,7 @@ import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.persistence.Bundle;
 import org.neo4j.graphdb.GraphDatabaseService;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -109,7 +101,8 @@ public class LinkResource extends AbstractAccessibleResource<Link>
             @QueryParam(SOURCE_PARAM) String source,
             @QueryParam(TARGET_PARAM) String target,
             @QueryParam(BODY_PARAM) List<String> bodies,
-            @QueryParam(ACCESSOR_PARAM) List<String> accessors)
+            @QueryParam(ACCESSOR_PARAM) List<String> accessors,
+            @QueryParam("directional") @DefaultValue("false") boolean directional)
             throws PermissionDenied, ValidationError,
             DeserializationError, ItemNotFound {
         try (final Tx tx = beginTx()) {
@@ -117,8 +110,9 @@ public class LinkResource extends AbstractAccessibleResource<Link>
                 throw new DeserializationError("Both source and target must be provided");
             }
             UserProfile user = getCurrentUser();
-            Link link = api().createLink(target,
-                    source, bodies, bundle, getAccessors(accessors, user), getLogMessage());
+            Link link = api().createLink(
+                    source, target, bodies, bundle, directional,
+                    getAccessors(accessors, user), getLogMessage());
             Response response = creationResponse(link);
             tx.success();
             return response;


### PR DESCRIPTION
Also some parameter renaming.

This makes e.g. copy links more useful for analysis. The implementation is backwards compatible so the source (hasLinkSource) is  *also* a target (hasLinkTarget). This is a bit redundant and requires extra checks in some places, but is better than having two incompatible types of links.
