### PR TITLE
Generalise to IOException when opening a remote stream for import

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -159,7 +159,7 @@ public abstract class AbstractImportManager implements ImportManager {
                 try (InputStream stream = url.openStream()) {
                     logger.info("Importing URL with identifier: {}", name);
                     importInputStream(stream, currentFile, action, log);
-                } catch (ValidationError | SSLException | MalformedURLException | SocketException e) {
+                } catch (ValidationError | IOException e) {
                     log.addError(formatErrorLocation(), e.getMessage());
                     if (!options.tolerant) {
                         throw e;


### PR DESCRIPTION
This prevents bailing when we get e.g. a 503 error for one file