### PR TITLE
Update Neo4j to 3.5.28 and tweak the Docker init script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for EHRI backend web service
-FROM neo4j:3.5.21
+FROM neo4j:3.5.28
 
 ENV NEO4J_HOME=/var/lib/neo4j
 ENV NEO4J_AUTH=none

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <neo4j.version>3.5.21</neo4j.version>
+        <neo4j.version>3.5.28</neo4j.version>
         <blueprints.version>2.6.0</blueprints.version>
         <jackson.version>2.10.5</jackson.version>
         <junit.version>4.13.1</junit.version>

--- a/scripts/initdb.sh
+++ b/scripts/initdb.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-echo "Initializing DB: $NEO4J_HOME/data/databases/graph.db"
 
-$NEO4J_HOME/scripts/cmd initialize
-$NEO4J_HOME/scripts/cmd gen-schema
+NEO4J_DB="$NEO4J_HOME/data/databases/graph.db"
+if [ ! -d "$NEO4J_DB" ]; then
+  echo "Initializing DB: $NEO4J_DB"
+  $NEO4J_HOME/scripts/cmd initialize
+  $NEO4J_HOME/scripts/cmd gen-schema
+fi
 
 ADMIN_USER=${ADMIN_USER:-""}
 


### PR DESCRIPTION
We now only run initialisation in the Docker image if there is no graph already. This makes the image useful for dev as well
as testing.