### PR TITLE
Deprecate the existing generic 'related' field on GraphQL

### DIFF
--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLinkingTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLinkingTest.java
@@ -64,8 +64,9 @@ public class ApiLinkingTest extends AbstractFixtureTest {
     public void testGetLinksWithAclFilter() throws Exception {
         // Link1 should not be retrieved because target c1 is not visible to invalidUser
         List<Link> links = Lists.newArrayList(api(invalidUser).getLinks("c4"));
-        assertEquals(1, links.size());
+        assertEquals(2, links.size());
         assertTrue(links.contains(manager.getEntity("link4", Link.class)));
+        assertTrue(links.contains(manager.getEntity("link5", Link.class)));
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
@@ -49,13 +49,13 @@ public class LinkerTest extends AbstractFixtureTest {
         Vocabulary vocabulary = manager.getEntity("cvoc2", Vocabulary.class);
         int eventCount = Iterables.size(actionManager.getLatestGlobalEvents());
         // The doc c1 contains two access point nodes which should be made
-        // into links, and c3 contains 2
+        // into links, c3 contains 2, and c4 contains 1
         String logMessage = "This is a test!";
         int newLinkCount = linker
                 .withExcludeSingles(false)
                 .withLogMessage(logMessage)
                 .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
-        assertEquals(4, newLinkCount);
+        assertEquals(5, newLinkCount);
         assertEquals(eventCount + 2,
                 Iterables.size(actionManager.getLatestGlobalEvents()));
         assertEquals(actionManager.getLatestGlobalEvent().getLogMessage(), logMessage);

--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -408,6 +408,15 @@
           name: Documentary Unit m19
           languageCode: eng
           scopeAndContent: Some description text for m19
+        relationships:
+          relatesTo:
+            - id: ur5
+              type: AccessPoint
+              data:
+                name: Subject Access 2
+                type: subject
+                description: test description
+                category: associative
     heldBy: r1
     hasPermissionScope: r1
 
@@ -620,6 +629,17 @@
       - c4
       - r4
     hasLinkSource: c4
+
+- id: link5
+  type: Link
+  data:
+    type: copy
+    description: A link indicating that cvocc2 is related to c4
+  relationships:
+    hasLinkTarget:
+      - c4
+      - cvocc2
+    hasLinkBody: ur5
 
 --- # Permission grants
 

--- a/ehri-io/src/test/resources/fixtures/link-resolver.yaml
+++ b/ehri-io/src/test/resources/fixtures/link-resolver.yaml
@@ -16,14 +16,14 @@
           scopeAndContent: Some description text for c5
         relationships:
           relatesTo:
-            - id: ur5
+            - id: ur6
               type: AccessPoint
               data:
                 name: Unresolved 1
                 type: person
                 cvoc: auths
                 target: a1
-            - id: ur6
+            - id: ur7
               type: AccessPoint
               data:
                 name: Unresolved 2

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/messages.properties
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/messages.properties
@@ -31,7 +31,8 @@ cvocConcept.description=An item representing a concept in a controlled vocabular
 cvocConcept.field.broader.description=Broader concepts, as a list
 cvocConcept.field.identifier.description=The concept's local identifier
 cvocConcept.field.narrower.description=Narrower concepts, as a list
-cvocConcept.field.related.description=Related concepts, as a list
+cvocConcept.field.related.description=Concepts that are related (as per SKOS definition), as a list
+cvocConcept.field.related.deprecated=This field may be removed or renamed in a future version
 cvocConcept.field.vocabulary.description=The vocabulary
 
 cvocVocabulary.description=A vocabulary
@@ -89,6 +90,9 @@ graphql.field.pageInfo.nextPage.description=A cursor pointing to the next page o
 graphql.field.pageInfo.previousPage.description=A cursor pointing to the previous page of items
 graphql.field.related.description=Related items
 graphql.field.related.item.description=The related item
+graphql.field.related.deprecated=This field will be removed in a future version. Use the ''connected'' field instead
+graphql.field.connected.description=Items connected via copy, access point or other types of links
+graphql.field.connected.item.description=The connected item
 graphql.field.systemEvents.description=Events describing this item's digital curation
 graphql.field.type.description=The item's EHRI type
 

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/GraphQLImplTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/GraphQLImplTest.java
@@ -15,7 +15,7 @@ public class GraphQLImplTest extends AbstractFixtureTest {
         GraphQLSchema schema = graphQL.getSchema();
         String testQuery = readResourceFileAsString("testquery.graphql");
         ExecutionResult result = GraphQL.newGraphQL(schema).build().execute(testQuery);
-        // System.out.println(result);
+//         System.out.println(result);
         assertTrue(result.getErrors().isEmpty());
     }
 }

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
@@ -96,7 +96,7 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
 
         assertStatus(OK, response);
         JsonNode data = response.getEntity(JsonNode.class);
-        // System.out.println(data.toPrettyString());
+//         System.out.println(data.toPrettyString());
         assertEquals("c1", data.path("data").path("c1").path("id").textValue());
         assertEquals(0, data.path("data").path("c1").path("ancestors").size());
         assertEquals(1, data.path("data").path("c1")
@@ -148,6 +148,8 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
                 .path(0).path("targets").path(0).path("id").textValue());
         assertEquals("cvocc1", data.path("data").path("cvocc2").path("related")
                 .path(0).path("id").textValue());
+        assertEquals("Subject Access 2", data.path("data").path("cvocc2").path("connected")
+                .path(0).path("context").path("body").path(0).path("name").textValue());
         assertEquals("Test", data.path("data").path("gb").path("summary").textValue());
         assertEquals("Test", data.path("data").path("gb").path("situation").textValue());
         assertEquals("Test", data.path("data").path("gb").path("history").textValue());

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -107,6 +107,22 @@ query test {
                 }
             }
         }
+        connected {
+            item {
+                ... on HistoricalAgent {
+                    id
+                }
+            }
+            context {
+                id
+                description
+                body {
+                    id
+                    name
+                    type
+                }
+            }
+        }
     }
 
     c4: DocumentaryUnit(id: "c4") {
@@ -196,6 +212,13 @@ query test {
     cvocc2: CvocConcept(id: "cvocc2") {
         related {
             id
+        }
+        connected {
+            context {
+                body {
+                    name
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Add a 'connected' field instead which does not clash with the CvocConcept 'related' field