### PR TITLE
Use a library for sloppy date parsing

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -72,6 +72,7 @@
                             <include>com.typesafe:config</include>
                             <include>com.flipkart.zjsonpatch:zjsonpatch</include>
                             <include>org.apache.commons:commons-collections4</include>
+                            <include>com.github.sisyphsu:*</include>
 
                             <!-- GraphQL deps -->
                             <include>org.antlr:antlr4-runtime</include>

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
@@ -35,7 +35,7 @@ import eu.ehri.project.models.base.*;
  */
 @EntityType(EntityClass.AUTHORITATIVE_SET)
 public interface AuthoritativeSet extends Accessible, PermissionScope, ItemHolder, Named, Promotable, Annotatable {
-
+    
     @Meta(CHILD_COUNT)
     @UniqueAdjacency(label = Ontology.ITEM_IN_AUTHORITATIVE_SET, direction = Direction.IN)
     int countChildren();

--- a/ehri-io/pom.xml
+++ b/ehri-io/pom.xml
@@ -108,6 +108,13 @@
             <version>1.4.1</version>
         </dependency>
 
+        <!-- Date parsing -->
+        <dependency>
+            <groupId>com.github.sisyphsu</groupId>
+            <artifactId>dateparser</artifactId>
+            <version>1.0.11</version>
+        </dependency>
+
         <!-- Jackson CSV -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/ehri-io/src/main/java/eu/ehri/project/importers/base/AbstractImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/base/AbstractImporter.java
@@ -30,7 +30,10 @@ import eu.ehri.project.importers.ErrorCallback;
 import eu.ehri.project.importers.ImportCallback;
 import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.ImportOptions;
+import eu.ehri.project.importers.links.LinkResolver;
+import eu.ehri.project.importers.util.DateParser;
 import eu.ehri.project.models.base.Accessible;
+import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
 import eu.ehri.project.persistence.Bundle;
@@ -48,6 +51,8 @@ public abstract class AbstractImporter<I, T extends Accessible> implements ItemI
     protected final GraphManager manager;
     protected final ImportOptions options;
     protected final ImportLog log;
+    protected final DateParser dateParser;
+    protected final LinkResolver linkResolver;
     private final List<ImportCallback> callbacks = Lists.newArrayList();
     private final List<ErrorCallback> errorCallbacks = Lists.newArrayList();
 
@@ -91,6 +96,8 @@ public abstract class AbstractImporter<I, T extends Accessible> implements ItemI
         this.log = log;
         this.options = options;
         manager = GraphManagerFactory.getInstance(graph);
+        linkResolver = new LinkResolver(graph, actioner.as(Accessor.class));
+        dateParser = new DateParser();
     }
 
     @Override

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eac/EacImporter.java
@@ -30,12 +30,10 @@ import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.base.PermissionScopeFinder;
-import eu.ehri.project.importers.links.LinkResolver;
 import eu.ehri.project.importers.util.ImportHelpers;
 import eu.ehri.project.models.AccessPointType;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.HistoricalAgent;
-import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.Description;
 import eu.ehri.project.models.base.PermissionScope;
@@ -58,8 +56,6 @@ public class EacImporter extends AbstractImporter<Map<String, Object>, Historica
     private static final String REL_TYPE = "type";
     private static final String REL_NAME = "name";
 
-    private final LinkResolver linkResolver;
-
     /**
      * Construct an EacImporter object.
      *
@@ -71,7 +67,6 @@ public class EacImporter extends AbstractImporter<Map<String, Object>, Historica
      */
     public EacImporter(FramedGraph<?> graph, PermissionScopeFinder permissionScope, Actioner actioner, ImportOptions options, ImportLog log) {
         super(graph, permissionScope, actioner, options, log);
-        linkResolver = new LinkResolver(graph, actioner.as(Accessor.class));
     }
 
     @Override
@@ -92,7 +87,7 @@ public class EacImporter extends AbstractImporter<Map<String, Object>, Historica
                 extractUnitDescription(itemData, EntityClass.HISTORICAL_AGENT_DESCRIPTION));
 
         // Add dates and descriptions to the bundle since they are @Dependent relations.
-        for (Map<String, Object> dpb : ImportHelpers.extractDates(itemData)) {
+        for (Map<String, Object> dpb : dateParser.extractDates(itemData)) {
             descBundle = descBundle.withRelation(Ontology.ENTITY_HAS_DATE, Bundle.of(EntityClass.DATE_PERIOD, dpb));
         }
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/ead/EadImporter.java
@@ -31,17 +31,18 @@ import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.base.AbstractImporter;
 import eu.ehri.project.importers.base.PermissionScopeFinder;
-import eu.ehri.project.importers.links.LinkResolver;
 import eu.ehri.project.importers.util.ImportHelpers;
 import eu.ehri.project.models.AccessPointType;
 import eu.ehri.project.models.DocumentaryUnit;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.base.AbstractUnit;
-import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
-import eu.ehri.project.persistence.*;
+import eu.ehri.project.persistence.Bundle;
+import eu.ehri.project.persistence.BundleManager;
+import eu.ehri.project.persistence.Mutation;
+import eu.ehri.project.persistence.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,6 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
     //the EadImporter can import ead as DocumentaryUnits, the default, or overwrite those and create VirtualUnits instead.
     private final EntityClass unitEntity = EntityClass.DOCUMENTARY_UNIT;
     private final Serializer mergeSerializer;
-    private final LinkResolver linkResolver;
 
     public static final String ACCESS_POINT = "AccessPoint";
 
@@ -80,8 +80,6 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
     public EadImporter(FramedGraph<?> graph, PermissionScopeFinder scopeFinder, Actioner actioner, ImportOptions options, ImportLog log) {
         super(graph, scopeFinder, actioner, options, log);
         mergeSerializer = new Serializer.Builder(graph).dependentOnly().build();
-        linkResolver = new LinkResolver(graph, actioner.as(Accessor.class));
-
     }
 
     /**
@@ -146,7 +144,7 @@ public class EadImporter extends AbstractImporter<Map<String, Object>, AbstractU
      * @throws ValidationError when data constraints are not met
      */
     protected Bundle getDescription(Map<String, Object> itemData) throws ValidationError {
-        List<Map<String, Object>> extractedDates = ImportHelpers.extractDates(itemData);
+        List<Map<String, Object>> extractedDates = dateParser.extractDates(itemData);
 
         Map<String, Object> raw = ImportHelpers.extractDescription(itemData, EntityClass.DOCUMENTARY_UNIT_DESCRIPTION);
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/eag/EagImporter.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/eag/EagImporter.java
@@ -109,7 +109,7 @@ public class EagImporter extends AbstractImporter<Map<String, Object>, Repositor
 
         // Add dates and descriptions to the bundle since they're @Dependent
         // relations.
-        for (Map<String, Object> dpb : ImportHelpers.extractDates(itemData)) {
+        for (Map<String, Object> dpb : dateParser.extractDates(itemData)) {
             descBundle = descBundle.withRelation(Ontology.ENTITY_HAS_DATE, Bundle.of(EntityClass.DATE_PERIOD, dpb));
         }
 

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -55,7 +55,6 @@ public class SaxImportManager extends AbstractImportManager {
 
     private static final Logger logger = LoggerFactory.getLogger(SaxImportManager.class);
 
-    private static final Config config = ConfigFactory.load();
     private final Class<? extends SaxXmlHandler> handlerClass;
     private final ImportOptions options;
     private final List<ImportCallback> extraCallbacks;

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/DateParser.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/DateParser.java
@@ -5,26 +5,17 @@ import com.google.common.collect.Maps;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.properties.XmlImportProperties;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static eu.ehri.project.importers.util.ImportHelpers.getSubNode;
 
 /**
- * This class contains static functions to extract date information from
- * largely unstructured maps.
+ * Class for extracting date info from unstructured or semi-structured data and text.
  *
  * There are two main scenarios:
  *
@@ -37,43 +28,15 @@ import static eu.ehri.project.importers.util.ImportHelpers.getSubNode;
  *  Notable, the function that returns the dates removes the data from
  *  which they were extracted
  */
-class DateParser {
+public class DateParser {
 
     private static final Logger logger = LoggerFactory.getLogger(DateParser.class);
-
-    // Various date patterns
-    private static final Pattern[] datePatterns = {
-            // Yad Vashem, ICA-Atom style: 1924-1-1 - 1947-12-31
-            // Yad Vashem in Wp2: 12-15-1941, 9-30-1944
-            Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})\\s?-\\s?(\\d{4}-\\d{1,2}-\\d{1,2})$"),
-            Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})$"),
-            Pattern.compile("^(\\d{4})\\s?-\\s?(\\d{4})$"),
-            Pattern.compile("^(\\d{4})-\\[(\\d{4})\\]$"),
-            Pattern.compile("^(\\d{4})-\\[(\\d{4})\\]$"),
-            Pattern.compile("^(\\d{4}s)-\\[(\\d{4}s)\\]$"),
-            Pattern.compile("^\\[(\\d{4})\\]$"),
-            Pattern.compile("^(\\d{4})$"),
-            Pattern.compile("^(\\d{2})th century$"),
-            Pattern.compile("^\\s*(\\d{4})\\s*-\\s*(\\d{4})"),
-            //bundesarchive: 1906/19
-            Pattern.compile("^\\s*(\\d{4})/(\\d{2})"),
-            Pattern.compile("^\\s*(\\d{4})\\s*/\\s*(\\d{4})"),
-            Pattern.compile("^(\\d{4}-\\d{1,2})/(\\d{4}-\\d{1,2})"),
-            Pattern.compile("^(\\d{4}-\\d{1,2}-\\d{1,2})/(\\d{4}-\\d{1,2}-\\d{1,2})"),
-            Pattern.compile("^(\\d{4})/(\\d{4}-\\d{1,2}-\\d{1,2})")
-    };
-
-    // NB: Using English locale here to avoid ambiguities caused by system dependent
-    // time zones such as: Cannot parse "1940-05-16": Illegal instant due to time zone
-    // offset transition (Europe/Amsterdam)
-    // https://en.wikipedia.org/wiki/UTC%2B00:20
-    private static final DateTimeFormatter isoDateTimeFormat = ISODateTimeFormat.date().withLocale(Locale.ENGLISH);
-
-    // NB: Not static yet since these objects aren't thread safe :(
-    private static final SimpleDateFormat yearMonthDateFormat = new SimpleDateFormat("yyyy-MM");
-    private static final SimpleDateFormat yearDateFormat = new SimpleDateFormat("yyyy");
     private static final XmlImportProperties dates = new XmlImportProperties("dates.properties");
+    private final DateRangeParser rangeParser;
 
+    public DateParser() {
+        rangeParser = new DateRangeParser();
+    }
 
     /**
      * Extract a set of dates from input data. The input data is mutated to
@@ -82,7 +45,7 @@ class DateParser {
      * @param data a map of input data
      * @return a list of parsed date period maps
      */
-    static List<Map<String, Object>> extractDates(Map<String, Object> data) {
+    public List<Map<String, Object>> extractDates(Map<String, Object> data) {
         List<Map<String, Object>> extractedDates = Lists.newArrayList();
 
         if (data.containsKey(Entities.DATE_PERIOD)) {
@@ -108,7 +71,7 @@ class DateParser {
         return extractedDates;
     }
 
-    private static void replaceDates(Map<String, Object> data, List<Map<String, Object>> extractedDates, Map<String, String> dateValues) {
+    private void replaceDates(Map<String, Object> data, List<Map<String, Object>> extractedDates, Map<String, String> dateValues) {
         Map<String, String> dateTypes = Maps.newHashMap();
         for (String dateValue : dateValues.keySet()) {
             dateTypes.put(dateValues.get(dateValue), null);
@@ -134,23 +97,8 @@ class DateParser {
         }
     }
 
-    private static Optional<Map<String, Object>> extractDate(String date) {
-        Map<String, Object> data = matchDate(date);
-        return data.isEmpty() ? Optional.empty() : Optional.of(data);
-    }
-
-    private static Map<String, Object> matchDate(String date) {
-        Map<String, Object> data = Maps.newHashMap();
-        for (Pattern re : datePatterns) {
-            Matcher matcher = re.matcher(date);
-            if (matcher.matches()) {
-                data.put(Ontology.DATE_PERIOD_START_DATE, normaliseDate(matcher.group(1)));
-                data.put(Ontology.DATE_PERIOD_END_DATE, normaliseDate(matcher.group(matcher.groupCount() > 1 ? 2 : 1), true));
-                data.put(Ontology.DATE_HAS_DESCRIPTION, date);
-                break;
-            }
-        }
-        return data;
+    private Optional<Map<String, Object>> extractDate(String date) {
+        return rangeParser.parse(date).map(DateRange::data);
     }
 
     private static Map<String, String> returnDatesAsString(Map<String, Object> data) {
@@ -171,41 +119,5 @@ class DateParser {
             }
         }
         return datesAsString;
-    }
-
-    static String normaliseDate(String date) {
-        return normaliseDate(date, false);
-    }
-
-    /**
-     * Normalise a date in a string.
-     *
-     * @param date        a String date that needs formatting
-     * @param endOfPeriod a string signifying whether this date is the begin of
-     *                    a period or the end of a period
-     * @return a String containing the formatted date.
-     */
-    static String normaliseDate(String date, boolean endOfPeriod) {
-        String returnDate = isoDateTimeFormat.print(DateTime.parse(date));
-        if (returnDate.startsWith("00")) {
-            returnDate = "19" + returnDate.substring(2);
-            date = "19" + date;
-        }
-        if (endOfPeriod) {
-            if (!date.equals(returnDate)) {
-                ParsePosition p = new ParsePosition(0);
-                yearMonthDateFormat.parse(date, p);
-                if (p.getIndex() > 0) {
-                    returnDate = isoDateTimeFormat.print(DateTime.parse(date).plusMonths(1).minusDays(1));
-                } else {
-                    p = new ParsePosition(0);
-                    yearDateFormat.parse(date, p);
-                    if (p.getIndex() > 0) {
-                        returnDate = isoDateTimeFormat.print(DateTime.parse(date).plusYears(1).minusDays(1));
-                    }
-                }
-            }
-        }
-        return returnDate;
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/DateParser.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/DateParser.java
@@ -98,7 +98,7 @@ public class DateParser {
     }
 
     private Optional<Map<String, Object>> extractDate(String date) {
-        return rangeParser.parse(date).map(DateRange::data);
+        return rangeParser.tryParse(date).map(DateRange::data);
     }
 
     private static Map<String, String> returnDatesAsString(Map<String, Object> data) {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/DateRange.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/DateRange.java
@@ -1,0 +1,84 @@
+package eu.ehri.project.importers.util;
+
+import eu.ehri.project.definitions.Ontology;
+import org.apache.jena.ext.com.google.common.collect.Maps;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Objects;
+
+public class DateRange {
+
+    private static final DateTimeFormatter isoDateFormat = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    private final LocalDate start;
+    private final LocalDate end;
+    private final String description;
+
+    public DateRange(LocalDate start, LocalDate end, String description) {
+        if (start == null) {
+            throw new IllegalArgumentException("DateRange start must not be null");
+        }
+        this.start = start;
+        this.end = end;
+        this.description = description;
+    }
+
+    public static DateRange of(LocalDate start, LocalDate end, String description) {
+        return new DateRange(start, end, description);
+    }
+
+    public DateRange(LocalDate start, String description) {
+        this(start, null, description);
+    }
+
+    @Override
+    public String toString() {
+        return end != null
+                ? String.format("%s - %s", toLocalDateString(start), toLocalDateString(end))
+                : toLocalDateString(start);
+    }
+
+    /**
+     * Debug constructor: creates a DateRange from a "YYYY-MM-DD - YYYY-MM-DD"
+     * string.
+     */
+    public static DateRange fromString(String s, String description) {
+        final String[] split = s.split("\\s-\\s");
+            final LocalDate d1 = LocalDate.parse(split[0]);
+            final LocalDate d2 = split.length > 1 ? LocalDate.parse(split[1]) : null;
+            return new DateRange(d1, d2, description);
+    }
+
+    public Map<String, Object> data() {
+        Map<String, Object> data = Maps.newHashMap();
+        data.put(Ontology.DATE_PERIOD_START_DATE, toLocalDateString(start));
+        if (end != null) {
+            data.put(Ontology.DATE_PERIOD_END_DATE, toLocalDateString(end));
+        }
+        if (description != null) {
+            data.put(Ontology.DATE_HAS_DESCRIPTION, description);
+        }
+        return data;
+    }
+
+    private String toLocalDateString(LocalDate instant) {
+        return instant.format(isoDateFormat);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DateRange dateRange = (DateRange) o;
+        return start.equals(dateRange.start)
+                && Objects.equals(end, dateRange.end)
+                && description.equals(dateRange.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end, description);
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/DateRangeParser.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/DateRangeParser.java
@@ -1,0 +1,108 @@
+package eu.ehri.project.importers.util;
+
+import com.github.sisyphsu.dateparser.DateParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DateRangeParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(DateRangeParser.class);
+    private static final Pattern yearRange = Pattern.compile("^(?<start>\\d{4})\\s?[\\-/]\\s?(?<end>\\d{4})$");
+    private static final String SEP_CHARS = "/-";
+
+    private final DateParser parser;
+
+    public DateRangeParser() {
+        parser = DateParser.newBuilder()
+                .addRule("(?<year>\\d{4}) ca\\.?")
+                .addRule("summer (?<year>\\d{4})")
+                .addRule("(?<year>\\d{4})[/\\-](?<month>\\d)[/\\-](?<day>\\d)")
+                .addRule("(?<month>\\d{2})/(?<year>\\d{4})")
+                .addRule("(?<year>\\d{4})-(?<month>\\d{2})")
+                .build();
+    }
+
+    private Optional<DateRange> parseRange(String from, String to, String orig) {
+        final LocalDate d1 = parser.parseDateTime(from).toLocalDate();
+        final LocalDate d2 = parser.parseDateTime(to).toLocalDate();
+
+        // If we don't have a specific day or month, set these to the appropriate maximum
+        // based on the length of the raw date string - a fallible heuristic for sure.
+        final String rawDateString = to.replaceAll("\\D", "");
+        if (rawDateString.length() < 6) {
+            return Optional.of(DateRange.of(
+                    d1,
+                    d2.with(TemporalAdjusters.lastDayOfYear()),
+                    orig
+            ));
+        } else if (rawDateString.length() < 8) {
+            return Optional.of(DateRange.of(
+                    d1,
+                    d2.with(TemporalAdjusters.lastDayOfMonth()),
+                    orig
+            ));
+        } else {
+            return Optional.of(DateRange.of(d1, d2, orig));
+        }
+    }
+
+    private Optional<DateRange> parseSingle(String date, String orig) {
+        final LocalDate d = parser.parseDateTime(date).toLocalDate();
+        if (date.replaceAll("\\D", "").length() == 4) {
+            LocalDate d2 = d.with(TemporalAdjusters.lastDayOfYear());
+            return Optional.of(DateRange.of(d, d2, orig));
+        }
+        return Optional.of(DateRange.of(d, null, orig));
+    }
+
+    /**
+     * Heuristically attempt to parse a date range. This handles valid dates
+     * separated by a hyphen (optionally with surrounding spaces.)
+     *
+     * @param str a date range string
+     * @return an DateRange if the string is parsable, or an empty optional if not
+     */
+    public Optional<DateRange> parse(String str) {
+        try {
+            // See if the string matches a year range...
+            final Matcher matcher = yearRange.matcher(str);
+            if (matcher.matches()) {
+                return parseRange(matcher.group("start"), matcher.group("end"), str);
+            } else if (str.contains(" - ")) {
+                // If it contains a separator with whitespace
+                final String[] parts = str.split("\\s-\\s");
+                return parseRange(parts[0], parts[1], str);
+            } else {
+                final int mid = str.length() / 2;
+                final char midChar = str.charAt(mid);
+                // If the total string is greater or equal to the minimum length
+                // for a YEAR-MONTH range and the middle char is a range separator
+                // attempt to parse each part as a date...
+                if (str.length() > 12 && SEP_CHARS.indexOf(midChar) != -1) {
+                    // Heuristics: if a string is longer than 12 chars and the
+                    // middle char is a '-', assume it's a date range...
+                    return parseRange(
+                            str.subSequence(0, mid).toString().trim(),
+                            str.subSequence(mid + 1, str.length()).toString().trim(), str);
+                } else {
+                    // Otherwise, attempt to parse as a single date, or fail...
+                    return parseSingle(str, str);
+                }
+            }
+        } catch (IllegalArgumentException | DateTimeParseException e ) {
+            logger.debug(String.format("Unable to parse date range %s", str), e);
+            return Optional.empty();
+        } catch (DateTimeException e) {
+            logger.warn(String.format("Invalid date detected parsing date range %s", str), e);
+            return Optional.empty();
+        }
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/DateRangeParser.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/DateRangeParser.java
@@ -30,7 +30,7 @@ public class DateRangeParser {
                 .build();
     }
 
-    private Optional<DateRange> parseRange(String from, String to, String orig) {
+    private DateRange parseRange(String from, String to, String orig) {
         final LocalDate d1 = parser.parseDateTime(from).toLocalDate();
         final LocalDate d2 = parser.parseDateTime(to).toLocalDate();
 
@@ -38,29 +38,67 @@ public class DateRangeParser {
         // based on the length of the raw date string - a fallible heuristic for sure.
         final String rawDateString = to.replaceAll("\\D", "");
         if (rawDateString.length() < 6) {
-            return Optional.of(DateRange.of(
+            return DateRange.of(
                     d1,
                     d2.with(TemporalAdjusters.lastDayOfYear()),
                     orig
-            ));
+            );
         } else if (rawDateString.length() < 8) {
-            return Optional.of(DateRange.of(
+            return DateRange.of(
                     d1,
                     d2.with(TemporalAdjusters.lastDayOfMonth()),
                     orig
-            ));
+            );
         } else {
-            return Optional.of(DateRange.of(d1, d2, orig));
+            return DateRange.of(d1, d2, orig);
         }
     }
 
-    private Optional<DateRange> parseSingle(String date, String orig) {
+    private DateRange parseSingle(String date, String orig) {
         final LocalDate d = parser.parseDateTime(date).toLocalDate();
         if (date.replaceAll("\\D", "").length() == 4) {
             LocalDate d2 = d.with(TemporalAdjusters.lastDayOfYear());
-            return Optional.of(DateRange.of(d, d2, orig));
+            return DateRange.of(d, d2, orig);
         }
-        return Optional.of(DateRange.of(d, null, orig));
+        return DateRange.of(d, null, orig);
+    }
+
+    /**
+     * Heuristically attempt to parse a date range. This handles valid dates
+     * separated by a hyphen (optionally with surrounding spaces.)
+     *
+     * @param str a date range string
+     * @return a DateRange
+     * @throws DateTimeParseException if the string is not parsable
+     * @throws DateTimeException if the date is invalid
+     */
+    public DateRange parse(String str) throws DateTimeException {
+        // See if the string matches a year range...
+        final Matcher matcher = yearRange.matcher(str);
+        if (matcher.matches()) {
+            return parseRange(matcher.group("start"), matcher.group("end"), str);
+        } else if (str.contains(" - ")) {
+            // If it contains a separator with whitespace
+            final String[] parts = str.split("\\s-\\s");
+            return parseRange(parts[0], parts[1], str);
+        } else {
+            final int mid = str.length() / 2;
+            final char midChar = str.charAt(mid);
+            // If the total string is greater or equal to the minimum length
+            // for a YEAR-MONTH range and the middle char is a range separator
+            // attempt to parse each part as a date...
+            if (str.length() > 12 && SEP_CHARS.indexOf(midChar) != -1) {
+                // Heuristics: if a string is longer than 12 chars and the
+                // middle char is a '-', assume it's a date range...
+                return parseRange(
+                        str.subSequence(0, mid).toString().trim(),
+                        str.subSequence(mid + 1, str.length()).toString().trim(), str);
+            } else {
+                // Otherwise, attempt to parse as a single date, or fail...
+                return parseSingle(str, str);
+            }
+        }
+
     }
 
     /**
@@ -70,33 +108,9 @@ public class DateRangeParser {
      * @param str a date range string
      * @return an DateRange if the string is parsable, or an empty optional if not
      */
-    public Optional<DateRange> parse(String str) {
+    public Optional<DateRange> tryParse(String str) {
         try {
-            // See if the string matches a year range...
-            final Matcher matcher = yearRange.matcher(str);
-            if (matcher.matches()) {
-                return parseRange(matcher.group("start"), matcher.group("end"), str);
-            } else if (str.contains(" - ")) {
-                // If it contains a separator with whitespace
-                final String[] parts = str.split("\\s-\\s");
-                return parseRange(parts[0], parts[1], str);
-            } else {
-                final int mid = str.length() / 2;
-                final char midChar = str.charAt(mid);
-                // If the total string is greater or equal to the minimum length
-                // for a YEAR-MONTH range and the middle char is a range separator
-                // attempt to parse each part as a date...
-                if (str.length() > 12 && SEP_CHARS.indexOf(midChar) != -1) {
-                    // Heuristics: if a string is longer than 12 chars and the
-                    // middle char is a '-', assume it's a date range...
-                    return parseRange(
-                            str.subSequence(0, mid).toString().trim(),
-                            str.subSequence(mid + 1, str.length()).toString().trim(), str);
-                } else {
-                    // Otherwise, attempt to parse as a single date, or fail...
-                    return parseSingle(str, str);
-                }
-            }
+            return Optional.of(parse(str));
         } catch (IllegalArgumentException | DateTimeParseException e ) {
             logger.debug(String.format("Unable to parse date range %s", str), e);
             return Optional.empty();

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportHelpers.java
@@ -179,18 +179,6 @@ public class ImportHelpers {
     }
 
     /**
-     * Extract a list of entity bundles for DatePeriods from the data,
-     * attempting to parse the unitdate attribute.
-     *
-     * @param data the data map. This is an out parameter from which
-     *             keys associated with extracted dates will be removed
-     * @return a list of entity bundles
-     */
-    public static List<Map<String, Object>> extractDates(Map<String, Object> data) {
-        return DateParser.extractDates(data);
-    }
-
-    /**
      * Extract the data from a sub-node.
      *
      * @param event a Map of event properties

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveSplitTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveSplitTest.java
@@ -34,10 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 public class BundesarchiveSplitTest extends AbstractImporterTest {
@@ -67,13 +64,13 @@ public class BundesarchiveSplitTest extends AbstractImporterTest {
         // How many new nodes will have been created? We should have
         // - 1 more DocumentaryUnits (archdesc)
         // - 1 more DocumentDescription
-        // - 1 more DatePeriod
+        // - 0 more DatePeriods
         // - 1 more UnknownProperties
         // - 3 more Relationships
         // - 2 more import Event links (1 for every Unit, 1 for the User)
         // - 1 more import Event
         // - 5 more MaintenanceEvents (4 revised, 1 created)
-        int newCount = origCount + 9 + 1 + 4 + 1;
+        int newCount = origCount + 8 + 1 + 4 + 1;
         printGraph(graph);
 
         assertEquals(newCount, getNodeCount(graph));
@@ -94,14 +91,14 @@ public class BundesarchiveSplitTest extends AbstractImporterTest {
         for (DocumentaryUnitDescription d : archUnit.getDocumentDescriptions()) {
             assertEquals("Reichsschatzmeister der NSDAP", d.getName());
         }
-        //test dates
+        // test dates (support for parsing these was removed, so they're just
+        // strings now and not DatePeriods)
         for (DocumentaryUnitDescription d : archUnit.getDocumentDescriptions()) {
-            // Single date is just a string
-            assertFalse(d.getPropertyKeys().contains("unitDates"));
+            // Single date is not parsable as a range or year
+            String unitDates = d.getProperty("unitDates");
+            assertNotNull(unitDates);
             List<DatePeriod> datePeriods = Lists.newArrayList(d.getDatePeriods());
-            assertEquals(1, datePeriods.size());
-            assertEquals("1906-01-01", datePeriods.get(0).getStartDate());
-            assertEquals("1919-12-31", datePeriods.get(0).getEndDate());
+            assertEquals(0, datePeriods.size());
         }
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveVcTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/BundesarchiveVcTest.java
@@ -63,13 +63,13 @@ public class BundesarchiveVcTest extends AbstractImporterTest {
         // How many new nodes will have been created? We should have
         // - 1 more DocumentaryUnits (archdesc)
         // - 1 more DocumentDescription
-        // - 1 more DatePeriod
+        // - 0 more DatePeriods
         // - 1 more UnknownProperties
         // - 3 more Relationships
         // - 2 more import Event links (1 for every Unit, 1 for the User)
         // - 1 more import Event
         // - 5 more MaintenanceEvents (4 revised, 1 created)
-        int newCount = origCount + 15;
+        int newCount = origCount + 14;
 
         assertEquals(newCount, getNodeCount(graph));
         graph.frame(getVertexByIdentifier(graph, ARCHDESC), DocumentaryUnit.class);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/StadsarchiefAdamTest.java
@@ -66,12 +66,12 @@ public class StadsarchiefAdamTest extends AbstractImporterTest {
         // How many new nodes will have been created? We should have
         // - 6 more DocumentaryUnits (archdesc, 5 children)
         // - 6 more DocumentDescription
-        // - 1 more DatePeriod
+        // - 4 more DatePeriod
         // - 6 more UnknownProperties 
         // - 7 more import Event links (6 for every Unit, 1 for the User)
         // - 1 more import Event
         // - 18 more MaintenanceEvents
-        int newCount = origCount + 45;
+        int newCount = origCount + 49;
         assertEquals(newCount, getNodeCount(graph));
 
         DocumentaryUnit archdesc = graph.frame(

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2JmpEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2JmpEadTest.java
@@ -68,14 +68,14 @@ public class Wp2JmpEadTest extends AbstractImporterTest {
             // How many new nodes will have been created? We should have
             // - 7 more DocumentaryUnits fonds C1 C2 C3 4,5,6
             // - 7 more DocumentDescription
-            // - 0 more DatePeriod 0 0 1
+            // - 1 more DatePeriod 0 0 1
             // - 3 UndeterminedRelationship, 0 0 0 11
             // - 8 more import Event links (4 for every Unit, 1 for the User)
             // - 1 more import Event
             // - 0 Annotation as resolved relationship
             // - 1 unknownProperty
 
-            int newCount = count + 27;
+            int newCount = count + 28;
             assertEquals(newCount, getNodeCount(graph));
 
             Iterable<Vertex> docs = graph.getVertices(Ontology.IDENTIFIER_KEY, FONDS);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/YadVashemTest.java
@@ -100,10 +100,10 @@ public class YadVashemTest extends AbstractImporterTest {
          * documentDescription: 3
          * maintenance event: 3
          * systemEvent: 1
-         * datePeriod: 1
+         * datePeriod: 3
          */
 
-        assertEquals(count + 18, getNodeCount(graph));
+        assertEquals(count + 20, getNodeCount(graph));
         assertEquals(2, toList(m19.getDocumentDescriptions()).size());
         for (DocumentaryUnitDescription desc : m19.getDocumentDescriptions()) {
             logger.debug("Document description graph ID: {}", desc.getId());
@@ -144,9 +144,9 @@ public class YadVashemTest extends AbstractImporterTest {
         * maintenance event: 3
         * property: 1
         * systemEvent: 1
-        * datePeriod: 1
+        * datePeriod: 3
         */
-        assertEquals(count + 20, getNodeCount(graph));
+        assertEquals(count + 22, getNodeCount(graph));
         //ENG also imported:
         assertEquals(2, toList(m19.getDocumentDescriptions()).size());
         DocumentaryUnit c1 = graph.frame(getVertexByIdentifier(graph, C1), DocumentaryUnit.class);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/util/DateParserTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/util/DateParserTest.java
@@ -5,23 +5,23 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import eu.ehri.project.definitions.Entities;
 import eu.ehri.project.definitions.Ontology;
-import eu.ehri.project.models.EntityClass;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static eu.ehri.project.importers.util.DateParser.normaliseDate;
 import static org.junit.Assert.*;
 
 public class DateParserTest {
     private Map<String, Object> mapWithOneParseableDate;
     private Map<String, Object> mapWithMultipleDates;
     private Map<String, Object> mapWithMultipleDatesAsList;
+    private DateParser parser;
 
     @Before
     public void init() {
+        parser = new DateParser();
         mapWithOneParseableDate = Maps.newHashMap();
         mapWithOneParseableDate.put("unitDates", "1934/1936");
 
@@ -47,7 +47,7 @@ public class DateParserTest {
 
     @Test
     public void extractDatesFromDateProperty() {
-        List<Map<String, Object>> extractedDates = ImportHelpers.extractDates(mapWithOneParseableDate);
+        List<Map<String, Object>> extractedDates = parser.extractDates(mapWithOneParseableDate);
         assertEquals(1, extractedDates.size());
         assertEquals("1934/1936", extractedDates.get(0).get(Ontology.DATE_HAS_DESCRIPTION));
     }
@@ -55,7 +55,7 @@ public class DateParserTest {
     @Test
     public void removeDateFromDateProperty() {
         assertTrue(mapWithOneParseableDate.containsKey("unitDates"));
-        ImportHelpers.extractDates(mapWithOneParseableDate);
+        parser.extractDates(mapWithOneParseableDate);
         assertFalse(mapWithOneParseableDate.containsKey("unitDates"));
     }
 
@@ -65,7 +65,7 @@ public class DateParserTest {
         assertTrue(mapWithMultipleDates.containsKey("existDate"));
         assertTrue(mapWithMultipleDates.containsKey("unitDates"));
         assertTrue(mapWithMultipleDates.containsKey(Entities.DATE_PERIOD));
-        List<Map<String, Object>> dates = ImportHelpers.extractDates(mapWithMultipleDates);
+        List<Map<String, Object>> dates = parser.extractDates(mapWithMultipleDates);
         assertEquals(3, dates.size());
         assertFalse(mapWithMultipleDates.containsKey(Entities.DATE_PERIOD));
         assertEquals("summer 1978", mapWithMultipleDates.get("unitDates"));
@@ -75,27 +75,7 @@ public class DateParserTest {
     @Test
     public void removeDatesFromDatePropertyList() {
         assertTrue(mapWithMultipleDatesAsList.containsKey("unitDates"));
-        ImportHelpers.extractDates(mapWithMultipleDatesAsList);
+        parser.extractDates(mapWithMultipleDatesAsList);
         assertFalse(mapWithMultipleDatesAsList.containsKey("unitDates"));
-    }
-
-    @Test
-    public void beginDateYear() {
-        assertEquals("1944-01-01", normaliseDate("1944"));
-    }
-
-    @Test
-    public void beginDateYearMonth() {
-        assertEquals("1944-01-01", normaliseDate("1944-01"));
-    }
-
-    @Test
-    public void endDateYear() {
-        assertEquals("1944-12-31", normaliseDate("1944", true));
-    }
-
-    @Test
-    public void endDateYearMonth() {
-        assertEquals("1944-01-31", normaliseDate("1944-01", true));
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/util/DateRangeParserTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/util/DateRangeParserTest.java
@@ -43,10 +43,10 @@ public class DateRangeParserTest {
     }
 
     private void check(String sloppy, String canonical) {
-        assertEquals(Optional.of(DateRange.fromString(canonical, sloppy)), rangeParser.parse(sloppy));
+        assertEquals(DateRange.fromString(canonical, sloppy), rangeParser.parse(sloppy));
     }
 
     private void checkNone(String sloppy) {
-        assertEquals(Optional.empty(), rangeParser.parse(sloppy));
+        assertEquals(Optional.empty(), rangeParser.tryParse(sloppy));
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/util/DateRangeParserTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/util/DateRangeParserTest.java
@@ -1,0 +1,52 @@
+package eu.ehri.project.importers.util;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.compress.utils.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class DateRangeParserTest {
+
+    private DateRangeParser rangeParser;
+
+    @Before
+    public void setUp() throws Exception {
+        rangeParser = new DateRangeParser();
+    }
+
+    @Test
+    public void parse() {
+        check("1939 ca.", "1939-01-01 - 1939-12-31");
+        check("1939 - 1942", "1939-01-01 - 1942-12-31");
+        check("01/1942 - 06/1942", "1942-01-01 - 1942-06-30");
+        check("1935-03/1935-05", "1935-03-01 - 1935-05-31");
+        check("summer 1940", "1940-01-01 - 1940-12-31"); // Meh? good enough
+        check("1939-01-01 - 1942-12-31", "1939-01-01 - 1942-12-31");
+        check("1935-03-03 - 1945-05", "1935-03-03 - 1945-05-31");
+        check("1935-03 - 1945-05-01", "1935-03-01 - 1945-05-01");
+    }
+
+    @Test
+    public void parseInvalid() {
+        checkNone("blob");
+        checkNone("40");
+        checkNone("13/1942");
+        checkNone("mid-1940"); // TODO: support this?
+        checkNone("1939-06-31");
+    }
+
+    private void check(String sloppy, String canonical) {
+        assertEquals(Optional.of(DateRange.fromString(canonical, sloppy)), rangeParser.parse(sloppy));
+    }
+
+    private void checkNone(String sloppy) {
+        assertEquals(Optional.empty(), rangeParser.parse(sloppy));
+    }
+}

--- a/ehri-io/src/test/java/eu/ehri/project/importers/util/DateRangeTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/util/DateRangeTest.java
@@ -1,0 +1,16 @@
+package eu.ehri.project.importers.util;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateRangeTest {
+
+    @Test
+    public void fromString() {
+        assertEquals(DateRange.fromString("2020-01-01", ""),
+                new DateRange(LocalDate.parse("2020-01-01"), ""));
+    }
+}


### PR DESCRIPTION
Remove support for dangerous Bundesarchiv date range format (1906/08, meaning the years) and add support for e.g. `1933 ca.` and `1939/09 - 1945/05`. More refactoring and tests are needed here.