### PR TITLE
Fix fetching of link targets and Concept related items

### DIFF
--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
@@ -140,6 +140,10 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
                 .path("items").size());
         assertFalse(data.path("data").path("topLevelDocumentaryUnits")
                 .path("items").path(0).path("id").isMissingNode());
+        assertEquals("c4", data.path("data").path("r4").path("links")
+                .path(0).path("targets").path(0).path("id").textValue());
+        assertEquals("cvocc1", data.path("data").path("cvocc2").path("related")
+                .path(0).path("id").textValue());
         assertFalse(data.path("data").path("wrongType").isMissingNode());
         assertTrue(data.path("data").path("wrongType").isNull());
     }

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -180,6 +180,20 @@ query test {
         }
     }
 
+    r4: Repository(id: "r4") {
+        links {
+            targets {
+                id
+            }
+        }
+    }
+
+    cvocc2: CvocConcept(id: "cvocc2") {
+        related {
+            id
+        }
+    }
+
     wrongType: HistoricalAgent(id: "c1") {
         id
     }


### PR DESCRIPTION
Two different issues here: there was a missing data fetcher for the link and annotation targets relationship. Unrelatedly, there was a name clash which resulted in the concept type attempting to return a set of relationship items for the `related` instead of SKOS `related` concepts (very confusing I know.)