### PR TITLE
Fix an issue where deletion logs could be created superfluously

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/json/BatchOperations.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/json/BatchOperations.java
@@ -250,6 +250,7 @@ public class BatchOperations {
      */
     public int batchDelete(Collection<String> ids, Actioner actioner, Optional<String> logMessage)
             throws ItemNotFound {
+        boolean logged = false;
         int done = 0;
         if (!ids.isEmpty()) {
             try {
@@ -262,13 +263,16 @@ public class BatchOperations {
                         if (version) {
                             ctx = ctx.createVersion(entity);
                         }
+                        logged = true;
                     } catch (ItemNotFound e) {
                         if (!tolerant) {
                             throw e;
                         }
                     }
                 }
-                ctx.commit();
+                if (logged) {
+                    ctx.commit();
+                }
                 try {
                     for (String id : ids) {
                         dao.delete(serializer.entityToBundle(manager.getEntity(id, Entity.class)));

--- a/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
@@ -207,4 +207,13 @@ public class BatchOperationsTest extends AbstractImporterTest {
         //  - 1 event
         assertEquals(nodesBefore, getNodeCount(graph));
     }
+
+    @Test
+    public void testBatchDeleteWithNoValidIds() throws Exception {
+        int nodesBefore = getNodeCount(graph);
+        int deleted = new BatchOperations(graph).setTolerant(true).batchDelete(Lists.newArrayList("NOT-AN-ID"),
+                validUser.as(Actioner.class), Optional.of("Test delete"));
+        assertEquals(0, deleted);
+        assertEquals(nodesBefore, getNodeCount(graph));
+    }
 }


### PR DESCRIPTION
If, for example, we are given a list of IDs that have already been deleted, and we're in tolerant mode, we should not create a log if nothing actually gets changed.