### PR TITLE
Set the public ID on the Sax parser and use this for errors

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/SaxXmlHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/SaxXmlHandler.java
@@ -89,7 +89,7 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
         this.importer = importer;
         this.defaultLang = defaultLang;
         this.properties = properties;
-        currentGraphPath.push(Maps.<String, Object>newHashMap());
+        currentGraphPath.push(Maps.newHashMap());
     }
 
     /**
@@ -168,7 +168,7 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
         if (needToCreateSubNode(qName)) { //a new subgraph should be created
             depth++;
             logger.trace("Pushing depth... {} -> {}", depth, qName);
-            currentGraphPath.push(Maps.<String, Object>newHashMap());
+            currentGraphPath.push(Maps.newHashMap());
         }
 
         // Store attributes that are listed in the .properties file
@@ -261,7 +261,7 @@ public abstract class SaxXmlHandler extends DefaultHandler implements LexicalHan
      * whitespace.
      */
     @Override
-    public void characters(char ch[], int start, int length) throws SAXException {
+    public void characters(char[] ch, int start, int length) {
         // NB: 'Blank' (whitespace) only strings are significant here, because
         // otherwise a sequence of character, line-break, and an entity will
         // end up being concatenated with the line-break removed. We therefore

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
@@ -259,9 +259,8 @@ public class EadHandler extends SaxXmlHandler {
                         // In order to indicate what has errored here if there's no
                         // ID we need to create one with the line number reference.
                     String path = pathIds.isEmpty() ? null : Joiner.on("/").useForNull("[null]").join(pathIds);
-                        String ref = String.format("[Item completed prior to line: %d]",
-                                locator.getLineNumber());
-                        String id = Joiner.on(" ").skipNulls().join(path, locator.getSystemId(), ref);
+                        String ref = String.format("[Item completed prior to line: %d]", locator.getLineNumber());
+                        String id = Joiner.on(" ").skipNulls().join(path, locator.getPublicId(), ref);
                         importer.handleError(new ValidationError(bundle.withId(id), ex.getErrorSet()));
                     } else {
                         importer.handleError(ex);

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -143,9 +143,7 @@ public abstract class AbstractImportManager implements ImportManager {
     @Override
     public ImportLog importJson(InputStream json, String logMessage) throws ValidationError, InputParseError {
         Preconditions.checkNotNull(json);
-        URL url = null;
-        try (final JsonParser parser = factory
-                .createParser(new InputStreamReader(json, Charsets.UTF_8))) {
+        try (final JsonParser parser = factory.createParser(new InputStreamReader(json, Charsets.UTF_8))) {
 
             JsonToken jsonToken = parser.nextValue();
             if (!parser.isExpectedStartObjectToken()) {
@@ -163,13 +161,13 @@ public abstract class AbstractImportManager implements ImportManager {
                 if (name == null) {
                     break;
                 }
-                url = new URL(parser.nextTextValue());
+                URL url = new URL(parser.nextTextValue());
 
                 currentFile = name;
                 try (InputStream stream = url.openStream()) {
                     logger.info("Importing URL with identifier: {}", name);
                     importInputStream(stream, currentFile, action, log);
-                } catch (ValidationError | SSLException | SocketException e) {
+                } catch (ValidationError | SSLException | MalformedURLException | SocketException e) {
                     log.addError(formatErrorLocation(), e.getMessage());
                     if (!tolerant) {
                         throw e;
@@ -180,8 +178,6 @@ public abstract class AbstractImportManager implements ImportManager {
             // Only mark the transaction successful if we're
             // actually accomplished something.
             return log.committing(action);
-        } catch (MalformedURLException e) {
-            throw new InputParseError("Malformed URL: " + url);
         } catch (JsonParseException e) {
             throw new InputParseError("Error reading JSON", e);
         } catch (IOException e) {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -178,6 +178,7 @@ public class SaxImportManager extends AbstractImportManager {
             SAXParser saxParser = spf.newSAXParser();
             saxParser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
             InputSource src = new InputSource(stream);
+            src.setPublicId(tag);
             src.setSystemId(tag);
             saxParser.parse(src, handler);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException |


### PR DESCRIPTION
The system ID gets resolved to a local file URL, which is wrong if the source was e.g. an URL.

Other minor cleanups.