### PR TITLE
Fixes for handling EADs with completely anonymous C-levels

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
@@ -207,12 +207,6 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
         final String languageOfDesc = descBundle.getDataValue(Ontology.LANGUAGE_OF_DESCRIPTION);
         final String thisSourceFileId = descBundle.getDataValue(Ontology.SOURCEFILE_KEY);
 
-        // Ensure none of the parent items (not yet saved) have an invalid
-        // missing identifier
-        if (idPath.contains(null)) {
-            throw new ValidationError(unit, Ontology.IDENTIFIER_KEY, "Parent item has missing identifier");
-        }
-
         /*
          * for some reason, the idpath from the permissionscope does not contain the parent documentary unit.
          * TODO: so for now, it is added manually
@@ -220,8 +214,16 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
         List<String> itemIdPath = Lists.newArrayList(getPermissionScope().idPath());
         itemIdPath.addAll(idPath);
 
+
+        // Ensure none of the parent items (not yet saved) have an invalid
+        // missing identifier
+        if (itemIdPath.contains(null)) {
+            throw new ValidationError(unit, Ontology.IDENTIFIER_KEY, "Parent item has missing identifier");
+        }
+
         Bundle unitWithIds = unit.generateIds(itemIdPath);
         logger.debug("merging: docUnit's graph id = {}", unitWithIds.getId());
+
         // If the bundle exists, we merge
         if (manager.exists(unitWithIds.getId())) {
             try {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -70,7 +70,7 @@ public abstract class AbstractImportManager implements ImportManager {
 
     // Ugly stateful variables for tracking import state
     // and reporting errors usefully...
-    private String currentFile;
+    protected String currentFile;
     protected Integer currentPosition;
     protected final Class<? extends ItemImporter<?, ?>> importerClass;
     private int consecutiveIoErrors = 0;
@@ -130,7 +130,7 @@ public abstract class AbstractImportManager implements ImportManager {
         try {
             importInputStream(stream, tag, action, log);
         } catch (ValidationError e) {
-            throw new ImportValidationError(formatErrorLocation(), e);
+            throw new ImportValidationError(e.getMessage(), e);
         }
 
         // Commit the action if necessary
@@ -162,7 +162,9 @@ public abstract class AbstractImportManager implements ImportManager {
                 } catch (ValidationError e) {
                     log.addError(formatErrorLocation(), e.getMessage());
                     if (!options.tolerant) {
-                        throw new ImportValidationError(formatErrorLocation(), e);
+                        // when importing from an input stream there is no point giving
+                        // a formatted error location since the XML file is always null
+                        throw new ImportValidationError(e.getMessage(), e);
                     }
                 } catch (IOException | InputParseError e) {
                     e.printStackTrace();
@@ -335,8 +337,7 @@ public abstract class AbstractImportManager implements ImportManager {
     }
 
     private String formatErrorLocation() {
-        return String.format("File: %s, XML document: %d", currentFile,
-                currentPosition);
+        return String.format("File: %s, XML document: %d", currentFile, currentPosition);
     }
 
     private InputStream readUrl(URL url, int retry) throws IOException {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/AnonymousCLevelTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/AnonymousCLevelTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.importers.ead;
+
+import eu.ehri.project.importers.ImportLog;
+import eu.ehri.project.importers.ImportOptions;
+import eu.ehri.project.importers.base.AbstractImporterTest;
+import eu.ehri.project.importers.exceptions.ImportValidationError;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+
+public class AnonymousCLevelTest extends AbstractImporterTest {
+
+    @Test
+    public void testImportItems() throws Exception {
+        String ead = "anonymous-c-levels.xml";
+        InputStream ios = ClassLoader.getSystemResourceAsStream(ead);
+        try {
+            saxImportManager(EadImporter.class, EadHandler.class).importInputStream(ios, "Test");
+            fail("Import with " + ead + " should have thrown a validation error");
+        } catch (ImportValidationError ex) {
+            assertThat(ex.getError().getMessage(),
+                    containsString("DocumentaryUnit p/c1/[null] - [Item completed prior to line: 29]: " +
+                            "identifier: Parent item has missing identifier"));
+        }
+    }
+
+    @Test
+    public void testImportItemsTolerant() throws Exception {
+        String ead = "anonymous-c-levels.xml";
+        InputStream ios = ClassLoader.getSystemResourceAsStream(ead);
+        ImportLog log = saxImportManager(EadImporter.class, EadHandler.class, ImportOptions.basic().withTolerant(true))
+                .importInputStream(ios, "Test");
+        System.out.println(log.getData());
+        assertEquals(2, log.getCreated());
+        assertEquals(2, log.getErrored());
+    }
+}

--- a/ehri-io/src/test/resources/anonymous-c-levels.xml
+++ b/ehri-io/src/test/resources/anonymous-c-levels.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN"
+        "http://lcweb2.loc.gov/xmlcommon/dtds/ead2002/ead.dtd">
+
+<ead>
+    <eadheader>
+        <eadid>C00001</eadid>
+        <filedesc>
+            <titlestmt>
+                <titleproper encodinganalog="Title">Test EAD Item</titleproper>
+            </titlestmt>
+        </filedesc>
+    </eadheader>
+    <archdesc level="collection" relatedencoding="ISAD(G)v2">
+        <did>
+            <unittitle>Parent</unittitle>
+            <unitid>p</unitid>
+        </did>
+        <dsc type="combined">
+            <c>
+                <did>
+                    <unitid>c1</unitid>
+                </did>
+                <c>
+                    <c>
+                        <did>
+                            <unitid>c2</unitid>
+                        </did>
+                    </c>
+                </c>
+            </c>
+        </dsc>
+    </archdesc>
+</ead>

--- a/ehri-ws/src/main/java/eu/ehri/project/ws/RepositoryResource.java
+++ b/ehri-ws/src/main/java/eu/ehri/project/ws/RepositoryResource.java
@@ -128,7 +128,6 @@ public class RepositoryResource extends AbstractAccessibleResource<Repository>
             @QueryParam(VERSION_PARAM) @DefaultValue("true") boolean version,
             @QueryParam("batch") @DefaultValue("-1") int batchSize)
                 throws ItemNotFound, PermissionDenied, HierarchyError {
-        System.out.printf("All: %s, Batch size: %d%n", all, batchSize);
         try (final Tx tx = beginTx()) {
             Table out = deleteContents(id, all, version, batchSize);
             tx.success();

--- a/ehri-ws/src/main/java/eu/ehri/project/ws/errors/mappers/ValidationErrorMapper.java
+++ b/ehri-ws/src/main/java/eu/ehri/project/ws/errors/mappers/ValidationErrorMapper.java
@@ -37,6 +37,7 @@ public class ValidationErrorMapper implements ExceptionMapper<ValidationError> {
     public Response toResponse(ValidationError e) {
         return WebDeserializationError.errorToJson(
                 Status.BAD_REQUEST,
+                e.getMessage(),
                 e.getErrorSet().toData());
     }
 }

--- a/ehri-ws/src/test/java/eu/ehri/project/ws/test/ImportResourceClientTest.java
+++ b/ehri-ws/src/test/java/eu/ehri/project/ws/test/ImportResourceClientTest.java
@@ -174,6 +174,23 @@ public class ImportResourceClientTest extends AbstractResourceClientTest {
     }
 
     @Test
+    public void testImportEadWithValidationError() {
+        InputStream payloadStream = getClass()
+                .getClassLoader().getResourceAsStream("anonymous-c-levels.xml");
+        URI uri = getImportUrl("ead", "r1", "Error test", false)
+                .queryParam(HANDLER_PARAM, EadHandler.class.getName())
+                .queryParam(COMMIT_PARAM, true)
+                .build();
+        ClientResponse response = callAs(getAdminUserProfileId(), uri)
+                .type(MediaType.TEXT_XML_TYPE)
+                .entity(payloadStream)
+                .post(ClientResponse.class);
+
+        System.out.println(response.getEntity(String.class));
+        assertStatus(ClientResponse.Status.BAD_REQUEST, response);
+    }
+
+    @Test
     public void testImportSingleEadWithValidationErrorInTolerantMode() {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("invalid-ead.xml");

--- a/ehri-ws/src/test/resources/anonymous-c-levels.xml
+++ b/ehri-ws/src/test/resources/anonymous-c-levels.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE ead PUBLIC "+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN"
+        "http://lcweb2.loc.gov/xmlcommon/dtds/ead2002/ead.dtd">
+<ead>
+    <eadheader>
+        <eadid>C00001</eadid>
+        <filedesc>
+            <titlestmt>
+                <titleproper encodinganalog="Title">Test EAD Item</titleproper>
+            </titlestmt>
+        </filedesc>
+    </eadheader>
+    <archdesc level="collection" relatedencoding="ISAD(G)v2">
+        <did>
+            <unittitle>Parent</unittitle>
+            <unitid>p</unitid>
+        </did>
+        <dsc type="combined">
+            <c>
+                <did>
+                    <unitid>c1</unitid>
+                </did>
+                <c>
+                    <c>
+                        <did>
+                            <unitid>c2</unitid>
+                        </did>
+                    </c>
+                </c>
+            </c>
+        </dsc>
+    </archdesc>
+</ead>


### PR DESCRIPTION
This caused issues because we didn't push an ID on the stack until we saw the <did> section, and that never happened, so the stack got confused. This didn't manifest itself unless the import was done in tolerant mode.

A second fix passes more info about *where* the error occurred to the web service.