### PR TITLE
Extend import logs to contain a mapping of source -> item IDs

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>build</artifactId>
@@ -62,6 +62,7 @@
                             <include>com.fasterxml.uuid:*</include>
                             <include>com.fasterxml.jackson.core:*</include>
                             <include>com.fasterxml.jackson.dataformat:*</include>
+                            <include>com.fasterxml.jackson.datatype:*</include>
                             <include>com.google.guava:guava</include>
                             <include>commons-cli:commons-cli</include>
                             <include>commons-codec:commons-codec</include>
@@ -79,6 +80,18 @@
                             <include>org.reactivestreams:reactive-streams</include>
                         </includes>
                     </artifactSet>
+
+                    <!-- Exclude module-info.class files from the jar. These are compiled for Java 9 and
+                         cause problems when the plugin is loaded by Neo4j on Java 8. At the time of writing
+                         it was Jackson 2.10.* that includes the module-info.java file. -->
+                    <filters>
+                        <filter>
+                            <artifact>com.fasterxml.jackson.*:*</artifact>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
 
                     <!-- Concatenate reference.conf files in each module into a single file. -->
                     <transformers>
@@ -102,6 +115,7 @@
 
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
+                <version>3.5.1</version>
                 <configuration>
                     <generateReports>false</generateReports>
                 </configuration>

--- a/ehri-cli/pom.xml
+++ b/ehri-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <artifactId>ehri-cli</artifactId>
     <name>Command Line Tools</name>

--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <artifactId>ehri-core</artifactId>
     <packaging>jar</packaging>
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>
             <artifactId>zjsonpatch</artifactId>
-            <version>0.4.6</version>
+            <version>0.4.11</version>
         </dependency>
         <dependency>
             <groupId>ehri-project</groupId>
@@ -181,8 +181,13 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/ehri-cypher/pom.xml
+++ b/ehri-cypher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <artifactId>ehri-io</artifactId>
 
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
-            <version>2.9.7</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/ehri-io/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/cvoc/JenaSkosImporter.java
@@ -268,8 +268,9 @@ public final class JenaSkosImporter implements SkosImporter {
             model.add(SKOS.broader, OWL.inverseOf, SKOS.narrower);
 
             model.read(ios, null, format);
-            OntClass conceptClass = model.getOntClass(SkosRDFVocabulary.CONCEPT.getURI().toString());
-            logger.trace("in import file: {}", SkosRDFVocabulary.CONCEPT.getURI());
+            URI uri = SkosRDFVocabulary.CONCEPT.getURI();
+            OntClass conceptClass = model.getOntClass(uri.toString());
+            logger.trace("in import file: {}", uri);
             Map<Resource, Concept> imported = Maps.newHashMap();
 
             ExtendedIterator<? extends OntResource> itemIterator = conceptClass.listInstances();
@@ -280,13 +281,14 @@ public final class JenaSkosImporter implements SkosImporter {
                     try {
                         Mutation<Concept> graphConcept = importConcept(item);
                         imported.put(item, graphConcept.getNode());
+                        String graphId = graphConcept.getNode().getId();
 
                         switch (graphConcept.getState()) {
                             case UNCHANGED:
-                                log.addUnchanged();
+                                log.addUnchanged(uri.toString(), graphId);
                                 break;
                             case CREATED:
-                                log.addCreated();
+                                log.addCreated(uri.toString(), graphId);
                                 eventContext.addSubjects(graphConcept.getNode());
                                 break;
                             case UPDATED:
@@ -295,7 +297,7 @@ public final class JenaSkosImporter implements SkosImporter {
                                             "Item '%s' was updated but import manager does not allow updates",
                                             graphConcept.getNode().getId()));
                                 }
-                                log.addUpdated();
+                                log.addUpdated(uri.toString(), graphId);
                                 eventContext.addSubjects(graphConcept.getNode());
                                 break;
                         }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/links/LinkImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/links/LinkImporter.java
@@ -104,7 +104,7 @@ public class LinkImporter {
                 }
 
                 eventContext.addSubjects(link);
-                log.addCreated();
+                log.addCreated("-", link.getId());
             } catch (ItemNotFound e) {
                 logger.error("Item not found at row {}: {}", i, e.getValue());
                 log.addError(e.getValue(), e.getMessage());

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -77,7 +77,7 @@ public class CsvImportManager extends AbstractImportManager {
                     .newInstance(framedGraph, permissionScope, actioner, log);
             logger.trace("importer of class {}", importer.getClass());
 
-            importer.addCallback(mutation -> defaultImportCallback(log, context, mutation));
+            importer.addCallback(mutation -> defaultImportCallback(log, tag, context, mutation));
             importer.addErrorCallback(ex -> defaultErrorCallback(log, ex));
 
             CsvSchema schema = CsvSchema.emptySchema().withColumnSeparator(VALUE_DELIMITER).withHeader();

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/ImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/ImportManager.java
@@ -60,7 +60,7 @@ public interface ImportManager {
      */
     default ImportLog importInputStream(InputStream stream, String logMessage)
             throws IOException, InputParseError, ValidationError {
-        return importInputStream(stream, null, logMessage);
+        return importInputStream(stream, "-", logMessage);
     }
 
     /**

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -67,15 +67,15 @@ public class SaxImportManager extends AbstractImportManager {
      * @param actioner the actioner
      */
     public SaxImportManager(FramedGraph<?> graph,
-            PermissionScope scope,
-            Actioner actioner,
-            boolean tolerant,
-            boolean allowUpdates,
-            String defaultLang,
-            Class<? extends ItemImporter<?,?>> importerClass,
-            Class<? extends SaxXmlHandler> handlerClass,
-            XmlImportProperties properties,
-            List<ImportCallback> callbacks) {
+                            PermissionScope scope,
+                            Actioner actioner,
+                            boolean tolerant,
+                            boolean allowUpdates,
+                            String defaultLang,
+                            Class<? extends ItemImporter<?,?>> importerClass,
+                            Class<? extends SaxXmlHandler> handlerClass,
+                            XmlImportProperties properties,
+                            List<ImportCallback> callbacks) {
         super(graph, scope, actioner, tolerant, allowUpdates, defaultLang, importerClass);
         this.handlerClass = handlerClass;
         this.properties = properties;
@@ -92,14 +92,15 @@ public class SaxImportManager extends AbstractImportManager {
      * @param actioner the actioner
      */
     public SaxImportManager(FramedGraph<?> graph,
-            PermissionScope scope, Actioner actioner,
-            boolean tolerant,
-            boolean allowUpdates,
-            String defaultLang,
-            Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass,
-            List<ImportCallback> callbacks) {
-        this(graph, scope, actioner, tolerant, allowUpdates, defaultLang, importerClass, handlerClass, null,
-                callbacks);
+                            PermissionScope scope,
+                            Actioner actioner,
+                            boolean tolerant,
+                            boolean allowUpdates,
+                            String defaultLang,
+                            Class<? extends ItemImporter<?,?>> importerClass,
+                            Class<? extends SaxXmlHandler> handlerClass,
+                            List<ImportCallback> callbacks) {
+        this(graph, scope, actioner, tolerant, allowUpdates, defaultLang, importerClass, handlerClass, null, callbacks);
     }
 
     /**
@@ -110,15 +111,15 @@ public class SaxImportManager extends AbstractImportManager {
      * @param actioner the actioner
      */
     public SaxImportManager(FramedGraph<?> graph,
-            PermissionScope scope, Actioner actioner,
-            boolean tolerant,
-            boolean allowUpdates,
-            String defaultLang,
-            Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass,
-            XmlImportProperties properties) {
-        this(graph, scope, actioner, tolerant, allowUpdates, defaultLang, importerClass, handlerClass,
-                properties,
-                Lists.<ImportCallback>newArrayList());
+                            PermissionScope scope,
+                            Actioner actioner,
+                            boolean tolerant,
+                            boolean allowUpdates,
+                            String defaultLang,
+                            Class<? extends ItemImporter<?,?>> importerClass,
+                            Class<? extends SaxXmlHandler> handlerClass,
+                            XmlImportProperties properties) {
+        this(graph, scope, actioner, tolerant, allowUpdates, defaultLang, importerClass, handlerClass, properties, Lists.newArrayList());
     }
 
     /**
@@ -129,11 +130,11 @@ public class SaxImportManager extends AbstractImportManager {
      * @param actioner the actioner
      */
     public SaxImportManager(FramedGraph<?> graph,
-            PermissionScope scope, Actioner actioner,
-            Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
-        this(graph, scope, actioner, false, false,
-                config.getString("defaultLang"),
-                importerClass, handlerClass, Lists.<ImportCallback>newArrayList());
+                            PermissionScope scope,
+                            Actioner actioner,
+                            Class<? extends ItemImporter<?,?>> importerClass,
+                            Class<? extends SaxXmlHandler> handlerClass) {
+        this(graph, scope, actioner, false, false, config.getString("defaultLang"), importerClass, handlerClass, Lists.newArrayList());
     }
 
     /**
@@ -156,7 +157,7 @@ public class SaxImportManager extends AbstractImportManager {
                 importer.addCallback(callback);
             }
 
-            importer.addCallback(mutation -> defaultImportCallback(log, context, mutation));
+            importer.addCallback(mutation -> defaultImportCallback(log, tag, context, mutation));
             importer.addErrorCallback(ex -> defaultErrorCallback(log, ex));
 
             //TODO decide which handler to use, HandlerFactory? now part of constructor ...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ImportLogTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ImportLogTest.java
@@ -1,0 +1,35 @@
+package eu.ehri.project.importers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.Test;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class ImportLogTest {
+    private final ObjectMapper mapper = new JsonMapper();
+
+    @Test
+    public void testDeserialize() throws Exception {
+        ImportLog log = mapper.readValue("{" +
+                "\"message\":\"test\", " +
+                "\"errors\": {}, " +
+                "\"created_keys\": {}, " +
+                "\"created\": 0," +
+                "\"updated_keys\": {}, " +
+                "\"updated\": 0," +
+                "\"unchanged_keys\": {}," +
+                "\"unchanged\": 0" +
+                "}", ImportLog.class);
+        assertEquals(new ImportLog("test"), log);
+    }
+
+    @Test
+    public void testSerialize() throws Exception {
+        ImportLog log = new ImportLog("test");
+        String json = mapper.writeValueAsString(log);
+        assertThat(json, containsString("\"created\":0"));
+    }
+}

--- a/ehri-ws-graphql/pom.xml
+++ b/ehri-ws-graphql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.9.7</version>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/ehri-ws-oaipmh/pom.xml
+++ b/ehri-ws-oaipmh/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-ws/pom.xml
+++ b/ehri-ws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.11</version>
+        <version>0.13.12</version>
     </parent>
     <artifactId>ehri-ws</artifactId>
     <name>Web Service</name>

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/GlobalPermissionSetProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/GlobalPermissionSetProvider.java
@@ -39,7 +39,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 
 
 @Provider
@@ -54,7 +53,7 @@ public class GlobalPermissionSetProvider implements MessageBodyReader<GlobalPerm
     @Override
     public GlobalPermissionSet readFrom(Class<GlobalPermissionSet> bundleClass, Type type, Annotation[] annotations,
             MediaType mediaType, MultivaluedMap<String,
-            String> headers, InputStream stream) throws IOException, WebApplicationException {
+            String> headers, InputStream stream) throws WebApplicationException {
 
         try {
             return parseMatrix(stream);
@@ -65,8 +64,8 @@ public class GlobalPermissionSetProvider implements MessageBodyReader<GlobalPerm
 
     private GlobalPermissionSet parseMatrix(InputStream json) throws DeserializationError {
         try {
-            TypeReference<HashMap<ContentTypes, List<PermissionType>>> typeRef = new TypeReference<HashMap<ContentTypes,
-                    List<PermissionType>>>() {
+            TypeReference<HashMap<ContentTypes, Collection<PermissionType>>> typeRef = new TypeReference<HashMap<ContentTypes,
+                    Collection<PermissionType>>>() {
             };
             HashMap<ContentTypes, Collection<PermissionType>> globals = mapper.readValue(json, typeRef);
             return GlobalPermissionSet.from(globals);

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/JsonMessageBodyHandler.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/JsonMessageBodyHandler.java
@@ -1,8 +1,9 @@
 package eu.ehri.extension.providers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 
 public interface JsonMessageBodyHandler {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
 }

--- a/ehri-ws/src/main/java/eu/ehri/extension/providers/TableProvider.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/providers/TableProvider.java
@@ -58,12 +58,12 @@ import java.util.List;
 @Consumes({MediaType.APPLICATION_JSON, AbstractResource.CSV_MEDIA_TYPE})
 public class TableProvider implements MessageBodyWriter<Table>, MessageBodyReader<Table>, JsonMessageBodyHandler {
 
-    private static CsvMapper csvMapper = new CsvMapper()
+    private static final CsvMapper csvMapper = new CsvMapper()
             .enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING)
             .enable(CsvParser.Feature.WRAP_AS_ARRAY);
-    private static CsvSchema csvSchema = csvMapper.schemaFor(List.class);
+    private static final CsvSchema csvSchema = csvMapper.schemaFor(List.class);
 
-    private static TypeReference<List<List<String>>> typeRef = new TypeReference<List<List<String>>>() {
+    private static final TypeReference<List<List<String>>> typeRef = new TypeReference<List<List<String>>>() {
     };
 
     @Override
@@ -94,7 +94,12 @@ public class TableProvider implements MessageBodyWriter<Table>, MessageBodyReade
     }
 
     @Override
-    public Table readFrom(Class<Table> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+    public Table readFrom(Class<Table> type,
+                          Type genericType,
+                          Annotation[] annotations,
+                          MediaType mediaType,
+                          MultivaluedMap<String, String> httpHeaders,
+                          InputStream entityStream) throws IOException, WebApplicationException {
         try {
             ObjectReader reader = mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE)
                     ? mapper.readerFor(typeRef)

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceClientTest.java
@@ -40,7 +40,10 @@ import org.junit.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -62,7 +65,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     private static final String HIERARCHICAL_EAD = "hierarchical-ead.xml";
 
     @Test
-    public void testImportSkos() throws Exception {
+    public void testImportSkos() {
         // Get the path of an EAD file
         InputStream payloadStream = ClassLoader.getSystemResourceAsStream("simple.n3");
 
@@ -124,13 +127,14 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
-    public void testImportSingleEad() throws Exception {
+    public void testImportSingleEad() {
         // Get the path of an EAD file
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream(SINGLE_EAD);
         String logText = "Testing import";
         URI uri = getImportUrl("ead", "r1", logText, false)
                 .queryParam(HANDLER_PARAM, EadHandler.class.getName())
+                .queryParam(TAG_PARAM, SINGLE_EAD)
                 .queryParam(COMMIT_PARAM, true)
                 .build();
         ImportLog log = callAs(getAdminUserProfileId(), uri)
@@ -141,11 +145,12 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
         assertEquals(1, log.getCreated());
         assertEquals(0, log.getUpdated());
         assertEquals(0, log.getUnchanged());
+        assertTrue("Tag is not in log", log.getCreatedKeys().containsKey(SINGLE_EAD));
         assertEquals(logText, log.getLogMessage().orElse(null));
     }
 
     @Test
-    public void testImportSingleEadWithValidationError() throws Exception {
+    public void testImportSingleEadWithValidationError() {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("invalid-ead.xml");
         URI uri = getImportUrl("ead", "r1", "Error test", false)
@@ -162,7 +167,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
-    public void testImportSingleEadWithValidationErrorInTolerantMode() throws Exception {
+    public void testImportSingleEadWithValidationErrorInTolerantMode() {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("invalid-ead.xml");
         URI uri = getImportUrl("ead", "r1", "Error test", true)
@@ -431,7 +436,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
-    public void testImportEag() throws Exception {
+    public void testImportEag() {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("eag.xml");
         String logText = "Testing import";
@@ -451,7 +456,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
-    public void testImportEac() throws Exception {
+    public void testImportEac() {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("eac.xml");
         String logText = "Testing import";
@@ -471,7 +476,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
-    public void testImportLinks() throws Exception {
+    public void testImportLinks() {
         Table table = Table.of(ImmutableList.of(
                 ImmutableList.of("r1", "c1", "", "associative", "", "Test"),
                 ImmutableList.of("r1", "c1", "ur1", "associative", "", "Test 2"),
@@ -492,8 +497,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
                 .queryParam(TOLERANT_PARAM, String.valueOf(tolerant));
     }
 
-    private InputStream getPayloadStream(String... resources)
-            throws URISyntaxException, UnsupportedEncodingException {
+    private InputStream getPayloadStream(String... resources) throws URISyntaxException {
         List<String> paths = Lists.newArrayList();
         for (String resourceName : resources) {
             URL resource = Resources.getResource(resourceName);

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/PermissionResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/PermissionResourceClientTest.java
@@ -280,7 +280,7 @@ public class PermissionResourceClientTest extends AbstractResourceClientTest {
     }
 
     private List<Map<String, Map<String, List<String>>>> getInheritedMatrix(String json) throws IOException {
-        TypeReference<LinkedList<HashMap<String, Map<String, List<String>>>>> typeRef = new TypeReference<LinkedList<HashMap<String, Map<String, List<String>>>>>() {
+        TypeReference<List<Map<String, Map<String, List<String>>>>> typeRef = new TypeReference<List<Map<String, Map<String, List<String>>>>>() {
         };
         return jsonMapper.readValue(json, typeRef);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
-    <version>0.13.11</version>
+    <version>0.13.12</version>
     <packaging>pom</packaging>
 
     <name>EHRI Backend</name>
@@ -119,6 +119,7 @@
 
         <neo4j.version>3.5.21</neo4j.version>
         <blueprints.version>2.6.0</blueprints.version>
+        <jackson.version>2.10.5</jackson.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This is part of work to improve the traceability of imported data. Imports that come from a streamed XML body will just have "-" as the key (standing for stdin).

As part of these changes various XML dependencies were upgraded as well.