### PR TITLE
Revert "Bump guava from 24.1.1-jre to 29.0-jre in /ehri-core"

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>


### PR DESCRIPTION
This turned out to have issues, namely a NoClassDefFound error with Neo4j.

This reverts commit 73a14dd6b023edf25f710d226a71418835bb8716.