### PR TITLE
Add a coreference table importer to the import resource

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>build</artifactId>

--- a/ehri-cli/pom.xml
+++ b/ehri-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <artifactId>ehri-cli</artifactId>
     <name>Command Line Tools</name>

--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <artifactId>ehri-core</artifactId>
     <packaging>jar</packaging>

--- a/ehri-core/src/main/java/eu/ehri/project/persistence/Mutation.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/Mutation.java
@@ -45,6 +45,18 @@ public final class Mutation<T> {
         this(node, state, Optional.ofNullable(bundle));
     }
 
+    public static <T> Mutation<T> created(T item) {
+        return new Mutation<>(item, MutationState.CREATED);
+    }
+
+    public static <T> Mutation<T> updated(T item) {
+        return new Mutation<>(item, MutationState.UPDATED);
+    }
+
+    public static <T> Mutation<T> unchanged(T item) {
+        return new Mutation<>(item, MutationState.UNCHANGED);
+    }
+
     public T getNode() {
         return node;
     }

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/SerializerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/SerializerTest.java
@@ -110,8 +110,8 @@ public class SerializerTest extends AbstractFixtureTest {
         String t1 = DataUtils.get(serialized, "hasLinkTarget[0]/identifier");
         String t2 = DataUtils.get(serialized, "hasLinkTarget[1]/identifier");
         assertNotEquals(t1, t2);
-        assertTrue(Lists.newArrayList("c3", "a1").contains(t1));
-        assertTrue(Lists.newArrayList("c3", "a1").contains(t2));
+        assertTrue(Lists.newArrayList("c3", "a1", "a2").contains(t1));
+        assertTrue(Lists.newArrayList("c3", "a1", "a2").contains(t2));
         try {
             DataUtils.getItem(serialized, "hasLinkTarget[0]/childOf[0]/describes[0]");
             fail("Max ifBelowLevel serialization should ignore childOf relation for item c3");

--- a/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
@@ -49,13 +49,13 @@ public class LinkerTest extends AbstractFixtureTest {
         Vocabulary vocabulary = manager.getEntity("cvoc2", Vocabulary.class);
         int eventCount = Iterables.size(actionManager.getLatestGlobalEvents());
         // The doc c1 contains two access point nodes which should be made
-        // into links
+        // into links, and c3 contains 2
         String logMessage = "This is a test!";
         int newLinkCount = linker
                 .withExcludeSingles(false)
                 .withLogMessage(logMessage)
                 .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
-        assertEquals(2, newLinkCount);
+        assertEquals(4, newLinkCount);
         assertEquals(eventCount + 2,
                 Iterables.size(actionManager.getLatestGlobalEvents()));
         assertEquals(actionManager.getLatestGlobalEvent().getLogMessage(), logMessage);
@@ -88,8 +88,7 @@ public class LinkerTest extends AbstractFixtureTest {
         // This won't create any links because all of the access points only point
         // to single items
         int newLinkCount = linker.withExcludeSingles(true)
-            .createAndLinkRepositoryVocabulary(repository, vocabulary,
-                    validUser);
+            .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
         assertEquals(0, newLinkCount);
         // No new events should have been created...
         assertEquals(eventCount,

--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -337,6 +337,14 @@
                 type: creation
                 startDate: !!str 1939-01-01
                 endDate: !!str 1945-01-01
+          relatesTo:
+            - id: ur3
+              type: AccessPoint
+              data:
+                name: Person Access 2
+                type: person
+                description: test description
+                category: associative
     childOf: c2
     hasPermissionScope: c2    
     access:
@@ -364,6 +372,12 @@
                 type: creation
                 startDate: !!str 1939-01-01
                 endDate: !!str 1945-01-01
+          relatesTo:
+            - id: ur4
+              type: AccessPoint
+              data:
+                name: Disconnected Access 1
+                type: subject
           hasUnknownProperty:
             - id: c4-unp1
               type: UnknownProperty
@@ -588,8 +602,8 @@
   relationships:
     hasLinkTarget:
      - c3
-     - a1
-    hasLinkBody: ur1
+     - a2
+    hasLinkBody: ur3
     hasLinker: mike
 
 - id: link4

--- a/ehri-cypher/pom.xml
+++ b/ehri-cypher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-definitions/pom.xml
+++ b/ehri-definitions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ehri-definitions</artifactId>

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <artifactId>ehri-io</artifactId>
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkImporterTest.java
@@ -6,6 +6,7 @@ import eu.ehri.project.exceptions.DeserializationError;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Link;
+import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Linkable;
 import eu.ehri.project.test.AbstractFixtureTest;
@@ -15,8 +16,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class LinkImporterTest extends AbstractFixtureTest {
 
@@ -61,6 +61,21 @@ public class LinkImporterTest extends AbstractFixtureTest {
         ImportLog log = new LinkImporter(graph, validUser, true)
                 .importLinks(badData, "testing");
         assertEquals(3, log.getCreated());
+    }
+
+    @Test
+    public void importCoreferences() throws Exception {
+        Repository r1 = manager.getEntity("r1", Repository.class);
+        Table data = Table.of(ImmutableList.of(
+                        ImmutableList.of("Subject Access 1", "a1"), // already exists
+                        ImmutableList.of("Person Access 2", "a1"),
+                        ImmutableList.of("Disconnected Access 1", "r4") // Updated
+
+        ));
+        ImportLog log = new LinkImporter(graph, validUser, false)
+                .importCoreferences(r1, data, "Testing");
+        assertEquals(1, log.getCreated());
+        assertEquals(1, log.getUpdated());
     }
 
     private boolean linkExists(String srcId, String dstId, String bodyId, String text) {

--- a/ehri-io/src/test/resources/fixtures/link-resolver.yaml
+++ b/ehri-io/src/test/resources/fixtures/link-resolver.yaml
@@ -16,14 +16,14 @@
           scopeAndContent: Some description text for c5
         relationships:
           relatesTo:
-            - id: ur3
+            - id: ur5
               type: AccessPoint
               data:
                 name: Unresolved 1
                 type: person
                 cvoc: auths
                 target: a1
-            - id: ur4
+            - id: ur6
               type: AccessPoint
               data:
                 name: Unresolved 2

--- a/ehri-ws-graphql/pom.xml
+++ b/ehri-ws-graphql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/extension/test/GraphQLResourceClientTest.java
@@ -101,7 +101,7 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
                 .path("children").path("items").path(0)
                 .path("children").path("items").path(0)
                 .path("id").textValue());
-        assertEquals("a1", data.path("data").path("c3").path("related")
+        assertEquals("a2", data.path("data").path("c3").path("related")
                 .path(0).path("item").path("id").textValue());
         assertEquals("Amsterdam", data.path("data").path("c1").path("repository")
                 .path("english").path("addresses").path(0)

--- a/ehri-ws-oaipmh/pom.xml
+++ b/ehri-ws-oaipmh/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ehri-data</artifactId>
         <groupId>ehri-project</groupId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ehri-ws/pom.xml
+++ b/ehri-ws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ehri-project</groupId>
         <artifactId>ehri-data</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </parent>
     <artifactId>ehri-ws</artifactId>
     <name>Web Service</name>

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ImportResourceClientTest.java
@@ -504,6 +504,25 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
         assertEquals(3, out.getCreated());
     }
 
+    @Test
+    public void testImportCoreferences() {
+        Table table = Table.of(ImmutableList.of(
+                ImmutableList.of("Subject Access 1", "a1"), // already exists
+                ImmutableList.of("Person Access 2", "a1"),
+                ImmutableList.of("Disconnected Access 1", "r4") // Updated
+        ));
+        URI jsonUri = ehriUriBuilder(ImportResource.ENDPOINT, "coreferences")
+                .queryParam("scope", "r1")
+                .queryParam("commit", "true")
+                .build();
+        ClientResponse response = callAs(getAdminUserProfileId(), jsonUri)
+                .entity(table)
+                .post(ClientResponse.class);
+        ImportLog out = response.getEntity(ImportLog.class);
+        assertEquals(1, out.getCreated());
+        assertEquals(1, out.getUpdated());
+    }
+
     private UriBuilder getImportUrl(String endPoint, String scopeId, String log, boolean tolerant) {
         return ehriUriBuilder(ImportResource.ENDPOINT, endPoint)
                 .queryParam(LOG_PARAM, log)

--- a/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/extension/test/ToolsResourceClientTest.java
@@ -142,7 +142,7 @@ public class ToolsResourceClientTest extends AbstractResourceClientTest {
                         Table.of(ImmutableList.of(ImmutableList.of("a1", "a2"))));
         String out = response.getEntity(String.class);
         assertStatus(OK, response);
-        assertEquals("a1,a2,2\n", out);
+        assertEquals("a1,a2,1\n", out);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ehri-project</groupId>
     <artifactId>ehri-data</artifactId>
-    <version>0.14.0</version>
+    <version>0.14.1</version>
     <packaging>pom</packaging>
 
     <name>EHRI Backend</name>


### PR DESCRIPTION
This is able to idempotently set the link body to an access point matching the text-to-target pairing given in the provided table.

Also bumped version.