### PR TITLE
Revert "Bump commons-compress from 1.19 to 1.21 in /ehri-core"

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>


### PR DESCRIPTION
This reverts commit 7595c7c85a5b78067ec52867488c919d3c76810a, which caused an incompatible class change error on the server.