### PR TITLE
Continue to develop bulk-deletion API, w/ changes to WS API

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/api/Api.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/Api.java
@@ -187,6 +187,19 @@ public interface Api {
             throws ItemNotFound, PermissionDenied, SerializationError;
 
     /**
+     * Delete all item's within the given item's permission scope.
+     *
+     * @param parentId   the parent ID
+     * @param all        whether to recursively delete children of this item.
+     * @param logMessage an optional log message
+     * @return the IDs of delete items
+     * @throws HierarchyError if {{all}} is not given and a child item has children
+     *                        of its own.
+     */
+    List<String> deleteChildren(String parentId, boolean all, Optional<String> logMessage)
+            throws ItemNotFound, PermissionDenied, SerializationError, HierarchyError;
+
+    /**
      * Create a dependent item, belonging to the given parent.
      *
      * @param parentId   the parent ID
@@ -237,7 +250,7 @@ public interface Api {
      *
      * @param source the identifier of a Accessible target of this Annotation
      * @param target the identifier of a Annotator source of this Annotation
-     * @param bundle    the annotation itself
+     * @param bundle the annotation itself
      * @return a new link
      */
     Link createAccessPointLink(String source, String target, String descriptionId, String bodyName,

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiCrudTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiCrudTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.api;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import eu.ehri.project.acl.AclManager;
 import eu.ehri.project.acl.ContentTypes;
 import eu.ehri.project.acl.PermissionType;
@@ -37,6 +38,8 @@ import eu.ehri.project.test.TestData;
 import org.junit.Test;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -226,5 +229,16 @@ public class ApiCrudTest extends AbstractFixtureTest {
 
         int deleted = api(validUser).delete(c4.getId());
         assertEquals(shouldDelete, deleted);
+    }
+
+    @Test(expected = HierarchyError.class)
+    public void testDeleteChildrenWithError() throws Exception {
+        api(validUser).deleteChildren(item.getId(), false, Optional.empty());
+    }
+
+    @Test
+    public void testDeleteChildren() throws Exception {
+        List<String> out = api(validUser).deleteChildren(item.getId(), true, Optional.empty());
+        assertEquals(Lists.newArrayList("c2", "c3"), out);
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingCrudTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingCrudTest.java
@@ -19,7 +19,10 @@
 
 package eu.ehri.project.api;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import eu.ehri.project.definitions.EventTypes;
+import eu.ehri.project.exceptions.HierarchyError;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.events.SystemEvent;
@@ -103,5 +106,14 @@ public class ApiLoggingCrudTest extends AbstractFixtureTest {
         List<Version> r1vl = Lists.newArrayList(loggingApi(validUser).versionManager()
                 .versionsAtDeletion(EntityClass.REPOSITORY, null, null));
         assertEquals(1, r1vl.size());
+    }
+
+    @Test
+    public void testDeleteChildren() throws Exception {
+        List<String> out = loggingApi(validUser).deleteChildren(item.getId(), true, Optional.empty());
+        assertEquals(Lists.newArrayList("c2", "c3"), out);
+        SystemEvent event = am.getLatestGlobalEvent();
+        assertEquals(EventTypes.deletion, event.getEventType());
+        assertEquals(Iterables.size(event.getPriorVersions()), 2);
     }
 }

--- a/ehri-ws/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/AuthoritativeSetResource.java
@@ -133,13 +133,14 @@ public class AuthoritativeSetResource extends
         }
     }
 
-    @Override
     @DELETE
-    @Path("{id:[^/]+}/all")
+    @Path("{id:[^/]+}/list")
     @Produces({MediaType.APPLICATION_JSON, CSV_MEDIA_TYPE})
-    public Table deleteAll(@PathParam("id") String id) throws ItemNotFound, PermissionDenied, ValidationError {
+    @Override
+    public Table deleteChildren(@PathParam("id") String id, @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
+            throws ItemNotFound, PermissionDenied, ValidationError, HierarchyError {
         try (final Tx tx = beginTx()) {
-            Table out = deleteAll(id, AuthoritativeSet::getAllContainedItems);
+            Table out = deleteContents(id, all);
             tx.success();
             return out;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/CountryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CountryResource.java
@@ -126,13 +126,14 @@ public class CountryResource
         }
     }
 
-    @Override
     @DELETE
-    @Path("{id:[^/]+}/all")
+    @Path("{id:[^/]+}/list")
     @Produces({MediaType.APPLICATION_JSON, CSV_MEDIA_TYPE})
-    public Table deleteAll(@PathParam("id") String id) throws ItemNotFound, PermissionDenied, ValidationError {
+    @Override
+    public Table deleteChildren(@PathParam("id") String id, @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
+            throws ItemNotFound, PermissionDenied, ValidationError, HierarchyError {
         try (final Tx tx = beginTx()) {
-            Table out = deleteAll(id, Country::getAllContainedItems);
+            Table out = deleteContents(id, all);
             tx.success();
             return out;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/CvocConceptResource.java
@@ -101,7 +101,7 @@ public class CvocConceptResource extends AbstractAccessibleResource<Concept>
     @DELETE
     @Path("{id:[^/]+}/all")
     @Override
-    public Table deleteAll(@PathParam("id") String id)
+    public Table deleteChildren(@PathParam("id") String id, boolean all)
             throws PermissionDenied, ItemNotFound, ValidationError {
         try {
             // NB: While it has hierarchical behaviour this does not

--- a/ehri-ws/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/DocumentaryUnitResource.java
@@ -146,13 +146,14 @@ public class DocumentaryUnitResource
         }
     }
 
-    @Override
     @DELETE
-    @Path("{id:[^/]+}/all")
+    @Path("{id:[^/]+}/list")
     @Produces({MediaType.APPLICATION_JSON, CSV_MEDIA_TYPE})
-    public Table deleteAll(@PathParam("id") String id) throws ItemNotFound, PermissionDenied, ValidationError {
+    @Override
+    public Table deleteChildren(@PathParam("id") String id, @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
+            throws ItemNotFound, PermissionDenied, ValidationError, HierarchyError {
         try (final Tx tx = beginTx()) {
-            Table out = deleteAll(id, DocumentaryUnit::getAllContainedItems);
+            Table out = deleteContents(id, all);
             tx.success();
             return out;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/RepositoryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/RepositoryResource.java
@@ -123,13 +123,14 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
         }
     }
 
-    @Override
     @DELETE
-    @Path("{id:[^/]+}/all")
+    @Path("{id:[^/]+}/list")
     @Produces({MediaType.APPLICATION_JSON, CSV_MEDIA_TYPE})
-    public Table deleteAll(@PathParam("id") String id) throws ItemNotFound, PermissionDenied, ValidationError {
+    @Override
+    public Table deleteChildren(@PathParam("id") String id, @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
+            throws ItemNotFound, PermissionDenied, ValidationError, HierarchyError {
         try (final Tx tx = beginTx()) {
-            Table out = deleteAll(id, Repository::getAllContainedItems);
+            Table out = deleteContents(id, all);
             tx.success();
             return out;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/VocabularyResource.java
@@ -123,13 +123,14 @@ public class VocabularyResource extends AbstractAccessibleResource<Vocabulary>
         }
     }
 
-    @Override
     @DELETE
-    @Path("{id:[^/]+}/all")
+    @Path("{id:[^/]+}/list")
     @Produces({MediaType.APPLICATION_JSON, CSV_MEDIA_TYPE})
-    public Table deleteAll(@PathParam("id") String id) throws ItemNotFound, PermissionDenied, ValidationError {
+    @Override
+    public Table deleteChildren(@PathParam("id") String id, @QueryParam(ALL_PARAM) @DefaultValue("false") boolean all)
+            throws ItemNotFound, PermissionDenied, ValidationError, HierarchyError {
         try (final Tx tx = beginTx()) {
-            Table out = deleteAll(id, Vocabulary::getAllContainedItems);
+            Table out = deleteContents(id, all);
             tx.success();
             return out;
         }

--- a/ehri-ws/src/main/java/eu/ehri/extension/base/ParentResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/base/ParentResource.java
@@ -19,10 +19,7 @@
 
 package eu.ehri.extension.base;
 
-import eu.ehri.project.exceptions.DeserializationError;
-import eu.ehri.project.exceptions.ItemNotFound;
-import eu.ehri.project.exceptions.PermissionDenied;
-import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.exceptions.*;
 import eu.ehri.project.persistence.Bundle;
 import eu.ehri.project.utils.Table;
 
@@ -58,19 +55,26 @@ public interface ParentResource {
      * @param accessors the users/groups who can access this item.
      * @return A serialized representation of the created resource.
      */
-    Response createChild(String id,
-                         Bundle bundle, List<String> accessors)
+    Response createChild(String id, Bundle bundle, List<String> accessors)
             throws PermissionDenied, ValidationError, DeserializationError, ItemNotFound;
 
     /**
-     * Delete a parent resource and all of its contained items.
+     * Delete all
      *
-     * @param id the parent resource ID
+     * <p>
+     * Example:
+     * <pre>
+     *     <code>
+     * curl -XDELETE -HX-User:admin http://localhost:7474/ehri/[RESOURCE]/[ID]/list
+     *     </code>
+     * </pre>
+     *
+     * @param id  the parent resource ID
+     * @param all descend into the hierarchy of any child items
      * @return an ordered list of deleted item IDs
-     * @throws PermissionDenied
-     * @throws ValidationError
-     * @throws DeserializationError
-     * @throws ItemNotFound
+     * @throws HierarchyError if an attempt is made to delete child items that have
+     *                        children themselves without using the {{all}} parameter.
      */
-    Table deleteAll(String id) throws PermissionDenied, ValidationError, DeserializationError, ItemNotFound;
+    Table deleteChildren(String id, boolean all)
+            throws PermissionDenied, ValidationError, DeserializationError, ItemNotFound, HierarchyError;
 }

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/CountryResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/CountryResourceClientTest.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.net.URI;
 
 import static com.sun.jersey.api.client.ClientResponse.Status.OK;
+import static eu.ehri.extension.base.AbstractResource.ALL_PARAM;
 import static org.junit.Assert.assertEquals;
 
 public class CountryResourceClientTest extends AbstractResourceClientTest {
@@ -49,12 +50,13 @@ public class CountryResourceClientTest extends AbstractResourceClientTest {
     public void testDeleteAll() throws Exception {
         // Create
         ClientResponse response = jsonCallAs(getAdminUserProfileId(),
-                entityUri(Entities.COUNTRY, "nl", "all"))
+                entityUriBuilder(Entities.COUNTRY, "nl", "list")
+                    .queryParam(ALL_PARAM, "true")
+                    .build())
                 .delete(ClientResponse.class);
         assertStatus(OK, response);
 
         Table expected = Table.of(Lists.newArrayList(
-                Lists.newArrayList("nl"),
                 Lists.newArrayList("c1"),
                 Lists.newArrayList("c2"),
                 Lists.newArrayList("c3"),

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/DocumentaryUnitResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/DocumentaryUnitResourceClientTest.java
@@ -40,6 +40,7 @@ import java.net.URI;
 import java.util.List;
 
 import static com.sun.jersey.api.client.ClientResponse.Status.*;
+import static eu.ehri.extension.base.AbstractResource.ALL_PARAM;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -124,15 +125,16 @@ public class DocumentaryUnitResourceClientTest extends AbstractResourceClientTes
     }
 
     @Test
-    public void testDeleteDocumentaryUnitAndChildren() throws Exception {
+    public void testDeleteChildren() throws Exception {
         // Create
         ClientResponse response = jsonCallAs(getAdminUserProfileId(),
-                entityUri(Entities.DOCUMENTARY_UNIT, FIRST_DOC_ID, "all"))
+                entityUriBuilder(Entities.DOCUMENTARY_UNIT, FIRST_DOC_ID, "list")
+                        .queryParam(ALL_PARAM, "true")
+                        .build())
                 .delete(ClientResponse.class);
         assertStatus(OK, response);
 
         Table expected = Table.of(Lists.newArrayList(
-                Lists.newArrayList(FIRST_DOC_ID),
                 Lists.newArrayList("c2"),
                 Lists.newArrayList("c3")
         ));

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/VocabularyResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/VocabularyResourceClientTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 import static com.sun.jersey.api.client.ClientResponse.Status.*;
+import static eu.ehri.extension.base.AbstractResource.ALL_PARAM;
 import static org.junit.Assert.assertEquals;
 
 
@@ -125,14 +126,14 @@ public class VocabularyResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
-    public void testDeleteAll() throws Exception {
-        URI uri = entityUriBuilder(Entities.CVOC_VOCABULARY, TEST_CVOC_ID, "all")
-                .queryParam("commit", "true").build();
+    public void testDeleteChildren() throws Exception {
+        URI uri = entityUriBuilder(Entities.CVOC_VOCABULARY, TEST_CVOC_ID, "list")
+                .queryParam(ALL_PARAM, "true").build();
         ClientResponse response = jsonCallAs(getAdminUserProfileId(), uri)
                 .delete(ClientResponse.class);
         assertStatus(OK, response);
         assertEquals(
-                Table.column(ImmutableList.of(TEST_CVOC_ID, "cvocc1", "cvocc2")),
+                Table.column(ImmutableList.of("cvocc1", "cvocc2")),
                 response.getEntity(Table.class));
 
         // Check it's really gone...


### PR DESCRIPTION
The `delete all` methods has been changed to a (safer) `delete children` method which requires an all=true parameter to descend the hierarchy and errors if children have child nodes of their own. This method no longer deletes the parent.

The WS method signature now matches the corresponding GET method for children.