### PR TITLE
Downgrade guava to a lower but still newer-than-before version.

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>


### PR DESCRIPTION
Version 29 seems to cause issues in the prod environment.