### PR TITLE
Fix GraphQL interface error and inconsistency.

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/models/Country.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/Country.java
@@ -30,17 +30,14 @@ import eu.ehri.project.models.annotations.EntityType;
 import eu.ehri.project.models.annotations.Mandatory;
 import eu.ehri.project.models.annotations.Meta;
 import eu.ehri.project.models.annotations.UniqueAdjacency;
-import eu.ehri.project.models.base.Annotatable;
-import eu.ehri.project.models.base.ItemHolder;
-import eu.ehri.project.models.base.PermissionScope;
-import eu.ehri.project.models.base.Versioned;
+import eu.ehri.project.models.base.*;
 
 /**
  * Frame class representing a country. It's identifier should
  * be represented by an ISO3166 Alpha 2 code, lower cased.
  */
 @EntityType(EntityClass.COUNTRY)
-public interface Country extends PermissionScope, ItemHolder, Versioned, Annotatable {
+public interface Country extends PermissionScope, ItemHolder, Versioned, Annotatable, Linkable {
 
     /**
      * Alias function for fetching the country code identifier.

--- a/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
+++ b/ehri-core/src/main/java/eu/ehri/project/models/cvoc/AuthoritativeSet.java
@@ -34,7 +34,7 @@ import eu.ehri.project.models.base.*;
  * historical agents.
  */
 @EntityType(EntityClass.AUTHORITATIVE_SET)
-public interface AuthoritativeSet extends Accessible, PermissionScope, ItemHolder, Named, Promotable {
+public interface AuthoritativeSet extends Accessible, PermissionScope, ItemHolder, Named, Promotable, Annotatable {
 
     @Meta(CHILD_COUNT)
     @UniqueAdjacency(label = Ontology.ITEM_IN_AUTHORITATIVE_SET, direction = Direction.IN)

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
@@ -1251,7 +1251,7 @@ public class GraphQLImpl {
                     GraphQLTypeReference.typeRef("repositories")))
             .fields(linksAndAnnotationsFields())
             .field(itemEventsFieldDefinition())
-            .withInterfaces(entityInterface, annotatableInterface)
+            .withInterfaces(entityInterface, annotatableInterface, linkableInterface)
             .build();
 
     private final GraphQLObjectType conceptType = newObject()


### PR DESCRIPTION
Previously, the `Country` type was not linkable. We don't typically link these, but some legacy links existed.

Additionally, the `Vocabulary` and `AuthoritativeSet` types have been made annotatable, which matches the GraphQL schema.