### PR TITLE
Revert updated commons-compress

### DIFF
--- a/ehri-core/pom.xml
+++ b/ehri-core/pom.xml
@@ -167,7 +167,8 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <!-- NB: later versions are incompatible w/ Neo4j 3.5 -->
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>


### PR DESCRIPTION
This reverts 94c66e953623a645f01e3fa6314e86a153b46db7

Updated commons compress is incompatible w/ Neo4j 3.5