### PR TITLE
Make using the source file ID optional when importing new descriptions

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>build</artifactId>

--- a/ehri-cli/pom.xml
+++ b/ehri-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <artifactId>ehri-cli</artifactId>
     <name>Command Line Tools</name>

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -25,13 +25,11 @@ import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
-import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.base.SaxXmlHandler;
 import eu.ehri.project.importers.managers.SaxImportManager;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.models.UserProfile;
 import eu.ehri.project.models.base.PermissionScope;
 import org.apache.commons.cli.CommandLine;
@@ -153,7 +151,7 @@ public abstract class ImportCommand extends BaseCommand {
                     .withTolerant(cmdLine.hasOption("tolerant"))
                     .withDefaultLang(lang);
 
-            ImportLog log = new SaxImportManager(graph, scope, user,
+            ImportLog log = SaxImportManager.create(graph, scope, user,
                     importer,
                     handler,
                     options,

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -87,6 +87,12 @@ public abstract class ImportCommand extends BaseCommand {
                 .desc("Allow the ingest process to update existing items.")
                 .build());
         options.addOption(Option.builder()
+                .longOpt("use-source-id")
+                .desc("Allow adding multiple descriptions with the same language by using the " +
+                        "source file ID (usually the EAD ID) to disambiguate descriptions in " +
+                        "addition to the language code.")
+                .build());
+        options.addOption(Option.builder()
                 .longOpt("lang")
                 .hasArg()
                 .type(String.class)
@@ -149,6 +155,7 @@ public abstract class ImportCommand extends BaseCommand {
                     .withProperties(cmdLine.getOptionValue("properties"))
                     .withUpdates(cmdLine.hasOption("allow-updates"))
                     .withTolerant(cmdLine.hasOption("tolerant"))
+                    .withUseSourceId(cmdLine.hasOption("use-source-id"))
                     .withDefaultLang(lang);
 
             ImportLog log = SaxImportManager.create(graph, scope, user,

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCommand.java
@@ -27,6 +27,7 @@ import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
 import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.base.SaxXmlHandler;
 import eu.ehri.project.importers.managers.SaxImportManager;
@@ -142,20 +143,21 @@ public abstract class ImportCommand extends BaseCommand {
             UserProfile user = manager.getEntity(cmdLine.getOptionValue("user"),
                     UserProfile.class);
 
-            XmlImportProperties optionalProperties = null;
             if (cmdLine.hasOption("properties")) {
-                XmlImportProperties properties = new XmlImportProperties(cmdLine.getOptionValue("properties"));
                 logMessage += " Using properties file : " + cmdLine.getOptionValue("properties");
-                optionalProperties = properties;
             }
 
+            ImportOptions options = ImportOptions.basic()
+                    .withProperties(cmdLine.getOptionValue("properties"))
+                    .withUpdates(cmdLine.hasOption("allow-updates"))
+                    .withTolerant(cmdLine.hasOption("tolerant"))
+                    .withDefaultLang(lang);
+
             ImportLog log = new SaxImportManager(graph, scope, user,
-                    cmdLine.hasOption("tolerant"),
-                    cmdLine.hasOption("allow-updates"),
-                    lang,
-                    importer, handler,
-                    optionalProperties,
-                    Lists.<ImportCallback>newArrayList())
+                    importer,
+                    handler,
+                    options,
+                    Lists.newArrayList())
                     .importFiles(filePaths, logMessage);
             System.out.println(log);
 

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
@@ -116,7 +116,7 @@ public abstract class ImportCsvCommand extends BaseCommand {
                     .withUpdates(cmdLine.hasOption("allow-updates"))
                     .withDefaultLang(cmdLine.getOptionValue("lang"));
 
-            ImportLog log = new CsvImportManager(graph, scope, user, importer, options)
+            ImportLog log = CsvImportManager.create(graph, scope, user, importer, options)
                     .importFiles(filePaths, logMessage);
 
             System.out.println(log);

--- a/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/ImportCsvCommand.java
@@ -24,6 +24,7 @@ import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.ImportLog;
@@ -95,10 +96,6 @@ public abstract class ImportCsvCommand extends BaseCommand {
             logMessage = cmdLine.getOptionValue("log");
         }
 
-        boolean tolerant = cmdLine.hasOption("tolerant");
-        boolean allowUpdates = cmdLine.hasOption("allow-updates");
-        String lang = cmdLine.hasOption("lang") ? cmdLine.getOptionValue("lang") : "eng";
-
         if (cmdLine.getArgList().size() < 1)
             throw new RuntimeException(getUsage());
 
@@ -113,10 +110,13 @@ public abstract class ImportCsvCommand extends BaseCommand {
             }
 
             // Find the user
-            UserProfile user = manager.getEntity(cmdLine.getOptionValue("user"),
-                    UserProfile.class);
+            UserProfile user = manager.getEntity(cmdLine.getOptionValue("user"), UserProfile.class);
+            ImportOptions options = ImportOptions.basic()
+                    .withTolerant(cmdLine.hasOption("tolerant"))
+                    .withUpdates(cmdLine.hasOption("allow-updates"))
+                    .withDefaultLang(cmdLine.getOptionValue("lang"));
 
-            ImportLog log = new CsvImportManager(graph, scope, user, tolerant, allowUpdates, lang, importer)
+            ImportLog log = new CsvImportManager(graph, scope, user, importer, options)
                     .importFiles(filePaths, logMessage);
 
             System.out.println(log);

--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <artifactId>ehri-core</artifactId>
     <packaging>jar</packaging>

--- a/ehri-cypher/pom.xml
+++ b/ehri-cypher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <artifactId>ehri-io</artifactId>
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ImportOptions.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ImportOptions.java
@@ -6,28 +6,34 @@ import eu.ehri.project.importers.properties.XmlImportProperties;
 
 import java.util.Optional;
 
+/**
+ * Options to control the behaviour of importers.
+ */
 public class ImportOptions {
     private static final Config config = ConfigFactory.load();
 
     public final boolean tolerant;
     public final boolean updates;
     public final String defaultLang;
-    public final boolean merging;
+    public final boolean useSourceId;
     public final XmlImportProperties properties;
 
     public static ImportOptions properties(String properties) {
-        return new ImportOptions(false, false, false, null, properties);
+        return create(false, false, false, null, properties);
     }
 
+    /**
+     * Basic factory method.
+     */
     public static ImportOptions basic() {
-        return new ImportOptions(false, false, false, null, (String)null);
+        return create(false, false, false, null, (String) null);
     }
 
-    public ImportOptions(boolean tolerant, boolean updates, boolean merging, String defaultLang, String properties) {
+    private ImportOptions(boolean tolerant, boolean updates, boolean useSourceId, String defaultLang, String properties) {
         this(
                 tolerant,
                 updates,
-                merging,
+                useSourceId,
                 Optional.ofNullable(defaultLang).orElse(config.getString("io.import.defaultLang")),
                 properties == null
                         ? new XmlImportProperties(config.getString("io.import.defaultProperties"))
@@ -35,31 +41,46 @@ public class ImportOptions {
         );
     }
 
-    private ImportOptions(boolean tolerant, boolean updates, boolean merging, String defaultLang, XmlImportProperties properties) {
+    private ImportOptions(boolean tolerant, boolean updates, boolean useSourceId, String defaultLang, XmlImportProperties properties) {
         this.tolerant = tolerant;
         this.updates = updates;
-        this.merging = merging;
+        this.useSourceId = useSourceId;
         this.defaultLang = defaultLang;
         this.properties = properties;
+    }
+
+    /**
+     * Factory method.
+     *
+     * @param tolerant     do not error if individual items fail to validate
+     * @param allowUpdates allow existing items to be updated
+     * @param useSourceId  take account of the 'source file ID' (usually the EAD ID value) when updating
+     *                     descriptions, in addition to the language code, allowing multiple descriptions
+     *                     in the same language/script to exist
+     * @param defaultLang  the default language code to use for newly-created items
+     * @param properties   a property mapping configuration
+     */
+    public static ImportOptions create(boolean tolerant, boolean allowUpdates, boolean useSourceId, String defaultLang, String properties) {
+        return new ImportOptions(tolerant, allowUpdates, useSourceId, defaultLang, properties);
     }
 
     public ImportOptions withProperties(String properties) {
         XmlImportProperties props = properties == null
                 ? new XmlImportProperties(config.getString("io.import.defaultProperties"))
                 : new XmlImportProperties(properties);
-        return new ImportOptions(tolerant, updates, merging, defaultLang, props);
+        return new ImportOptions(tolerant, updates, useSourceId, defaultLang, props);
     }
 
     public ImportOptions withUpdates(boolean updates) {
-        return new ImportOptions(tolerant, updates, merging, defaultLang, properties);
+        return new ImportOptions(tolerant, updates, useSourceId, defaultLang, properties);
     }
 
     public ImportOptions withDefaultLang(String lang) {
-        return new ImportOptions(tolerant, updates, merging, lang, properties);
+        return new ImportOptions(tolerant, updates, useSourceId, lang, properties);
     }
 
     public ImportOptions withTolerant(boolean tolerant) {
-        return new ImportOptions(tolerant, updates, merging, defaultLang, properties);
+        return new ImportOptions(tolerant, updates, useSourceId, defaultLang, properties);
     }
 
     public ImportOptions withMerging(boolean merging) {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ImportOptions.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ImportOptions.java
@@ -83,7 +83,7 @@ public class ImportOptions {
         return new ImportOptions(tolerant, updates, useSourceId, defaultLang, properties);
     }
 
-    public ImportOptions withMerging(boolean merging) {
+    public ImportOptions withUseSourceId(boolean merging) {
         return new ImportOptions(tolerant, updates, merging, defaultLang, properties);
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ImportOptions.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ImportOptions.java
@@ -1,0 +1,68 @@
+package eu.ehri.project.importers;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import eu.ehri.project.importers.properties.XmlImportProperties;
+
+import java.util.Optional;
+
+public class ImportOptions {
+    private static final Config config = ConfigFactory.load();
+
+    public final boolean tolerant;
+    public final boolean updates;
+    public final String defaultLang;
+    public final boolean merging;
+    public final XmlImportProperties properties;
+
+    public static ImportOptions properties(String properties) {
+        return new ImportOptions(false, false, false, null, properties);
+    }
+
+    public static ImportOptions basic() {
+        return new ImportOptions(false, false, false, null, (String)null);
+    }
+
+    public ImportOptions(boolean tolerant, boolean updates, boolean merging, String defaultLang, String properties) {
+        this(
+                tolerant,
+                updates,
+                merging,
+                Optional.ofNullable(defaultLang).orElse(config.getString("io.import.defaultLang")),
+                properties == null
+                        ? new XmlImportProperties(config.getString("io.import.defaultProperties"))
+                        : new XmlImportProperties(properties)
+        );
+    }
+
+    private ImportOptions(boolean tolerant, boolean updates, boolean merging, String defaultLang, XmlImportProperties properties) {
+        this.tolerant = tolerant;
+        this.updates = updates;
+        this.merging = merging;
+        this.defaultLang = defaultLang;
+        this.properties = properties;
+    }
+
+    public ImportOptions withProperties(String properties) {
+        XmlImportProperties props = properties == null
+                ? new XmlImportProperties(config.getString("io.import.defaultProperties"))
+                : new XmlImportProperties(properties);
+        return new ImportOptions(tolerant, updates, merging, defaultLang, props);
+    }
+
+    public ImportOptions withUpdates(boolean updates) {
+        return new ImportOptions(tolerant, updates, merging, defaultLang, properties);
+    }
+
+    public ImportOptions withDefaultLang(String lang) {
+        return new ImportOptions(tolerant, updates, merging, lang, properties);
+    }
+
+    public ImportOptions withTolerant(boolean tolerant) {
+        return new ImportOptions(tolerant, updates, merging, defaultLang, properties);
+    }
+
+    public ImportOptions withMerging(boolean merging) {
+        return new ImportOptions(tolerant, updates, merging, defaultLang, properties);
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/AbstractImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/AbstractImporter.java
@@ -24,10 +24,10 @@ import com.google.common.collect.Lists;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.core.GraphManager;
 import eu.ehri.project.core.GraphManagerFactory;
-import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ErrorCallback;
 import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
@@ -42,6 +42,7 @@ public abstract class AbstractImporter<I, T extends Accessible> implements ItemI
     protected final Actioner actioner;
     protected final FramedGraph<?> framedGraph;
     protected final GraphManager manager;
+    protected final ImportOptions options;
     protected final ImportLog log;
     private final List<ImportCallback> callbacks = Lists.newArrayList();
     private final List<ErrorCallback> errorCallbacks = Lists.newArrayList();
@@ -82,11 +83,12 @@ public abstract class AbstractImporter<I, T extends Accessible> implements ItemI
      * @param actioner the user performing the import
      * @param log      the log object
      */
-    public AbstractImporter(FramedGraph<?> graph, PermissionScope scope, Actioner actioner, ImportLog log) {
+    public AbstractImporter(FramedGraph<?> graph, PermissionScope scope, Actioner actioner, ImportOptions options, ImportLog log) {
         this.permissionScope = scope;
         this.framedGraph = graph;
         this.actioner = actioner;
         this.log = log;
+        this.options = options;
         manager = GraphManagerFactory.getInstance(graph);
     }
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporter.java
@@ -29,6 +29,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.util.ImportHelpers;
 import eu.ehri.project.models.EntityClass;
@@ -55,8 +56,8 @@ public class CsvAuthoritativeItemImporter extends AbstractImporter<Map<String, O
     private static final Logger logger = LoggerFactory.getLogger(CsvAuthoritativeItemImporter.class);
 
     public CsvAuthoritativeItemImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope,
-            Actioner actioner, ImportLog log) {
-        super(framedGraph, permissionScope, actioner, log);
+                                        Actioner actioner, ImportOptions options, ImportLog log) {
+        super(framedGraph, permissionScope, actioner, options, log);
     }
 
     @Override

--- a/ehri-io/src/main/java/eu/ehri/project/importers/csv/CsvConceptImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/csv/CsvConceptImporter.java
@@ -28,6 +28,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
@@ -46,8 +47,8 @@ import java.util.Map;
 public class CsvConceptImporter extends CsvAuthoritativeItemImporter {
 
     public CsvConceptImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope,
-            Actioner actioner, ImportLog log) {
-        super(framedGraph, permissionScope, actioner, log);
+                              Actioner actioner, ImportOptions options, ImportLog log) {
+        super(framedGraph, permissionScope, actioner, options, log);
     }
 
     @Override

--- a/ehri-io/src/main/java/eu/ehri/project/importers/csv/PersonalitiesImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/csv/PersonalitiesImporter.java
@@ -26,6 +26,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.importers.util.ImportHelpers;
@@ -52,13 +53,10 @@ import java.util.Map;
  */
 public class PersonalitiesImporter extends AbstractImporter<Map<String, Object>, HistoricalAgent> {
 
-    private final XmlImportProperties p = new XmlImportProperties("personalities.properties");
-
     private static final Logger logger = LoggerFactory.getLogger(PersonalitiesImporter.class);
 
-    public PersonalitiesImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, Actioner actioner,
-            ImportLog log) {
-        super(framedGraph, permissionScope, actioner, log);
+    public PersonalitiesImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, Actioner actioner, ImportOptions options, ImportLog log) {
+        super(framedGraph, permissionScope, actioner, options.withProperties("personalities.properties"), log);
     }
 
     @Override
@@ -128,10 +126,10 @@ public class PersonalitiesImporter extends AbstractImporter<Map<String, Object>,
         ImportHelpers.putPropertyInGraph(item, Ontology.NAME_KEY, getName(itemData));
         for (String key : itemData.keySet()) {
             if (!key.equals("id")) {
-                if (!p.containsProperty(key)) {
+                if (!options.properties.containsProperty(key)) {
                     ImportHelpers.putPropertyInGraph(item, ImportHelpers.UNKNOWN_PREFIX + key, itemData.get(key).toString());
                 } else {
-                    ImportHelpers.putPropertyInGraph(item, p.getProperty(key), itemData.get(key).toString());
+                    ImportHelpers.putPropertyInGraph(item, options.properties.getProperty(key), itemData.get(key).toString());
                 }
             }
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacHandler.java
@@ -25,9 +25,9 @@ import com.google.common.collect.Sets;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.base.SaxXmlHandler;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.importers.util.ImportHelpers;
 import eu.ehri.project.models.AccessPoint;
 import eu.ehri.project.models.DatePeriod;
@@ -63,12 +63,8 @@ public class EacHandler extends SaxXmlHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(EacHandler.class);
 
-    public EacHandler(ItemImporter<Map<String, Object>, ?> importer, String defaultLang) {
-        this(importer, defaultLang, new XmlImportProperties("eac.properties"));
-    }
-
-    public EacHandler(ItemImporter<Map<String, Object>, ?> importer, String defaultLang, XmlImportProperties properties) {
-        super(importer, defaultLang, properties);
+    public EacHandler(ItemImporter<Map<String, Object>, ?> importer, ImportOptions options) {
+        super(importer, options);
     }
 
     @Override
@@ -104,7 +100,7 @@ public class EacHandler extends SaxXmlHandler {
                 }
                 if (!currentGraphPath.peek().containsKey(Ontology.LANGUAGE_OF_DESCRIPTION)) {
                     logger.trace("no {} found", Ontology.LANGUAGE_OF_DESCRIPTION);
-                    putPropertyInCurrentGraph(Ontology.LANGUAGE_OF_DESCRIPTION, defaultLang);
+                    putPropertyInCurrentGraph(Ontology.LANGUAGE_OF_DESCRIPTION, langCode);
                 }
 
                 importer.importItem(currentGraphPath.pop(), Lists.<String>newArrayList());

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacImporter.java
@@ -27,6 +27,7 @@ import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.links.LinkResolver;
 import eu.ehri.project.importers.util.ImportHelpers;
@@ -65,8 +66,8 @@ public class EacImporter extends AbstractImporter<Map<String, Object>, Historica
      * @param permissionScope the permission scope
      * @param log             the import log
      */
-    public EacImporter(FramedGraph<?> graph, PermissionScope permissionScope, Actioner actioner, ImportLog log) {
-        super(graph, permissionScope, actioner, log);
+    public EacImporter(FramedGraph<?> graph, PermissionScope permissionScope, Actioner actioner, ImportOptions options, ImportLog log) {
+        super(graph, permissionScope, actioner, options, log);
         linkResolver = new LinkResolver(graph, actioner.as(Accessor.class));
     }
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadHandler.java
@@ -26,9 +26,9 @@ import com.google.common.collect.Lists;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.base.SaxXmlHandler;
-import eu.ehri.project.importers.properties.XmlImportProperties;
 import eu.ehri.project.importers.util.ImportHelpers;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.DocumentaryUnit;
@@ -114,23 +114,13 @@ public class EadHandler extends SaxXmlHandler {
     }
 
     /**
-     * Create an EadHandler using some importer. The default mapping of paths to node properties is used.
-     *
-     * @param importer the importer instance
-     */
-    public EadHandler(ItemImporter<Map<String, Object>, ?> importer, String defaultLang) {
-        this(importer, defaultLang, new XmlImportProperties(DEFAULT_PROPERTIES));
-        logger.trace("Using default properties file: {}", DEFAULT_PROPERTIES);
-    }
-
-    /**
      * Create an EadHandler using some importer, and a mapping of paths to node properties.
      *
      * @param importer   the importer instance
-     * @param properties an XML node properties instance
+     * @param options    an ImportOptions instance
      */
-    public EadHandler(ItemImporter<Map<String, Object>, ?> importer, String defaultLang, XmlImportProperties properties) {
-        super(importer, defaultLang, properties);
+    public EadHandler(ItemImporter<Map<String, Object>, ?> importer, ImportOptions options) {
+        super(importer, options);
         children[depth] = Lists.newArrayList();
     }
 
@@ -205,7 +195,7 @@ public class EadHandler extends SaxXmlHandler {
         if (qName.equals(ImportHelpers.LANGUAGE_KEY_PREFIX) || localName.equals(ImportHelpers.LANGUAGE_KEY_PREFIX)) {
             String lang = (String) currentGraphPath.peek().get("languageCode");
             if (lang != null) {
-                defaultLang = lang;
+                langCode = lang;
             }
         }
 
@@ -310,7 +300,7 @@ public class EadHandler extends SaxXmlHandler {
             logger.error("EADID not set yet, or not given in eadfile");
             return null;
         } else {
-            String suffix = "#" + defaultLang.toUpperCase();
+            String suffix = "#" + langCode.toUpperCase();
             if (eadId.toUpperCase().endsWith(suffix)) {
                 return eadId;
             }
@@ -325,7 +315,7 @@ public class EadHandler extends SaxXmlHandler {
      * @param currentGraph Data at the current node level
      */
     protected void useDefaultLanguage(Map<String, Object> currentGraph) {
-        useDefaultLanguage(currentGraph, defaultLang);
+        useDefaultLanguage(currentGraph, langCode);
     }
 
     /**

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
@@ -225,7 +225,7 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
                 Bundle oldBundle = mergeSerializer.vertexToBundle(manager.getVertex(unitWithIds.getId()));
 
                 // Filter out dependents that a) are descriptions, b) have the same language/code.
-                // If the merging option is enabled this allows us to have multiple
+                // If the useSourceId option is enabled this allows us to have multiple
                 // descriptions in the same language if they have different source file IDs,
                 // so in that case only remove those if the source ID matches.
                 // I know this is confusing: TODO: improve this.
@@ -235,11 +235,12 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
                     return relationLabel.equals(Ontology.DESCRIPTION_FOR_ENTITY)
                             && bundle.getType().equals(EntityClass.DOCUMENTARY_UNIT_DESCRIPTION)
                             && (lang != null && lang.equals(languageOfDesc))
-                            && (!options.merging || (oldSourceFileId != null && oldSourceFileId.equals(thisSourceFileId)));
+                            && (!options.useSourceId || (oldSourceFileId != null && oldSourceFileId.equals(thisSourceFileId)));
                 };
                 Bundle filtered = oldBundle.filterRelations(filter);
 
-                return unitWithIds.withRelations(filtered.getRelations())
+                return unitWithIds
+                        .withRelations(filtered.getRelations())
                         .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, descBundle);
             } catch (SerializationError ex) {
                 throw new RuntimeException("Unexpected error reading existing item: " + unitWithIds.getId(), ex);

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadSync.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadSync.java
@@ -46,7 +46,7 @@ public class EadSync {
     private final GraphManager manager;
     private final Serializer depSerializer;
 
-    public EadSync(
+    private EadSync(
             FramedGraph<?> graph,
             Api api,
             PermissionScope scope,
@@ -59,6 +59,15 @@ public class EadSync {
         this.importManager = importManager;
         this.manager = GraphManagerFactory.getInstance(graph);
         this.depSerializer = api.serializer().withDependentOnly(true);
+    }
+
+    public static EadSync create(
+            FramedGraph<?> graph,
+            Api api,
+            PermissionScope scope,
+            Actioner actioner,
+            SaxImportManager importManager) {
+        return new EadSync(graph, api, scope, actioner, importManager);
     }
 
     /**

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/VirtualEadImporter.java
@@ -26,6 +26,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
@@ -74,8 +75,8 @@ public class VirtualEadImporter extends EadImporter {
      * @param log             the import log
      */
     public VirtualEadImporter(FramedGraph<?> graph, PermissionScope permissionScope,
-            Actioner actioner, ImportLog log) {
-        super(graph, permissionScope, actioner, log);
+                              Actioner actioner, ImportOptions options, ImportLog log) {
+        super(graph, permissionScope, actioner, options, log);
     }
 
     /**

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eag/EagHandler.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eag/EagHandler.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.base.SaxXmlHandler;
 import eu.ehri.project.importers.properties.XmlImportProperties;
@@ -47,8 +48,8 @@ public class EagHandler extends SaxXmlHandler {
     );
     private static final Logger logger = LoggerFactory.getLogger(EagHandler.class);
 
-    public EagHandler(ItemImporter<Map<String, Object>, ?> importer, String defaultLang) {
-        super(importer, defaultLang, new XmlImportProperties("eag.properties"));
+    public EagHandler(ItemImporter<Map<String, Object>, ?> importer, ImportOptions options) {
+        super(importer, options);
     }
 
     @Override
@@ -89,7 +90,7 @@ public class EagHandler extends SaxXmlHandler {
                 }
                 if (!currentGraphPath.peek().containsKey(Ontology.LANGUAGE_OF_DESCRIPTION)) {
                     logger.debug("no {} found", Ontology.LANGUAGE_OF_DESCRIPTION);
-                    putPropertyInCurrentGraph(Ontology.LANGUAGE_OF_DESCRIPTION, defaultLang);
+                    putPropertyInCurrentGraph(Ontology.LANGUAGE_OF_DESCRIPTION, langCode);
                 }
                 if (!currentGraphPath.peek().containsKey("rulesAndConventions")) {
                     logger.debug("no rulesAndConventions found");

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eag/EagImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eag/EagImporter.java
@@ -24,6 +24,7 @@ import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.eac.EacImporter;
 import eu.ehri.project.importers.util.ImportHelpers;
@@ -61,8 +62,8 @@ public class EagImporter extends AbstractImporter<Map<String, Object>, Repositor
      * @param permissionScope A permission scope, e.g. a country
      * @param log             An import log instance
      */
-    public EagImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, Actioner actioner, ImportLog log) {
-        super(framedGraph, permissionScope, actioner, log);
+    public EagImporter(FramedGraph<?> framedGraph, PermissionScope permissionScope, Actioner actioner, ImportOptions options, ImportLog log) {
+        super(framedGraph, permissionScope, actioner, options, log);
     }
 
     @Override

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -54,10 +54,16 @@ public class CsvImportManager extends AbstractImportManager {
 
     private static final Logger logger = LoggerFactory.getLogger(CsvImportManager.class);
 
-    public CsvImportManager(FramedGraph<?> framedGraph,
-                            PermissionScope permissionScope, Actioner actioner,
-                            Class<? extends ItemImporter<?,?>> importerClass, ImportOptions options) {
+    private CsvImportManager(FramedGraph<?> framedGraph,
+                             PermissionScope permissionScope, Actioner actioner,
+                             Class<? extends ItemImporter<?, ?>> importerClass, ImportOptions options) {
         super(framedGraph, permissionScope, actioner, importerClass, options);
+    }
+
+    public static CsvImportManager create(FramedGraph<?> framedGraph,
+                                          PermissionScope permissionScope, Actioner actioner,
+                                          Class<? extends ItemImporter<?, ?>> importerClass, ImportOptions options) {
+        return new CsvImportManager(framedGraph, permissionScope, actioner, importerClass, options);
     }
 
     /**

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/CsvImportManager.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Maps;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.ItemImporter;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.util.ImportHelpers;
@@ -54,10 +55,9 @@ public class CsvImportManager extends AbstractImportManager {
     private static final Logger logger = LoggerFactory.getLogger(CsvImportManager.class);
 
     public CsvImportManager(FramedGraph<?> framedGraph,
-            PermissionScope permissionScope, Actioner actioner,
-            boolean tolerant,
-            boolean allowUpdates, String defaultLang, Class<? extends ItemImporter<?,?>> importerClass) {
-        super(framedGraph, permissionScope, actioner, tolerant, allowUpdates, defaultLang, importerClass);
+                            PermissionScope permissionScope, Actioner actioner,
+                            Class<? extends ItemImporter<?,?>> importerClass, ImportOptions options) {
+        super(framedGraph, permissionScope, actioner, importerClass, options);
     }
 
     /**
@@ -68,13 +68,13 @@ public class CsvImportManager extends AbstractImportManager {
      * @param log     an import log instance
      */
     @Override
-    protected void importInputStream(InputStream stream, String tag, final ActionManager.EventContext context,
-            final ImportLog log) throws IOException, ValidationError, InputParseError {
+    protected void importInputStream(InputStream stream, String tag, final ActionManager.EventContext context, final ImportLog log)
+            throws IOException, ValidationError, InputParseError {
 
         try {
             ItemImporter<?,?> importer = importerClass
-                    .getConstructor(FramedGraph.class, PermissionScope.class, Actioner.class, ImportLog.class)
-                    .newInstance(framedGraph, permissionScope, actioner, log);
+                    .getConstructor(FramedGraph.class, PermissionScope.class, Actioner.class, ImportOptions.class, ImportLog.class)
+                    .newInstance(framedGraph, permissionScope, actioner, options, log);
             logger.trace("importer of class {}", importer.getClass());
 
             importer.addCallback(mutation -> defaultImportCallback(log, tag, context, mutation));

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -59,20 +59,13 @@ public class SaxImportManager extends AbstractImportManager {
     private final ImportOptions options;
     private final List<ImportCallback> extraCallbacks;
 
-    /**
-     * Constructor.
-     *
-     * @param graph    the framed graph
-     * @param scope    the permission scope
-     * @param actioner the actioner
-     */
-    public SaxImportManager(FramedGraph<?> graph,
-                            PermissionScope scope,
-                            Actioner actioner,
-                            Class<? extends ItemImporter<?,?>> importerClass,
-                            Class<? extends SaxXmlHandler> handlerClass,
-                            ImportOptions options,
-                            List<ImportCallback> callbacks) {
+    private SaxImportManager(FramedGraph<?> graph,
+                             PermissionScope scope,
+                             Actioner actioner,
+                             Class<? extends ItemImporter<?, ?>> importerClass,
+                             Class<? extends SaxXmlHandler> handlerClass,
+                             ImportOptions options,
+                             List<ImportCallback> callbacks) {
         super(graph, scope, actioner, importerClass, options);
         this.handlerClass = handlerClass;
         this.extraCallbacks = Lists.newArrayList(callbacks);
@@ -81,19 +74,48 @@ public class SaxImportManager extends AbstractImportManager {
         logger.debug("handler used: {}", handlerClass);
     }
 
+    private SaxImportManager(FramedGraph<?> graph,
+                             PermissionScope scope,
+                             Actioner actioner,
+                             Class<? extends ItemImporter<?, ?>> importerClass,
+                             Class<? extends SaxXmlHandler> handlerClass, ImportOptions options) {
+        this(graph, scope, actioner, importerClass, handlerClass, options, Lists.newArrayList());
+    }
+
     /**
-     * Constructor.
-     *  @param graph    the framed graph
+     * Factory method.
+     *
+     * @param graph     the framed graph
+     * @param scope     the permission scope
+     * @param actioner  the actioner
+     * @param options   an ImportOptions instance
+     * @param callbacks a list of ImportCallback instances
+     */
+    public static SaxImportManager create(FramedGraph<?> graph,
+                                          PermissionScope scope,
+                                          Actioner actioner,
+                                          Class<? extends ItemImporter<?, ?>> importerClass,
+                                          Class<? extends SaxXmlHandler> handlerClass,
+                                          ImportOptions options,
+                                          List<ImportCallback> callbacks) {
+        return new SaxImportManager(graph, scope, actioner, importerClass, handlerClass, options, callbacks);
+    }
+
+    /**
+     * Factory method.
+     *
+     * @param graph    the framed graph
      * @param scope    a permission scope
      * @param actioner the actioner
-     * @param options an import options instance
+     * @param options  an import options instance
      */
-    public SaxImportManager(FramedGraph<?> graph,
-                            PermissionScope scope,
-                            Actioner actioner,
-                            Class<? extends ItemImporter<?, ?>> importerClass,
-                            Class<? extends SaxXmlHandler> handlerClass, ImportOptions options) {
-        this(graph, scope, actioner, importerClass, handlerClass, options, Lists.newArrayList());
+    public static SaxImportManager create(FramedGraph<?> graph,
+                                          PermissionScope scope,
+                                          Actioner actioner,
+                                          Class<? extends ItemImporter<?, ?>> importerClass,
+                                          Class<? extends SaxXmlHandler> handlerClass,
+                                          ImportOptions options) {
+        return new SaxImportManager(graph, scope, actioner, importerClass, handlerClass, options);
     }
 
     /**
@@ -105,7 +127,7 @@ public class SaxImportManager extends AbstractImportManager {
      */
     @Override
     protected void importInputStream(final InputStream stream, final String tag, final ActionManager.EventContext context,
-            final ImportLog log) throws IOException, ValidationError, InputParseError {
+                                     final ImportLog log) throws IOException, ValidationError, InputParseError {
         try {
             ItemImporter<?, ?> importer = importerClass
                     .getConstructor(FramedGraph.class, PermissionScope.class, Actioner.class, ImportOptions.class, ImportLog.class)
@@ -119,7 +141,7 @@ public class SaxImportManager extends AbstractImportManager {
             importer.addErrorCallback(ex -> defaultErrorCallback(log, ex));
 
             SaxXmlHandler handler = handlerClass.getConstructor(ItemImporter.class, ImportOptions.class)
-                            .newInstance(importer, options);
+                    .newInstance(importer, options);
 
             SAXParserFactory spf = SAXParserFactory.newInstance();
             spf.setNamespaceAware(false);
@@ -145,7 +167,7 @@ public class SaxImportManager extends AbstractImportManager {
             throw new InputParseError(e);
         } catch (RuntimeException e) {
             if (e.getCause() instanceof ValidationError) {
-                throw (ValidationError)e.getCause();
+                throw (ValidationError) e.getCause();
             } else {
                 throw e;
             }
@@ -153,18 +175,18 @@ public class SaxImportManager extends AbstractImportManager {
     }
 
     public SaxImportManager withScope(PermissionScope scope) {
-        return new SaxImportManager(framedGraph, scope, actioner, importerClass, handlerClass, options, extraCallbacks);
+        return create(framedGraph, scope, actioner, importerClass, handlerClass, options, extraCallbacks);
     }
 
     public SaxImportManager withCallback(ImportCallback callback) {
         List<ImportCallback> newCbs = Lists.newArrayList(extraCallbacks);
         newCbs.add(callback);
-        return new SaxImportManager(framedGraph, permissionScope, actioner,
+        return create(framedGraph, permissionScope, actioner,
                 importerClass, handlerClass, options, newCbs);
     }
 
     public SaxImportManager withUpdates(boolean updates) {
-        return new SaxImportManager(framedGraph, permissionScope, actioner, importerClass, handlerClass,
+        return create(framedGraph, permissionScope, actioner, importerClass, handlerClass,
                 options.withUpdates(updates), extraCallbacks);
     }
 }

--- a/ehri-io/src/main/resources/reference.conf
+++ b/ehri-io/src/main/resources/reference.conf
@@ -1,10 +1,14 @@
 # Configuration for import/export. These values can be overridden
 # by an "application.conf" file in the Neo4j conf directory.
 
-defaultLang = "eng"
-
 io {
   import {
+    # default EAD language import
+    defaultLang = "eng"
+
+    # this refers to a resource file
+    defaultProperties = "ead2002.properties"
+
     defaultLinkType = "associative"
     defaultLinkText = "Link provided by data provider."
   }

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
@@ -51,7 +51,7 @@ public class Eac2010ExporterTest extends XmlExporterTest {
         AuthoritativeSet auths = manager.getEntity("auths", AuthoritativeSet.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("abwehr.xml");
         String logMessage = "Test EAC import/export";
-        new SaxImportManager(graph, auths, validUser,
+        SaxImportManager.create(graph, auths, validUser,
                 EacImporter.class, EacHandler.class, ImportOptions.properties("eac.properties"))
                 .importInputStream(ios, logMessage);
         HistoricalAgent repo = graph.frame(getVertexByIdentifier(graph, "381"), HistoricalAgent.class);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.exporters.eac;
 
 import eu.ehri.project.exporters.test.XmlExporterTest;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.eac.EacHandler;
 import eu.ehri.project.importers.eac.EacImporter;
 import eu.ehri.project.importers.managers.SaxImportManager;
@@ -51,7 +52,7 @@ public class Eac2010ExporterTest extends XmlExporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream("abwehr.xml");
         String logMessage = "Test EAC import/export";
         new SaxImportManager(graph, auths, validUser,
-                EacImporter.class, EacHandler.class)
+                EacImporter.class, EacHandler.class, ImportOptions.properties("eac.properties"))
                 .importInputStream(ios, logMessage);
         HistoricalAgent repo = graph.frame(getVertexByIdentifier(graph, "381"), HistoricalAgent.class);
         String xml = testExport(repo, "eng");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.exporters.ead;
 
 import eu.ehri.project.exporters.test.XmlExporterTest;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.ead.EadHandler;
 import eu.ehri.project.importers.ead.EadImporter;
 import eu.ehri.project.importers.managers.SaxImportManager;
@@ -162,7 +163,7 @@ public class Ead2002ExporterTest extends XmlExporterTest {
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
         new SaxImportManager(graph, repository, validUser,
-                EadImporter.class, EadHandler.class)
+                EadImporter.class, EadHandler.class, ImportOptions.basic())
                 .importInputStream(ios, "Testing import/export");
         DocumentaryUnit fonds = graph.frame(
                 getVertexByIdentifier(graph, topLevelIdentifier), DocumentaryUnit.class);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
@@ -162,7 +162,7 @@ public class Ead2002ExporterTest extends XmlExporterTest {
     private String testImportExport(Repository repository, String resourceName,
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
-        new SaxImportManager(graph, repository, validUser,
+        SaxImportManager.create(graph, repository, validUser,
                 EadImporter.class, EadHandler.class, ImportOptions.basic())
                 .importInputStream(ios, "Testing import/export");
         DocumentaryUnit fonds = graph.frame(

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead3ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead3ExporterTest.java
@@ -176,7 +176,7 @@ public class Ead3ExporterTest extends XmlExporterTest {
     private String testImportExport(Repository repository, String resourceName,
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
-        new SaxImportManager(graph, repository, validUser,
+        SaxImportManager.create(graph, repository, validUser,
                 EadImporter.class, EadHandler.class, ImportOptions.properties("ead3.properties"))
                 .importInputStream(ios, "Testing import/export");
         DocumentaryUnit fonds = graph.frame(

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead3ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead3ExporterTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.exporters.ead;
 
 import eu.ehri.project.exporters.test.XmlExporterTest;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.ead.EadHandler;
 import eu.ehri.project.importers.ead.EadImporter;
 import eu.ehri.project.importers.managers.SaxImportManager;
@@ -176,8 +177,7 @@ public class Ead3ExporterTest extends XmlExporterTest {
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
         new SaxImportManager(graph, repository, validUser,
-                EadImporter.class, EadHandler.class)
-                .withProperties("ead3.properties")
+                EadImporter.class, EadHandler.class, ImportOptions.properties("ead3.properties"))
                 .importInputStream(ios, "Testing import/export");
         DocumentaryUnit fonds = graph.frame(
                 getVertexByIdentifier(graph, topLevelIdentifier), DocumentaryUnit.class);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
@@ -51,7 +51,7 @@ public class Eag2012ExporterTest extends XmlExporterTest {
     public void testImportExport1() throws Exception {
         Country nl = manager.getEntity("nl", Country.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("eag-2896.xml");
-        SaxImportManager importManager = new SaxImportManager(graph, nl, validUser,
+        SaxImportManager importManager = SaxImportManager.create(graph, nl, validUser,
                 EagImporter.class, EagHandler.class, ImportOptions.properties("eag.properties"));
         importManager.importInputStream(ios, "Text EAG import/export");
         Repository repo = graph.frame(getVertexByIdentifier(graph, "NL-002896"), Repository.class);

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.exporters.eag;
 
 import eu.ehri.project.exporters.test.XmlExporterTest;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.eag.EagHandler;
 import eu.ehri.project.importers.eag.EagImporter;
 import eu.ehri.project.importers.managers.SaxImportManager;
@@ -51,7 +52,7 @@ public class Eag2012ExporterTest extends XmlExporterTest {
         Country nl = manager.getEntity("nl", Country.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("eag-2896.xml");
         SaxImportManager importManager = new SaxImportManager(graph, nl, validUser,
-                EagImporter.class, EagHandler.class);
+                EagImporter.class, EagHandler.class, ImportOptions.properties("eag.properties"));
         importManager.importInputStream(ios, "Text EAG import/export");
         Repository repo = graph.frame(getVertexByIdentifier(graph, "NL-002896"), Repository.class);
         testExport(repo, "eng");

--- a/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
@@ -62,11 +62,11 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
      * Convenience method for creating a Sax import manager.
      */
     protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass, ImportOptions options) {
-        return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass, options);
+        return SaxImportManager.create(graph, repository, validUser, importerClass, handlerClass, options);
     }
 
     protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
-        return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass, ImportOptions.basic());
+        return SaxImportManager.create(graph, repository, validUser, importerClass, handlerClass, ImportOptions.basic());
     }
 
     protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass, String propertiesResource) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
@@ -24,6 +24,7 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.definitions.Ontology;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.annotations.EntityType;
@@ -60,14 +61,16 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
     /**
      * Convenience method for creating a Sax import manager.
      */
-    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends
-            SaxXmlHandler> handlerClass) {
-        return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass);
+    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass, ImportOptions options) {
+        return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass, options);
     }
 
-    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends
-            SaxXmlHandler> handlerClass, String propertiesResource) {
-        return saxImportManager(importerClass, handlerClass).withProperties(propertiesResource);
+    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
+        return new SaxImportManager(graph, repository, validUser, importerClass, handlerClass, ImportOptions.basic());
+    }
+
+    protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass, String propertiesResource) {
+        return saxImportManager(importerClass, handlerClass, ImportOptions.properties(propertiesResource));
     }
 
     /**

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporterTest.java
@@ -58,7 +58,7 @@ public class CsvAuthoritativeItemImporterTest extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_CSV);
 
         List<VertexProxy> graphState1 = getGraphState(graph);
-        ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser,
+        ImportLog log = CsvImportManager.create(graph, authoritativeSet, validUser,
                 CsvAuthoritativeItemImporter.class, ImportOptions.basic()).importInputStream(ios, logMessage);
         assertEquals(9, log.getCreated());
         printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporterTest.java
@@ -25,6 +25,7 @@ package eu.ehri.project.importers.csv;
 
 import com.google.common.collect.Lists;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.models.base.Accessible;
@@ -58,7 +59,7 @@ public class CsvAuthoritativeItemImporterTest extends AbstractImporterTest {
 
         List<VertexProxy> graphState1 = getGraphState(graph);
         ImportLog log = new CsvImportManager(graph, authoritativeSet, validUser,
-                false, false, "eng", CsvAuthoritativeItemImporter.class).importInputStream(ios, logMessage);
+                CsvAuthoritativeItemImporter.class, ImportOptions.basic()).importInputStream(ios, logMessage);
         assertEquals(9, log.getCreated());
         printGraph(graph);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
@@ -63,7 +63,7 @@ public class CsvConceptImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, authoritativeSet, validUser, CsvConceptImporter.class, ImportOptions.basic())
+        CsvImportManager.create(graph, authoritativeSet, validUser, CsvConceptImporter.class, ImportOptions.basic())
                 .importInputStream(ios, logMessage);
         /*
          * 18 Concept

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
@@ -23,6 +23,7 @@
  */
 package eu.ehri.project.importers.csv;
 
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
@@ -62,7 +63,7 @@ public class CsvConceptImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, authoritativeSet, validUser, true, false, "eng", CsvConceptImporter.class)
+        new CsvImportManager(graph, authoritativeSet, validUser, CsvConceptImporter.class, ImportOptions.basic())
                 .importInputStream(ios, logMessage);
         /*
          * 18 Concept

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
@@ -49,7 +49,7 @@ public class CsvDossinImporterTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream("dossin.csv");
-        ImportLog importLog = new CsvImportManager(graph, ps, validUser, EadImporter.class, ImportOptions.basic())
+        ImportLog importLog = CsvImportManager.create(graph, ps, validUser, EadImporter.class, ImportOptions.basic())
                 .importInputStream(ios, logMessage);
         System.out.println(importLog);
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
@@ -20,6 +20,7 @@
 package eu.ehri.project.importers.csv;
 
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.ead.EadImporter;
 import eu.ehri.project.importers.managers.CsvImportManager;
@@ -48,7 +49,7 @@ public class CsvDossinImporterTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream("dossin.csv");
-        ImportLog importLog = new CsvImportManager(graph, ps, validUser, false, false, "eng", EadImporter.class)
+        ImportLog importLog = new CsvImportManager(graph, ps, validUser, EadImporter.class, ImportOptions.basic())
                 .importInputStream(ios, logMessage);
         System.out.println(importLog);
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers.csv;
 
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.managers.CsvImportManager;
 import eu.ehri.project.importers.properties.XmlImportProperties;
@@ -55,8 +56,8 @@ public class PersonalitiesImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, authoritativeSet, validUser, false, false, "eng",
-                PersonalitiesImporter.class).importInputStream(ios, logMessage);
+        new CsvImportManager(graph, authoritativeSet, validUser,
+                PersonalitiesImporter.class, ImportOptions.basic()).importInputStream(ios, logMessage);
         SystemEvent ev = actionManager.getLatestGlobalEvent();
 
         /*

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
@@ -56,7 +56,7 @@ public class PersonalitiesImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        new CsvImportManager(graph, authoritativeSet, validUser,
+        CsvImportManager.create(graph, authoritativeSet, validUser,
                 PersonalitiesImporter.class, ImportOptions.basic()).importInputStream(ios, logMessage);
         SystemEvent ev = actionManager.getLatestGlobalEvent();
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/EacImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/EacImporterTest.java
@@ -24,6 +24,7 @@ import eu.ehri.project.acl.SystemScope;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.models.DatePeriod;
 import eu.ehri.project.models.HistoricalAgent;
@@ -59,7 +60,7 @@ public class EacImporterTest extends AbstractImporterTest {
 
         // Before...
         List<VertexProxy> graphState1 = GraphTestBase.getGraphState(graph);
-        saxImportManager(EacImporter.class, EacHandler.class)
+        saxImportManager(EacImporter.class, EacHandler.class, ImportOptions.properties("eac.properties"))
                 .withScope(SystemScope.getInstance())
                 .importInputStream(ios, logMessage);
         // After...
@@ -102,7 +103,7 @@ public class EacImporterTest extends AbstractImporterTest {
         List<VertexProxy> before = GraphTestBase.getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(eacFile);
-        ImportLog log = saxImportManager(EacImporter.class, EacHandler.class)
+        ImportLog log = saxImportManager(EacImporter.class, EacHandler.class, ImportOptions.properties("eac.properties"))
                 .withScope(SystemScope.getInstance())
                 .importInputStream(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadDescriptionUpdateTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadDescriptionUpdateTest.java
@@ -2,6 +2,7 @@ package eu.ehri.project.importers.ead;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.DocumentaryUnit;
@@ -24,7 +25,8 @@ public class EadDescriptionUpdateTest extends AbstractImporterTest {
     public void testUpdateDescription() throws Exception {
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream("single-ead-multilang-eng.xml");
-        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class);
+        ImportOptions options = ImportOptions.basic();
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, options);
         importManager.importInputStream(ios, "Import English description");
 
         // Added: 1 event, 2 event links, 1 doc unit, 1 description
@@ -34,7 +36,8 @@ public class EadDescriptionUpdateTest extends AbstractImporterTest {
         assertEquals(1, Iterables.size(unit.getDocumentDescriptions()));
 
         InputStream ios2 = ClassLoader.getSystemResourceAsStream("single-ead-multilang-deu.xml");
-        importManager.allowUpdates(true).importInputStream(ios2, "Import German description");
+        SaxImportManager importManager2 = saxImportManager(EadImporter.class, EadHandler.class, options.withUpdates(true));
+        importManager2.importInputStream(ios2, "Import German description");
 
         // Should only have: 1 event, 2 event links , 1 new description
         assertEquals(count + 9, getNodeCount(graph));
@@ -45,7 +48,7 @@ public class EadDescriptionUpdateTest extends AbstractImporterTest {
 
         // Updating the German description should only create event nodes
         InputStream ios3 = ClassLoader.getSystemResourceAsStream("single-ead-multilang-deu-2.xml");
-        importManager.allowUpdates(true).importInputStream(ios3, "Import German description again");
+        importManager2.importInputStream(ios3, "Import German description again");
         // Should only have: 1 event, 2 event links
         assertEquals(count + 12, getNodeCount(graph));
     }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadSyncTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadSyncTest.java
@@ -131,7 +131,7 @@ public class EadSyncTest extends AbstractImporterTest {
     }
 
     private SyncLog runSync(PermissionScope scope, Set<String> excludes, String logMessage, String ead) throws Exception {
-        EadSync sync = new EadSync(graph, api(validUser), scope, validUser, importManager);
+        EadSync sync = EadSync.create(graph, api(validUser), scope, validUser, importManager);
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(ead);
         return sync.sync(m -> {
             try {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadSyncTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadSyncTest.java
@@ -36,7 +36,7 @@ public class EadSyncTest extends AbstractImporterTest {
         repo = manager.getEntity("r1", Repository.class);
         importManager = saxImportManager(EadImporter.class, EadHandler.class)
                 .withScope(repo)
-                .allowUpdates(true);
+                .withUpdates(true);
         importManager.importInputStream(ios, "Initial setup");
     }
 
@@ -122,7 +122,7 @@ public class EadSyncTest extends AbstractImporterTest {
     public void testUnitSyncWithDuplicateIds() throws Exception {
         // Import the data again but with an additional item that duplicates
         // one of the local IDs. If they are non-unique we cannot sync.
-        importManager.allowUpdates(true).withScope(repo)
+        importManager.withUpdates(true).withScope(repo)
                 .importInputStream(ClassLoader.getSystemResourceAsStream(
                         "hierarchical-ead-sync-test-bad.xml"),
                         "Adding item with non-unique ID");

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/FinlandXmlImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/FinlandXmlImporterTest.java
@@ -86,7 +86,7 @@ public class FinlandXmlImporterTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
         //import the english version:
         ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_ENG);
-        importManager.allowUpdates(true).importInputStream(ios, logMessage);
+        importManager.withUpdates(true).importInputStream(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);
         GraphDiff diff = diffGraph(graphState1, graphState2);
@@ -131,7 +131,7 @@ public class FinlandXmlImporterTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1a = getGraphState(graph);
         ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_ENG);
-        importManager.allowUpdates(true).importInputStream(ios, logMessage);
+        importManager.withUpdates(true).importInputStream(ios, logMessage);
         // After...
         List<VertexProxy> graphState2a = getGraphState(graph);
         GraphDiff diffa = diffGraph(graphState1a, graphState2a);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/GenericEadImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/GenericEadImporterTest.java
@@ -21,14 +21,11 @@ package eu.ehri.project.importers.ead;
 
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
-import eu.ehri.project.models.DocumentaryUnit;
-import eu.ehri.project.models.DocumentaryUnitDescription;
-import eu.ehri.project.models.EntityClass;
 import org.junit.Test;
 
 import java.io.InputStream;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -71,8 +68,8 @@ public class GenericEadImporterTest extends AbstractImporterTest {
         int origCount = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream("invalid-ead.xml");
-        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
-                .setTolerant(true)
+        ImportOptions options = ImportOptions.basic().withTolerant(true);
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, options)
                 .importInputStream(ios, "Test invalid item import");
         System.out.println(log.getErrors());
         assertEquals(1, log.getErrored());
@@ -82,8 +79,8 @@ public class GenericEadImporterTest extends AbstractImporterTest {
     @Test
     public void testImportWithLang() throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream("single-ead-multilang-deu.xml");
-        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
-                .setDefaultLang("fre") // overridden!
+        ImportOptions options = ImportOptions.basic().withDefaultLang("fre");
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, options)
                 .importInputStream(ios, "Test language import");
         assertEquals(1, log.getCreated());
         assertTrue(manager.exists("nl-r1-c00001.deu-2_deu"));
@@ -92,8 +89,8 @@ public class GenericEadImporterTest extends AbstractImporterTest {
     @Test
     public void testImportWithDefaultLang() throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream("single-ead-no-lang.xml");
-        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
-                .setDefaultLang("fre")
+        ImportOptions options = ImportOptions.basic().withDefaultLang("fre");
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, options)
                 .importInputStream(ios, "Test language import");
         assertEquals(1, log.getCreated());
         assertTrue(manager.exists("nl-r1-c00001.fre-1_fre"));

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/ItsTest.java
@@ -61,8 +61,7 @@ public class ItsTest extends AbstractImporterTest {
     public void testUnitdate() throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(EAD_EN);
         final String logMessage = "Importing a single EAD by ItsTest";
-        saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("its-pertinence.properties")
+        saxImportManager(EadImporter.class, EadHandler.class, "its-pertinence.properties")
                 .importInputStream(ios, logMessage);
         DocumentaryUnit unit = graph.frame(
                 getVertexByIdentifier(graph, IMPORTED_ITEM_ID),
@@ -88,7 +87,7 @@ public class ItsTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, "its-pertinence" +
-                ".properties").allowUpdates(true);
+                ".properties").withUpdates(true);
         ImportLog log_en = importManager.importInputStream(ios, logMessage);
         ImportLog log_de = importManager.importInputStream(ios2, logMessage);
 
@@ -168,8 +167,7 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("its-provenance.properties")
+        saxImportManager(EadImporter.class, EadHandler.class, "its-provenance.properties")
                 .importInputStream(ios, logMessage);
 
         // After...
@@ -235,8 +233,7 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("its-provenance.properties")
+        saxImportManager(EadImporter.class, EadHandler.class, "its-provenance.properties")
                 .importInputStream(ios, logMessage);
 
         // After...
@@ -267,8 +264,7 @@ public class ItsTest extends AbstractImporterTest {
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
 
-        saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("its-pertinence.properties")
+        saxImportManager(EadImporter.class, EadHandler.class, "its-pertinence.properties")
                 .importInputStream(ios, logMessage);
 
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Jmp130Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Jmp130Test.java
@@ -50,8 +50,7 @@ public class Jmp130Test extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("jmp.properties")
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, "jmp.properties")
                 .importInputStream(ios, logMessage);
 
         List<VertexProxy> graphState1 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/JmpEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/JmpEadTest.java
@@ -52,8 +52,7 @@ public class JmpEadTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("wp2ead.properties")
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, "wp2ead.properties")
                 .importInputStream(ios, logMessage);
 
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/MemShoahTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/MemShoahTest.java
@@ -57,8 +57,7 @@ public class MemShoahTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("memshoah.properties")
+        saxImportManager(EadImporter.class, EadHandler.class, "memshoah.properties")
                 .importInputStream(ios, logMessage);
         // After...
         List<VertexProxy> graphState2 = getGraphState(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/NiodEadXsdTest.java
@@ -23,6 +23,7 @@ import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.exceptions.ItemNotFound;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.models.DatePeriod;
@@ -61,9 +62,8 @@ public class NiodEadXsdTest extends AbstractImporterTest {
         //  Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(XMLFILE);
-        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class)
-                .setTolerant(true)
-                .withProperties("niodead.properties")
+        ImportOptions options = ImportOptions.properties("niodead.properties").withTolerant(true);
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, options)
                 .importInputStream(ios, logMessage);
 
         // One item without an ID errored

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/VC_ARAImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/VC_ARAImporterTest.java
@@ -57,8 +57,7 @@ public class VC_ARAImporterTest extends AbstractImporterTest {
         printGraph(graph);
 
         InputStream ios_vc = ClassLoader.getSystemResourceAsStream(VC_EAD);
-        saxImportManager(VirtualEadImporter.class, VirtualEadHandler.class)
-                .withProperties("vc_ara.properties")
+        saxImportManager(VirtualEadImporter.class, VirtualEadHandler.class, "vc_ara.properties")
                 .importInputStream(ios_vc, logMessage);
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
@@ -161,7 +161,7 @@ public class Wp2BtEadTest extends AbstractImporterTest {
 
         // Check the importer is Idempotent
         ImportLog log2 = importManager
-                .allowUpdates(true)
+                .withUpdates(true)
                 .importInputStream(ClassLoader.getSystemResourceAsStream(SINGLE_EAD), logMessage);
         assertEquals(6, log2.getUnchanged());
         //assertEquals(0, log2.getChanged());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
@@ -77,8 +77,7 @@ public class Wp2YvEadTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class)
-                .withProperties("wp2ead.properties");
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, "wp2ead.properties");
         ImportLog log = importManager.importInputStream(ios, logMessage);
 
         //printGraph(graph);
@@ -149,7 +148,7 @@ public class Wp2YvEadTest extends AbstractImporterTest {
 
         // Check the importer is Idempotent
         ImportLog log2 = importManager
-                .allowUpdates(true)
+                .withUpdates(true)
                 .importInputStream(ClassLoader.getSystemResourceAsStream(SINGLE_EAD), logMessage);
         assertEquals(4, log2.getUnchanged());
         //assertEquals(0, log2.getChanged());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
@@ -84,7 +84,7 @@ public class YadVashemTest extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD_C1);
         ImportOptions options = ImportOptions.properties("yadvashem.properties")
                 .withUpdates(true)
-                .withMerging(true);
+                .withUseSourceId(true);
         saxImportManager(EadImporter.class, EadHandler.class, options)
                 .importInputStream(ios, logMessage);
 
@@ -126,7 +126,7 @@ public class YadVashemTest extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
         ImportOptions options = ImportOptions.properties("yadvashem.properties")
                 .withUpdates(true)
-                .withMerging(true);
+                .withUseSourceId(true);
         SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, options);
         importManager.importInputStream(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
@@ -23,6 +23,7 @@ import com.tinkerpop.blueprints.Vertex;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.importers.managers.SaxImportManager;
 import eu.ehri.project.models.Country;
@@ -60,7 +61,7 @@ public class Eag2896Test extends AbstractImporterTest {
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_UNIT);
         SaxImportManager importManager = new SaxImportManager(graph, country, validUser,
-                EagImporter.class, EagHandler.class);
+                EagImporter.class, EagHandler.class, ImportOptions.properties("eag.properties"));
         ImportLog log = importManager.importInputStream(ios, logMessage);
         //printGraph(graph);
         // How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
@@ -60,7 +60,7 @@ public class Eag2896Test extends AbstractImporterTest {
         logger.info("count of nodes before importing: " + count);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_UNIT);
-        SaxImportManager importManager = new SaxImportManager(graph, country, validUser,
+        SaxImportManager importManager = SaxImportManager.create(graph, country, validUser,
                 EagImporter.class, EagHandler.class, ImportOptions.properties("eag.properties"));
         ImportLog log = importManager.importInputStream(ios, logMessage);
         //printGraph(graph);

--- a/ehri-ws-graphql/pom.xml
+++ b/ehri-ws-graphql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-ws-oaipmh/pom.xml
+++ b/ehri-ws-oaipmh/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-ws/pom.xml
+++ b/ehri-ws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.13.12</version>
+        <version>0.14.0</version>
     </parent>
     <artifactId>ehri-ws</artifactId>
     <name>Web Service</name>

--- a/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/extension/ImportResource.java
@@ -371,7 +371,7 @@ public class ImportResource extends AbstractResource {
             InputStream data)
             throws ItemNotFound, ValidationError, IOException, DeserializationError {
         String eagFile = propertyFile == null
-                ? Resources.getResource("eag.properties").getFile()
+                ? Resources.getResource(EagImporter.class, "eag.properties").getFile()
                 : propertyFile;
         return importEad(scopeId, tolerant, allowUpdates, false, logMessage, defaultLang, eagFile, tag,
                 nameOrDefault(handlerClass, EagHandler.class.getName()),
@@ -400,7 +400,7 @@ public class ImportResource extends AbstractResource {
             InputStream data)
             throws ItemNotFound, ValidationError, IOException, DeserializationError {
         String eacFile = propertyFile == null
-                ? Resources.getResource("eac.properties").getFile()
+                ? Resources.getResource(EacImporter.class, "eac.properties").getFile()
                 : propertyFile;
         return importEad(scopeId, tolerant, allowUpdates, false, logMessage, defaultLang, eacFile, tag,
                 nameOrDefault(handlerClass, EacHandler.class.getName()),

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceClientTest.java
@@ -458,7 +458,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
                 .type(MediaType.TEXT_XML_TYPE)
                 .entity(payloadStream)
                 .post(ClientResponse.class);
-
+        assertStatus(ClientResponse.Status.OK, response);
         ImportLog log = response.getEntity(ImportLog.class);
         assertEquals(1, log.getCreated());
         assertEquals(0, log.getUpdated());
@@ -480,6 +480,7 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
                 .entity(payloadStream)
                 .post(ClientResponse.class);
 
+        assertStatus(ClientResponse.Status.OK, response);
         ImportLog log = response.getEntity(ImportLog.class);
         assertEquals(1, log.getCreated());
         assertEquals(0, log.getUpdated());

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
-    <version>0.13.12</version>
+    <version>0.14.0</version>
     <packaging>pom</packaging>
 
     <name>EHRI Backend</name>


### PR DESCRIPTION
The default behaviour of adding new descriptions if the source ID has changed is more commonly not what we want to do, and quite often the source file ID _has_ changed because of the way the input file is processed. Now, require a `use-source-id` option to be set to enable adding multiple descriptions in the same language.