### PR TITLE
Fix a missing trailing slash on ead2002 import properties

### DIFF
--- a/ehri-io/src/main/resources/ead2002.properties
+++ b/ehri-io/src/main/resources/ead2002.properties
@@ -31,7 +31,7 @@ processinfo/p/bibref/=sources
 processinfo/note/p/=ref
 did/abstract/=abstract
 did/physdesc/extent/=extentAndMedium
-did/physdesc/physfacet=extentAndMedium
+did/physdesc/physfacet/=extentAndMedium
 did/unitid/=objectIdentifier
 # NB: This is kind of a hack since materialspec
 # is not a good fit for this kind of info really:

--- a/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
@@ -19,6 +19,7 @@
 
 package eu.ehri.project.importers.base;
 
+import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
@@ -26,6 +27,8 @@ import com.tinkerpop.frames.FramedGraph;
 import eu.ehri.project.definitions.Ontology;
 import eu.ehri.project.importers.ImportOptions;
 import eu.ehri.project.importers.managers.SaxImportManager;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.DocumentaryUnitDescription;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.base.Description;
@@ -38,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 
@@ -150,6 +154,22 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
         indent += ".   ";// the '.' improves readability, but the whole printing could be improved
         for (Concept nc : c.getNarrowerConcepts()) {
             printConceptTree(out, nc, ++depth, indent); // recursive call
+        }
+    }
+
+    protected void printProps(final PrintStream out, DocumentaryUnit unit, String pad) {
+        out.println(pad + unit.getId());
+        for (DocumentaryUnitDescription d : unit.getDocumentDescriptions()) {
+            out.println(pad + d.getId());
+            final List<String> propertyKeys = Lists.newArrayList(d.getPropertyKeys());
+            propertyKeys.sort(String::compareTo);
+            for (String key : propertyKeys) {
+                out.printf("%s%-20s : %s%n", pad, key, d.getProperty(key));
+            }
+            out.println("");
+        }
+        for (DocumentaryUnit child : unit.getChildren()) {
+            printProps(out, child, pad + "    ");
         }
     }
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadHierarchicalMultipleDescriptionsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadHierarchicalMultipleDescriptionsTest.java
@@ -1,0 +1,62 @@
+package eu.ehri.project.importers.ead;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.tinkerpop.blueprints.TransactionalGraph;
+import com.tinkerpop.frames.FramedGraph;
+import eu.ehri.project.importers.ImportOptions;
+import eu.ehri.project.importers.base.AbstractImporterTest;
+import eu.ehri.project.importers.managers.SaxImportManager;
+import eu.ehri.project.models.DocumentaryUnit;
+import eu.ehri.project.models.DocumentaryUnitDescription;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test updating a hierarchical item with an alternate language
+ * description.
+ */
+public class EadHierarchicalMultipleDescriptionsTest extends AbstractImporterTest {
+
+    @Test
+    public void testUpdateDescription() throws Exception {
+        int count = getNodeCount(graph);
+        InputStream ios = ClassLoader.getSystemResourceAsStream("photos-en-00.xml");
+        ImportOptions options = ImportOptions.basic();
+        SaxImportManager importManager = saxImportManager(EadImporter.class, EadHandler.class, options);
+        importManager.importInputStream(ios, "Import English description");
+
+        // Added: 1 event, 4 event links, 3 doc unit, 3 description, 1 date period, 7 access points
+        assertEquals(count + 19, getNodeCount(this.graph));
+
+        DocumentaryUnit unit = manager.getEntity("nl-r1-photos", DocumentaryUnit.class);
+        assertEquals(1, Iterables.size(unit.getDocumentDescriptions()));
+
+        InputStream ios2 = ClassLoader.getSystemResourceAsStream("photos-uk-00.xml");
+        SaxImportManager importManager2 = saxImportManager(EadImporter.class, EadHandler.class, options.withUpdates(true));
+        importManager2.importInputStream(ios2, "Import Ukrainian description");
+
+        // Should have added: 1 event, 4 event links , 3 new descriptions, 1 new date period, 7 access points
+        assertEquals(count + 19 + 16, getNodeCount(this.graph));
+
+        unit = manager.getEntity("nl-r1-photos", DocumentaryUnit.class);
+        printProps(System.out, unit, "");
+        List<DocumentaryUnitDescription> descriptions = Lists.newArrayList(unit.getDocumentDescriptions());
+        assertEquals(2, descriptions.size());
+
+        // Check child descriptions have an `extentAndMedium` property...
+        DocumentaryUnit child = manager.getEntity("nl-r1-photos-14_pict-8", DocumentaryUnit.class);
+        List<DocumentaryUnitDescription> childDescriptions = Lists.newArrayList(child.getDocumentDescriptions());
+        assertEquals(2, childDescriptions.size());
+        for (DocumentaryUnitDescription childDesc : childDescriptions) {
+            assertNotNull(childDesc.getProperty("extentAndMedium"));
+        }
+    }
+}

--- a/ehri-io/src/test/resources/photos-en-00.xml
+++ b/ehri-io/src/test/resources/photos-en-00.xml
@@ -1,0 +1,54 @@
+<ead xmlns="urn:isbn:1-931666-22-9">
+    <eadheader>
+    <eadid>8</eadid>
+    <filedesc>
+        <titlestmt>
+            <titleproper>Vakhnyanyna Street, late 1940s</titleproper>
+        </titlestmt>
+    </filedesc>
+    <profiledesc>
+    <langusage>
+        <language langcode="eng">English</language>
+    </langusage>
+    </profiledesc>
+    </eadheader>
+    <archdesc level="fonds">
+        <did>
+            <unitid>Photos</unitid>
+            <unittitle>Photos</unittitle>
+        </did>
+        <dsc>
+            <c01 level="collection">
+                <did>
+                    <unitid>14_pict</unitid>
+                    <unitid>35</unitid>
+                    <unittitle>Andriy Dorosh</unittitle>
+                    <materialspec label="Web Source">
+                        <extptr xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://uma.lvivcenter.org/collections/35/photos"/>
+                    </materialspec>
+                </did>
+                <c02 level="item">
+                    <did>
+                        <unitid>8</unitid>
+                        <unittitle>Vakhnyanyna Street, late 1940s</unittitle>
+                        <unitdate>1959</unitdate>
+                        <materialspec label="Web Source">
+                            <extptr xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://uma.lvivcenter.org/en/photos/8"/>
+                        </materialspec>
+                        <physdesc><physfacet>Photograph</physfacet></physdesc>
+                        <note><p>Copyright: Julian Dorosh;"Halytska Brama", Lviv;Andriy Dorosh</p></note>
+                        <origination label="creator"><name>Julian Dorosh</name></origination>
+<origination label="creator"><name>Halytska Brama, Lviv</name></origination>
+<origination label="creator"><name>Andriy Dorosh</name></origination>
+                    </did>
+                    <controlaccess>
+                        <geogname>Lviv</geogname>
+                        <subject>Goat</subject>
+<subject> Vakhnyanyna Street</subject>
+<subject> postwar Lviv</subject>
+                    </controlaccess>
+                </c02>
+            </c01>
+        </dsc>
+    </archdesc>
+</ead>

--- a/ehri-io/src/test/resources/photos-uk-00.xml
+++ b/ehri-io/src/test/resources/photos-uk-00.xml
@@ -1,0 +1,54 @@
+<ead xmlns="urn:isbn:1-931666-22-9">
+    <eadheader>
+    <eadid>8</eadid>
+    <filedesc>
+        <titlestmt>
+            <titleproper>Вулиця Вахнянина, кінець 1940-х років</titleproper>
+        </titlestmt>
+    </filedesc>
+    <profiledesc>
+    <langusage>
+        <language langcode="ukr">Ukrainian</language>
+    </langusage>
+    </profiledesc>
+    </eadheader>
+    <archdesc level="fonds">
+        <did>
+            <unitid>Photos</unitid>
+            <unittitle>Photos</unittitle>
+        </did>
+        <dsc>
+            <c01 level="collection">
+                <did>
+                    <unitid>14_pict</unitid>
+                    <unitid>35</unitid>
+                    <unittitle>Андрій Дорош</unittitle>
+                    <materialspec label="Web Source">
+                        <extptr xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://uma.lvivcenter.org/uk/collections/35/photos"/>
+                    </materialspec>
+                </did>
+                <c02 level="item">
+                    <did>
+                        <unitid>8</unitid>
+                        <unittitle>Вулиця Вахнянина, кінець 1940-х років</unittitle>
+                        <unitdate>1949</unitdate>
+                        <materialspec label="Web Source">
+                            <extptr xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://uma.lvivcenter.org/uk/photos/8"/>
+                        </materialspec>
+                        <physdesc><physfacet>Photograph</physfacet></physdesc>
+                        <note><p>Copyright: Юліан Дорош;"Галицька брама", Львів;Андрій Дорош</p></note>
+                        <origination label="creator"><name>Юліан Дорош</name></origination>
+                        <origination label="creator"><name>Галицька брама, Львів</name></origination>
+                        <origination label="creator"><name>Андрій Дорош</name></origination>
+                    </did>
+                    <controlaccess>
+                        <geogname>Львів</geogname>
+                        <subject>Коза</subject>
+<subject> вулиця Вахнянина</subject>
+<subject> післявоєнне місто</subject>
+                    </controlaccess>
+                </c02>
+            </c01>
+        </dsc>
+    </archdesc>
+</ead>


### PR DESCRIPTION
This failed to import the `extentAndMedium` property from physFacet