### PR TITLE
Add an EAD hack to extract the 'ref' field from materialspec/extptr

### DIFF
--- a/ehri-io/src/main/resources/ead2002.properties
+++ b/ehri-io/src/main/resources/ead2002.properties
@@ -28,10 +28,14 @@ profiledesc/descrules/=rulesAndConventions
 processinfo/p/=archivistNote
 processinfo/p/date/=datesOfDescriptions
 processinfo/p/bibref/=sources
+processinfo/note/p/=ref
 did/abstract/=abstract
 did/physdesc/extent/=extentAndMedium
 did/physdesc/physfacet=extentAndMedium
 did/unitid/=objectIdentifier
+# NB: This is kind of a hack since materialspec
+# is not a good fit for this kind of info really:
+did/materialspec/extptr/@extptrhref=ref
 altformavail/p/=locationOfCopies
 originalsloc/p/=locationOfOriginals
 did/unittitle/=name
@@ -66,4 +70,5 @@ separatedmaterial/p/=separatedUnitsOfDescription
 #attributes
 @level=levelOfDesc
 @langcode=languagecode
+@href=extptrhref
 # TODO: langmaterial

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadSingleEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/IcaAtomEadSingleEadTest.java
@@ -85,8 +85,8 @@ public class IcaAtomEadSingleEadTest extends AbstractImporterTest {
                 "This is some test scope and content.\n\n" +
                         "This contains Something & Something else.\n\n" +
                         "This is another paragraph.";
-
         assertEquals(expected, scopeContent);
+        assertEquals("https://www.example.com/a", firstDesc.getProperty("ref"));
 
         // Check the right nodes get created.
         int createCount = origCount + 13;

--- a/ehri-io/src/test/resources/single-ead.xml
+++ b/ehri-io/src/test/resources/single-ead.xml
@@ -62,6 +62,9 @@
 				<language langcode="rum">Romanian</language>
 				<language langcode="yid">Yiddish</language>
 			</langmaterial>
+            <materialspec label="Web Source">
+				<extptr href="https://www.example.com/a" />
+			</materialspec>
 		</did>
 		<scopecontent encodinganalog="3.3.1">
 			<p>


### PR DESCRIPTION
This is a bit gross, since it's kind of a misuse of the tag, but there are few other places to put an extptr that won't break existing
assumptions. :|