### PR TITLE
Fixes around link ownership

### DIFF
--- a/ehri-cli/src/main/java/eu/ehri/project/commands/EntityAdd.java
+++ b/ehri-cli/src/main/java/eu/ehri/project/commands/EntityAdd.java
@@ -73,10 +73,6 @@ public class EntityAdd extends BaseCommand {
                 .type(String.class)
                 .desc("Identifier of scope to import into, i.e. repository")
                 .build());
-        options.addOption(Option.builder()
-                .longOpt("update")
-                .desc("Update item if it already exists")
-                .build());
     }
 
     @Override
@@ -155,11 +151,6 @@ public class EntityAdd extends BaseCommand {
         @SuppressWarnings("unchecked")
         Class<? extends Accessible> accessibleCls = (Class<? extends Accessible>) cls;
 
-        Api api = api(graph, user);
-        if (cmdLine.hasOption("update")) {
-            api.createOrUpdate(bundle.withId(id), accessibleCls, getLogMessage(logMessage));
-        } else {
-            api.create(bundle.withId(id), accessibleCls, getLogMessage(logMessage));
-        }
+        api(graph, user).create(bundle.withId(id), accessibleCls, getLogMessage(logMessage));
     }
 }

--- a/ehri-core/src/main/java/eu/ehri/project/api/Api.java
+++ b/ehri-core/src/main/java/eu/ehri/project/api/Api.java
@@ -111,21 +111,6 @@ public interface Api {
             throws PermissionDenied, ValidationError, DeserializationError;
 
     /**
-     * Create or update a new object of type `E` from the given data, within the
-     * scope of `scope`.
-     *
-     * @param bundle the item's data bundle
-     * @param cls    the item's class
-     * @param <E>    the type of entity
-     * @return the created framed vertex
-     * @throws PermissionDenied     if the user cannot perform the action
-     * @throws ValidationError      if the input data is incomplete or does not meet requirements
-     * @throws DeserializationError if the input data cannot be deserialized correctly
-     */
-    <E extends Accessible> Mutation<E> createOrUpdate(Bundle bundle, Class<E> cls)
-            throws PermissionDenied, ValidationError, DeserializationError;
-
-    /**
      * Delete an object bundle, following dependency cascades, within the scope
      * of item `scope`.
      *
@@ -171,22 +156,6 @@ public interface Api {
      * @throws DeserializationError if the input data cannot be deserialized correctly
      */
     <E extends Accessible> E create(Bundle bundle, Class<E> cls, Optional<String> logMessage)
-            throws PermissionDenied, ValidationError, DeserializationError;
-
-    /**
-     * Create or update a new object of type `E` from the given data, within the
-     * scope of `scope`.
-     *
-     * @param bundle     the item's data bundle
-     * @param cls        the item's class
-     * @param logMessage a log message
-     * @param <E>        the type of entity
-     * @return the created framed vertex
-     * @throws PermissionDenied     if the user cannot perform the action
-     * @throws ValidationError      if the input data is incomplete or does not meet requirements
-     * @throws DeserializationError if the input data cannot be deserialized correctly
-     */
-    <E extends Accessible> Mutation<E> createOrUpdate(Bundle bundle, Class<E> cls, Optional<String> logMessage)
             throws PermissionDenied, ValidationError, DeserializationError;
 
     /**

--- a/ehri-core/src/test/java/eu/ehri/project/acl/InheritedGlobalPermissionSetTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/InheritedGlobalPermissionSetTest.java
@@ -44,12 +44,12 @@ public class InheritedGlobalPermissionSetTest extends AbstractFixtureTest {
     @Test
     public void testHas() throws Exception {
         InheritedGlobalPermissionSet permissions1
-                = aclManager.getInheritedGlobalPermissions(invalidUser);
+                = aclManager.getInheritedGlobalPermissions(basicUser);
         assertFalse(permissions1.has(ContentTypes.DOCUMENTARY_UNIT, PermissionType.CREATE));
         assertFalse(permissions1.has(ContentTypes.DOCUMENTARY_UNIT, PermissionType.DELETE));
 
         InheritedGlobalPermissionSet permissions2
-                = aclManager.getInheritedGlobalPermissions(validUser);
+                = aclManager.getInheritedGlobalPermissions(adminUser);
         assertTrue(permissions2.has(ContentTypes.DOCUMENTARY_UNIT, PermissionType.CREATE));
         assertTrue(permissions2.has(ContentTypes.DOCUMENTARY_UNIT, PermissionType.DELETE));
     }
@@ -57,7 +57,7 @@ public class InheritedGlobalPermissionSetTest extends AbstractFixtureTest {
     @Test
     public void testSerialize() throws Exception {
         InheritedGlobalPermissionSet permissions
-                = aclManager.getInheritedGlobalPermissions(invalidUser);
+                = aclManager.getInheritedGlobalPermissions(basicUser);
         List<Map<String,GlobalPermissionSet>> list = permissions.serialize();
         assertEquals(2, list.size());
     }

--- a/ehri-core/src/test/java/eu/ehri/project/acl/InheritedItemPermissionSetTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/InheritedItemPermissionSetTest.java
@@ -46,7 +46,7 @@ public class InheritedItemPermissionSetTest extends AbstractFixtureTest {
     public void testHas() throws Exception {
         Repository r2 = manager.getEntity("r2", Repository.class);
         InheritedItemPermissionSet permissionSet
-                = aclManager.getInheritedItemPermissions(r2, invalidUser);
+                = aclManager.getInheritedItemPermissions(r2, basicUser);
         assertFalse(permissionSet.has(PermissionType.CREATE));
         assertTrue(permissionSet.has(PermissionType.UPDATE));
         assertFalse(permissionSet.has(PermissionType.DELETE));
@@ -55,7 +55,7 @@ public class InheritedItemPermissionSetTest extends AbstractFixtureTest {
     @Test
     public void testSerialize() throws Exception {
         InheritedItemPermissionSet permissions
-                = aclManager.getInheritedItemPermissions(manager.getEntity("r2", Repository.class), invalidUser
+                = aclManager.getInheritedItemPermissions(manager.getEntity("r2", Repository.class), basicUser
         );
         List<Map<String,List<PermissionType>>> serialized = permissions.serialize();
         // Should contain Reto and Kcl

--- a/ehri-core/src/test/java/eu/ehri/project/acl/PermissionUtilsTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/PermissionUtilsTest.java
@@ -46,14 +46,14 @@ public class PermissionUtilsTest extends AbstractFixtureTest {
 
     @Test(expected = PermissionDenied.class)
     public void testCheckContentPermissionThrows() throws Exception {
-        viewHelper.checkContentPermission(invalidUser,
+        viewHelper.checkContentPermission(basicUser,
                 ContentTypes.DOCUMENTARY_UNIT, PermissionType.CREATE);
     }
 
     @Test
     public void testCheckContentPermissionWithScope() throws Exception {
         Repository r1 = manager.getEntity("r1", Repository.class);
-        viewHelper.setScope(r1).checkContentPermission(invalidUser,
+        viewHelper.setScope(r1).checkContentPermission(basicUser,
                 ContentTypes.DOCUMENTARY_UNIT, PermissionType.CREATE);
     }
 
@@ -82,13 +82,13 @@ public class PermissionUtilsTest extends AbstractFixtureTest {
     @Test
     public void testCheckReadAccess() throws Exception {
         DocumentaryUnit c1 = manager.getEntity("c1", DocumentaryUnit.class);
-        viewHelper.checkReadAccess(c1, validUser);
+        viewHelper.checkReadAccess(c1, adminUser);
     }
 
     @Test(expected = AccessDenied.class)
     public void testCheckReadAccessThrows() throws Exception {
         DocumentaryUnit c1 = manager.getEntity("c1", DocumentaryUnit.class);
-        viewHelper.checkReadAccess(c1, invalidUser);
+        viewHelper.checkReadAccess(c1, basicUser);
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/acl/wrapper/AclGraphTest.java
@@ -39,8 +39,8 @@ public class AclGraphTest extends AbstractFixtureTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        validUserGraph = new AclGraph(graph.getBaseGraph(), validUser);
-        invalidUserGraph = new AclGraph(graph.getBaseGraph(), invalidUser);
+        validUserGraph = new AclGraph(graph.getBaseGraph(), adminUser);
+        invalidUserGraph = new AclGraph(graph.getBaseGraph(), basicUser);
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiAclTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiAclTest.java
@@ -163,14 +163,14 @@ public class ApiAclTest extends AbstractFixtureTest {
     public void testValidUserCanAddAccessorToGroup() throws Exception {
         Accessor user = manager.getEntity("linda", Accessor.class);
         Group group = manager.getEntity("kcl", Group.class);
-        api(validUser).acl().addAccessorToGroup(group, user);
+        api(adminUser).acl().addAccessorToGroup(group, user);
     }
 
     @Test(expected = PermissionDenied.class)
     public void testInvalidUserCannotAddAccessorToGroup() throws Exception {
         Accessor user = manager.getEntity("linda", Accessor.class);
         Group group = manager.getEntity("kcl", Group.class);
-        api(invalidUser).acl().addAccessorToGroup(group, user);
+        api(basicUser).acl().addAccessorToGroup(group, user);
     }
 
     @Test
@@ -178,7 +178,7 @@ public class ApiAclTest extends AbstractFixtureTest {
         Accessor user = manager.getEntity("linda", Accessor.class);
         Group group = manager.getEntity("dans", Group.class);
         assertTrue(Lists.newArrayList(group.getMembers()).contains(user));
-        api(validUser).acl().removeAccessorFromGroup(group, user);
+        api(adminUser).acl().removeAccessorFromGroup(group, user);
         assertFalse(Lists.newArrayList(group.getMembers()).contains(user));
     }
 
@@ -186,14 +186,14 @@ public class ApiAclTest extends AbstractFixtureTest {
     public void testInvalidUserCannotRemoveAccessorFromGroup() throws Exception {
         Accessor user = manager.getEntity("linda", Accessor.class);
         Group group = manager.getEntity("dans", Group.class);
-        api(invalidUser).acl().removeAccessorFromGroup(group, user);
+        api(basicUser).acl().removeAccessorFromGroup(group, user);
     }
 
     @Test
     public void testAddUserToGroupGranteeMembership() throws Exception {
         Accessor user = manager.getEntity("linda", Accessor.class);
         Group group = manager.getEntity("niod", Group.class);
-        Accessor grantee = invalidUser;
+        Accessor grantee = basicUser;
         // Grant the user specific permissions to update the group
         api(grantee).aclManager().grantPermission(
                 user.as(PermissionGrantTarget.class), PermissionType.GRANT, grantee);
@@ -217,7 +217,7 @@ public class ApiAclTest extends AbstractFixtureTest {
     public void testAddUserToGroupGranteePerms() throws Exception {
         Accessor user = manager.getEntity("linda", Accessor.class);
         Group group = manager.getEntity("soma", Group.class);
-        Accessor grantee = invalidUser;
+        Accessor grantee = basicUser;
         assertFalse(AclManager.belongsToAdmin(grantee));
         // Grant the user specific permissions to update the group
         group.addMember(grantee);

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiCrudTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiCrudTest.java
@@ -47,14 +47,14 @@ public class ApiCrudTest extends AbstractFixtureTest {
 
     @Test
     public void testDetail() throws ItemNotFound {
-        DocumentaryUnit unit = api(validUser).get(item.getId(), DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).get(item.getId(), DocumentaryUnit.class);
         assertEquals(item.asVertex(), unit.asVertex());
     }
 
     @Test
     public void testUserProfile() throws ItemNotFound {
-        UserProfile user = api(validUser).get(validUser.getId(), UserProfile.class);
-        assertEquals(validUser.asVertex(), user.asVertex());
+        UserProfile user = api(adminUser).get(adminUser.getId(), UserProfile.class);
+        assertEquals(adminUser.asVertex(), user.asVertex());
     }
 
     @Test(expected = ItemNotFound.class)
@@ -64,20 +64,20 @@ public class ApiCrudTest extends AbstractFixtureTest {
 
     @Test(expected = ItemNotFound.class)
     public void testDetailPermissionDenied() throws ItemNotFound {
-        api(invalidUser).get(item.getId(), DocumentaryUnit.class);
+        api(basicUser).get(item.getId(), DocumentaryUnit.class);
     }
 
     @Test
     public void testCreate() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
     }
 
     @Test(expected = PermissionDenied.class)
     public void testCreateAsUnauthorized() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(invalidUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(basicUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
     }
 
@@ -86,7 +86,7 @@ public class ApiCrudTest extends AbstractFixtureTest {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
 
         try {
-            api(invalidUser).create(bundle, DocumentaryUnit.class);
+            api(basicUser).create(bundle, DocumentaryUnit.class);
             fail("Creation should throw "
                     + PermissionDenied.class.getSimpleName());
         } catch (PermissionDenied e) {
@@ -95,9 +95,9 @@ public class ApiCrudTest extends AbstractFixtureTest {
             PermissionGrantTarget target = manager.getEntity(
                     ContentTypes.DOCUMENTARY_UNIT.getName(),
                     PermissionGrantTarget.class);
-            new AclManager(graph).grantPermission(target, PermissionType.CREATE, invalidUser
+            new AclManager(graph).grantPermission(target, PermissionType.CREATE, basicUser
             );
-            DocumentaryUnit unit = api(invalidUser).create(bundle, DocumentaryUnit.class);
+            DocumentaryUnit unit = api(basicUser).create(bundle, DocumentaryUnit.class);
             assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
         }
     }
@@ -108,21 +108,21 @@ public class ApiCrudTest extends AbstractFixtureTest {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
         // In the fixtures, 'reto' should have a grant for 'CREATE'
         // scoped to the 'r1' repository.
-        DocumentaryUnit unit = api(invalidUser)
+        DocumentaryUnit unit = api(basicUser)
                 .withScope(r1).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
     }
 
     @Test
     public void testUserDetailAccessDenied() throws ItemNotFound {
-        api(invalidUser).get(validUser.getId(), UserProfile.class);
+        api(basicUser).get(adminUser.getId(), UserProfile.class);
     }
 
     @Test
     public void testUpdate() throws Exception {
         Repository repository = manager.getEntity("r1", Repository.class);
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).withScope(repository)
+        DocumentaryUnit unit = api(adminUser).withScope(repository)
                 .create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
@@ -130,7 +130,7 @@ public class ApiCrudTest extends AbstractFixtureTest {
         Bundle newBundle = bundle.withId(unit.getId()).withDataValue(
                 "name", newName);
 
-        DocumentaryUnit changedUnit = api(validUser)
+        DocumentaryUnit changedUnit = api(adminUser)
                 .update(newBundle, DocumentaryUnit.class).getNode();
         assertEquals(newName, changedUnit.getProperty("name"));
         DocumentaryUnitDescription desc = graph.frame(
@@ -143,7 +143,7 @@ public class ApiCrudTest extends AbstractFixtureTest {
                 .withDataValue(Ontology.LANGUAGE_OF_DESCRIPTION, "ang")
                 .withDataValue(Ontology.IDENTIFIER_KEY, "Latn")
                 .withDataValue(Ontology.NAME_KEY, "Test Desc 2");
-        DocumentaryUnit changedUnit2 = api(validUser)
+        DocumentaryUnit changedUnit2 = api(adminUser)
                 .update(newBundle
                         .withRelation(Ontology.DESCRIPTION_FOR_ENTITY, newDesc
                         ), DocumentaryUnit.class).getNode();
@@ -161,27 +161,27 @@ public class ApiCrudTest extends AbstractFixtureTest {
     @Test
     public void testUserUpdate() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestUserBundle());
-        UserProfile user = api(validUser).create(bundle, UserProfile.class);
+        UserProfile user = api(adminUser).create(bundle, UserProfile.class);
         assertEquals(TestData.TEST_USER_NAME, user.getName());
 
         String newName = TestData.TEST_USER_NAME + " with new stuff";
         Bundle newBundle = bundle.withId(user.getId()).withDataValue(
                 "name", newName);
-        UserProfile changedUser = api(validUser).update(newBundle, UserProfile.class).getNode();
+        UserProfile changedUser = api(adminUser).update(newBundle, UserProfile.class).getNode();
         assertEquals(newName, changedUser.getName());
     }
 
     @Test
     public void testUserCreate() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestUserBundle());
-        UserProfile user = api(validUser).create(bundle, UserProfile.class);
+        UserProfile user = api(adminUser).create(bundle, UserProfile.class);
         assertEquals(TestData.TEST_USER_NAME, user.getName());
     }
 
     @Test
     public void testGroupCreate() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestGroupBundle());
-        Group group = api(validUser).create(bundle, Group.class);
+        Group group = api(adminUser).create(bundle, Group.class);
         assertEquals(TestData.TEST_GROUP_NAME, group.getName());
     }
 
@@ -191,23 +191,23 @@ public class ApiCrudTest extends AbstractFixtureTest {
                 .removeDataValue("name");
 
         // This shouldn't barf because the collection does not need a name.
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertNull(unit.getProperty("name"));
     }
 
     @Test(expected = HierarchyError.class)
     public void testDeleteWithHierarchyError() throws Exception {
-        api(validUser).delete(item.getId());
+        api(adminUser).delete(item.getId());
     }
 
     @Test
     public void testDeleteAdmin() throws Exception {
         try {
-            api(validUser).delete(Group.ADMIN_GROUP_IDENTIFIER);
+            api(adminUser).delete(Group.ADMIN_GROUP_IDENTIFIER);
             fail("Should not have been able to delete admin group");
         } catch (PermissionDenied e) {
             assertEquals(Group.ADMIN_GROUP_IDENTIFIER, e.getEntity());
-            assertEquals(validUser.getId(), e.getAccessor());
+            assertEquals(adminUser.getId(), e.getAccessor());
             assertEquals(PermissionType.DELETE.getName(), e.getPermission());
             assertEquals(SystemScope.getInstance().getId(), e.getScope());
         }
@@ -218,7 +218,7 @@ public class ApiCrudTest extends AbstractFixtureTest {
         int shouldDelete = 1;
 
         // FIXME: Surely there's a better way of doing this???
-        DocumentaryUnit c4 = api(validUser).get("c4", DocumentaryUnit.class);
+        DocumentaryUnit c4 = api(adminUser).get("c4", DocumentaryUnit.class);
         Iterator<Description> descIter = c4.getDescriptions().iterator();
         for (; descIter.hasNext(); shouldDelete++) {
             DocumentaryUnitDescription d = graph.frame(descIter.next().asVertex(), DocumentaryUnitDescription.class);
@@ -227,25 +227,25 @@ public class ApiCrudTest extends AbstractFixtureTest {
             shouldDelete += Iterables.size(d.getUnknownProperties());
         }
 
-        int deleted = api(validUser).delete(c4.getId());
+        int deleted = api(adminUser).delete(c4.getId());
         assertEquals(shouldDelete, deleted);
     }
 
     @Test(expected = HierarchyError.class)
     public void testDeleteChildrenWithError() throws Exception {
-        api(validUser).deleteChildren(item.getId(), false, true, Optional.empty());
+        api(adminUser).deleteChildren(item.getId(), false, true, Optional.empty());
     }
 
     @Test
     public void testDeleteChildren() throws Exception {
-        List<String> out = api(validUser).deleteChildren(item.getId(), true, true, Optional.empty());
+        List<String> out = api(adminUser).deleteChildren(item.getId(), true, true, Optional.empty());
         assertEquals(Lists.newArrayList("c2", "c3"), out);
     }
 
     @Test
     public void testDeleteChildrenWithBatchCallback() throws Exception {
         final List<String> ids = Lists.newArrayList();
-        List<String> out = api(validUser).deleteChildren(item.getId(), true, true, (num, id) -> {
+        List<String> out = api(adminUser).deleteChildren(item.getId(), true, true, (num, id) -> {
             graph.getBaseGraph().commit();
             ids.add(id);
         }, Optional.empty());

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiDescriptionsTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiDescriptionsTest.java
@@ -59,14 +59,14 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test
     public void testCreateDependent() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
         Bundle descBundle = bundle
                 .getRelations(Ontology.DESCRIPTION_FOR_ENTITY)
                 .get(0).withDataValue(Ontology.IDENTIFIER_KEY, "some-new-id");
 
-        DocumentaryUnitDescription changedDesc = api(validUser)
+        DocumentaryUnitDescription changedDesc = api(adminUser)
                 .createDependent(unit.getId(), descBundle,
                         DocumentaryUnitDescription.class, Optional.empty());
         unit.addDescription(changedDesc);
@@ -86,14 +86,14 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test(expected = ValidationError.class)
     public void testCreateDependentWithValidationError() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
         Bundle descBundle = bundle
                 .getRelations(Ontology.DESCRIPTION_FOR_ENTITY)
                 .get(0).removeDataValue(Ontology.NAME_KEY);
 
-        api(validUser).createDependent(unit.getId(), descBundle,
+        api(adminUser).createDependent(unit.getId(), descBundle,
                 DocumentaryUnitDescription.class, Optional.empty());
         fail("Creating a dependent should have thrown a validation error");
     }
@@ -101,7 +101,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test
     public void testUpdateDependent() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
         int descCount = Iterables.size(unit.getDocumentDescriptions());
@@ -109,7 +109,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
                 .getRelations(Ontology.DESCRIPTION_FOR_ENTITY)
                 .get(0).withDataValue(Ontology.NAME_KEY, "some-new-title");
 
-        DocumentaryUnitDescription changedDesc = api(validUser)
+        DocumentaryUnitDescription changedDesc = api(adminUser)
                 .updateDependent(unit.getId(), descBundle,
                         DocumentaryUnitDescription.class, Optional.empty())
                 .getNode();
@@ -120,14 +120,14 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test(expected = ValidationError.class)
     public void testUpdateDependentWithValidationError() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
         Bundle descBundle = new Serializer(graph).entityToBundle(unit)
                 .getRelations(Ontology.DESCRIPTION_FOR_ENTITY)
                 .get(0).removeDataValue(Ontology.NAME_KEY);
 
-        api(validUser).updateDependent(unit.getId(), descBundle,
+        api(adminUser).updateDependent(unit.getId(), descBundle,
                 DocumentaryUnitDescription.class, Optional.empty()).getNode();
         fail("Updating a dependent should have thrown a validation error");
     }
@@ -135,14 +135,14 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test
     public void testDeleteDependent() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
         int descCount = Iterables.size(unit.getDocumentDescriptions());
 
         DocumentaryUnitDescription d = Iterables.getFirst(unit.getDocumentDescriptions(), null);
         assertNotNull(d);
-        int delCount = api(validUser).deleteDependent(unit.getId(), d.getId(),
+        int delCount = api(adminUser).deleteDependent(unit.getId(), d.getId(),
                 Optional.empty());
         Assert.assertTrue(delCount >= 1);
         assertEquals(descCount - 1, Iterables.size(unit.getDocumentDescriptions()));
@@ -151,7 +151,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test
     public void testDeleteDependentDescription() throws Exception {
         // This should throw permission denied since c1 is not in the new item's subtree...
-        int delete = api(validUser).deleteDependent("c1", "cd1", Optional.empty());
+        int delete = api(adminUser).deleteDependent("c1", "cd1", Optional.empty());
         // the number of items deleted should be 1 desc, 2 dates, 2 access points = 5
         assertEquals(5, delete);
     }
@@ -159,14 +159,14 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
     @Test
     public void testDeleteDependentAccessPoint() throws Exception {
         // This should throw permission denied since c1 is not in the new item's subtree...
-        int delete = api(validUser).deleteDependent("c1", "ur1", Optional.empty());
+        int delete = api(adminUser).deleteDependent("c1", "ur1", Optional.empty());
         assertEquals(1, delete);
     }
 
     @Test(expected = PermissionDenied.class)
     public void testDeleteNonDependent() throws Exception {
         // This should throw permission denied since c1 is not in the new item's subtree...
-        api(validUser).deleteDependent("c1", "cd2", Optional.empty());
+        api(adminUser).deleteDependent("c1", "cd2", Optional.empty());
     }
 
     @Test
@@ -175,7 +175,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
         Description description = r1.getDescriptions().iterator().next();
         Bundle updated = depSerializer.entityToBundle(r1);
         Bundle desc = depSerializer.entityToBundle(description);
-        Mutation<RepositoryDescription> cou = loggingApi(validUser)
+        Mutation<RepositoryDescription> cou = loggingApi(adminUser)
                 .updateDependent("r1", desc.withDataValue("name", "changed"),
                         RepositoryDescription.class, Optional.empty());
         SystemEvent event = am.getLatestGlobalEvent();
@@ -191,7 +191,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
         Repository r1 = manager.getEntity("r1", Repository.class);
         Bundle desc = Bundle.fromData(TestData.getTestAgentBundle())
                 .getRelations(Ontology.DESCRIPTION_FOR_ENTITY).get(0);
-        loggingApi(validUser).createDependent("r1", desc, RepositoryDescription.class,
+        loggingApi(adminUser).createDependent("r1", desc, RepositoryDescription.class,
                 Optional.empty());
         assertEquals(r1, am.getLatestGlobalEvent()
                 .getSubjects().iterator().next());
@@ -202,7 +202,7 @@ public class ApiDescriptionsTest extends AbstractFixtureTest {
         Repository r1 = manager.getEntity("r1", Repository.class);
         Description description = r1.getDescriptions().iterator().next();
         Bundle updated = depSerializer.entityToBundle(r1);
-        loggingApi(validUser).deleteDependent("r1", description.getId(), Optional.empty());
+        loggingApi(adminUser).deleteDependent("r1", description.getId(), Optional.empty());
         SystemEvent event = am.getLatestGlobalEvent();
         assertTrue(event.getPriorVersions().iterator().hasNext());
         Bundle old = Bundle.fromString(event.getPriorVersions().iterator().next().getEntityData());

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLinkingTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLinkingTest.java
@@ -58,7 +58,7 @@ public class ApiLinkingTest extends AbstractFixtureTest {
 
     @Test
     public void testGetLinks() throws Exception {
-        List<Link> links = Lists.newArrayList(api(validUser).getLinks("c1"));
+        List<Link> links = Lists.newArrayList(api(adminUser).getLinks("c1"));
         assertEquals(2, links.size());
         assertTrue(links.contains(manager.getEntity("link1", Link.class)));
         assertTrue(links.contains(manager.getEntity("link2", Link.class)));
@@ -67,7 +67,7 @@ public class ApiLinkingTest extends AbstractFixtureTest {
     @Test
     public void testGetLinksWithAclFilter() throws Exception {
         // Link1 should not be retrieved because target c1 is not visible to invalidUser
-        List<Link> links = Lists.newArrayList(api(invalidUser).getLinks("c4"));
+        List<Link> links = Lists.newArrayList(api(basicUser).getLinks("c4"));
         assertEquals(2, links.size());
         assertTrue(links.contains(manager.getEntity("link4", Link.class)));
         assertTrue(links.contains(manager.getEntity("link5", Link.class)));
@@ -83,19 +83,19 @@ public class ApiLinkingTest extends AbstractFixtureTest {
         String linkType = "associative";
         Bundle linkBundle = getLinkBundle(linkDesc, linkType);
         // We have to first grant permission to create links...
-        acl.grantPermission(src, PermissionType.ANNOTATE, invalidUser);
-        Link link = loggingApi(invalidUser)
+        acl.grantPermission(src, PermissionType.ANNOTATE, basicUser);
+        Link link = loggingApi(basicUser)
                 .createLink("c1", "a1", Lists.newArrayList("ur1"),
                         linkBundle, false, Lists.newArrayList(), Optional.empty());
         assertEquals(linkDesc, link.getDescription());
-        assertTrue(acl.hasPermission(link, PermissionType.OWNER, invalidUser));
+        assertTrue(acl.hasPermission(link, PermissionType.OWNER, basicUser));
         assertEquals(2, Iterables.size(link.getLinkTargets()));
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
         assertTrue(Iterables.contains(link.getLinkTargets(), dst));
         assertNull(link.getLinkSource());
         assertEquals(1, Iterables.size(link.getLinkBodies()));
         assertTrue(Iterables.contains(link.getLinkBodies(), rel));
-        assertTrue(Lists.newArrayList(api(invalidUser).actionManager()
+        assertTrue(Lists.newArrayList(api(basicUser).actionManager()
                 .getLatestGlobalEvent().getSubjects()).contains(link));
     }
 
@@ -103,7 +103,7 @@ public class ApiLinkingTest extends AbstractFixtureTest {
     public void testCreateDirectionalLink() throws Exception {
         DocumentaryUnit src = manager.getEntity("c1", DocumentaryUnit.class);
         HistoricalAgent dst = manager.getEntity("a1", HistoricalAgent.class);
-        Link link = loggingApi(validUser)
+        Link link = loggingApi(adminUser)
                 .createLink("c1", "a1", Lists.newArrayList("ur1"),
                         getLinkBundle("test", "associative"),
                         true, Lists.newArrayList(), Optional.empty());
@@ -114,7 +114,7 @@ public class ApiLinkingTest extends AbstractFixtureTest {
 
     @Test(expected = PermissionDenied.class)
     public void testCreateLinkWithoutPermission() throws Exception {
-        api(invalidUser).createLink("c1", "a1", Lists.newArrayList("ur1"),
+        api(basicUser).createLink("c1", "a1", Lists.newArrayList("ur1"),
                 getLinkBundle("won't work!", "too bad!"), false,
                 Lists.newArrayList(), Optional.empty());
     }
@@ -128,12 +128,12 @@ public class ApiLinkingTest extends AbstractFixtureTest {
         String linkDesc = "Test Link";
         String linkType = "associative";
         Bundle linkBundle = getLinkBundle(linkDesc, linkType);
-        Link link = loggingApi(validUser)
+        Link link = loggingApi(adminUser)
                 .createAccessPointLink("c1", "a1", "cd1",
                         linkDesc, AccessPointType.subject, linkBundle,
-                        Lists.newArrayList(validUser, invalidUser), Optional.empty());
+                        Lists.newArrayList(adminUser, basicUser), Optional.empty());
         assertNull(linkDesc, link.getLinkField());
-        assertTrue(acl.hasPermission(link, PermissionType.OWNER, validUser));
+        assertTrue(acl.hasPermission(link, PermissionType.OWNER, adminUser));
         assertEquals(linkDesc, link.getDescription());
         assertEquals(2, Iterables.size(link.getLinkTargets()));
         assertTrue(Iterables.contains(link.getLinkTargets(), src));
@@ -145,7 +145,7 @@ public class ApiLinkingTest extends AbstractFixtureTest {
         Description d = rel.getDescription();
         assertEquals(desc, d);
         assertTrue(link.hasAccessRestriction());
-        assertTrue(Lists.newArrayList(api(validUser).actionManager()
+        assertTrue(Lists.newArrayList(api(adminUser).actionManager()
                 .getLatestGlobalEvent().getSubjects()).contains(link));
     }
 
@@ -155,15 +155,15 @@ public class ApiLinkingTest extends AbstractFixtureTest {
         AclManager acl = new AclManager(graph);
         Bundle linkBundle = getLinkBundle("Delete test", "associative");
         // We have to first grant permission to create links...
-        acl.grantPermission(src, PermissionType.ANNOTATE, invalidUser);
-        Link link = loggingApi(invalidUser)
+        acl.grantPermission(src, PermissionType.ANNOTATE, basicUser);
+        Link link = loggingApi(basicUser)
                 .createLink("c1", "a1", Lists.newArrayList("ur1"),
                         linkBundle, false, Lists.newArrayList(), Optional.empty());
         assertEquals(2, Iterables.size(link.getLinkTargets()));
 
-        assertFalse(acl.hasPermission(ContentTypes.LINK, PermissionType.DELETE, invalidUser));
-        loggingApi(invalidUser).delete(link.getId());
-        assertEquals(api(invalidUser).actionManager()
+        assertFalse(acl.hasPermission(ContentTypes.LINK, PermissionType.DELETE, basicUser));
+        loggingApi(basicUser).delete(link.getId());
+        assertEquals(api(basicUser).actionManager()
                 .getLatestGlobalEvent().getEventType(), EventTypes.deletion);
     }
 

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingCrudTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingCrudTest.java
@@ -22,7 +22,6 @@ package eu.ehri.project.api;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import eu.ehri.project.definitions.EventTypes;
-import eu.ehri.project.exceptions.HierarchyError;
 import eu.ehri.project.models.EntityClass;
 import eu.ehri.project.models.Repository;
 import eu.ehri.project.models.events.SystemEvent;
@@ -33,7 +32,6 @@ import eu.ehri.project.persistence.Mutation;
 import eu.ehri.project.persistence.Serializer;
 import eu.ehri.project.test.AbstractFixtureTest;
 import eu.ehri.project.test.TestData;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,21 +59,6 @@ public class ApiLoggingCrudTest extends AbstractFixtureTest {
         Repository repository = loggingApi(validUser).create(repoBundle, Repository.class);
         assertEquals(repository, am.getLatestGlobalEvent()
                 .getSubjects().iterator().next());
-    }
-
-    @Test
-    public void testCreateOrUpdate() throws Exception {
-        Bundle before = depSerializer.entityToBundle(manager.getEntity("r1", Repository.class));
-        Bundle repoBundle = Bundle.fromData(TestData.getTestAgentBundle())
-                .withId("r1");
-        Mutation<Repository> cou = loggingApi(validUser).createOrUpdate(repoBundle, Repository.class);
-        assertTrue(cou.updated());
-        SystemEvent event = am.getLatestGlobalEvent();
-        assertEquals(cou.getNode(), event.getSubjects().iterator().next());
-        assertTrue(event.getPriorVersions().iterator().hasNext());
-        Bundle old = Bundle.fromString(event.getPriorVersions().iterator().next().getEntityData());
-        assertNotSame(old, repoBundle);
-        Assert.assertEquals(before, old);
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingCrudTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingCrudTest.java
@@ -56,7 +56,7 @@ public class ApiLoggingCrudTest extends AbstractFixtureTest {
     @Test
     public void testCreate() throws Exception {
         Bundle repoBundle = Bundle.fromData(TestData.getTestAgentBundle());
-        Repository repository = loggingApi(validUser).create(repoBundle, Repository.class);
+        Repository repository = loggingApi(adminUser).create(repoBundle, Repository.class);
         assertEquals(repository, am.getLatestGlobalEvent()
                 .getSubjects().iterator().next());
     }
@@ -64,7 +64,7 @@ public class ApiLoggingCrudTest extends AbstractFixtureTest {
     @Test
     public void testUpdate() throws Exception {
         Bundle before = depSerializer.entityToBundle(manager.getEntity("r1", Repository.class));
-        Mutation<Repository> cou = loggingApi(validUser)
+        Mutation<Repository> cou = loggingApi(adminUser)
                 .update(before.withDataValue("identifier", "new-id"), Repository.class);
         assertTrue(cou.updated());
         SystemEvent event = am.getLatestGlobalEvent();
@@ -78,22 +78,22 @@ public class ApiLoggingCrudTest extends AbstractFixtureTest {
     public void testDelete() throws Exception {
         Repository r1 = manager.getEntity("r2", Repository.class);
         Bundle before = depSerializer.entityToBundle(r1);
-        loggingApi(validUser).delete("r2");
+        loggingApi(adminUser).delete("r2");
         SystemEvent event = am.getLatestGlobalEvent();
         assertFalse(manager.exists("r2"));
         assertTrue(event.getPriorVersions().iterator().hasNext());
         Bundle old = Bundle.fromString(event.getPriorVersions().iterator().next().getEntityData());
         assertEquals(before, old);
-        Optional<Version> r1v = loggingApi(validUser).versionManager().versionAtDeletion("r2");
+        Optional<Version> r1v = loggingApi(adminUser).versionManager().versionAtDeletion("r2");
         assertTrue(r1v.isPresent());
-        List<Version> r1vl = Lists.newArrayList(loggingApi(validUser).versionManager()
+        List<Version> r1vl = Lists.newArrayList(loggingApi(adminUser).versionManager()
                 .versionsAtDeletion(EntityClass.REPOSITORY, null, null));
         assertEquals(1, r1vl.size());
     }
 
     @Test
     public void testDeleteChildren() throws Exception {
-        List<String> out = loggingApi(validUser).deleteChildren(item.getId(), true, true, Optional.empty());
+        List<String> out = loggingApi(adminUser).deleteChildren(item.getId(), true, true, Optional.empty());
         assertEquals(Lists.newArrayList("c2", "c3"), out);
         SystemEvent event = am.getLatestGlobalEvent();
         assertEquals(EventTypes.deletion, event.getEventType());

--- a/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/ApiLoggingTest.java
@@ -44,13 +44,13 @@ public class ApiLoggingTest extends AbstractFixtureTest {
     @Test
     public void testUpdate() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestDocBundle());
-        DocumentaryUnit unit = api(validUser).create(bundle, DocumentaryUnit.class);
+        DocumentaryUnit unit = api(adminUser).create(bundle, DocumentaryUnit.class);
         assertEquals(TestData.TEST_COLLECTION_NAME, unit.getProperty("name"));
 
         String newName = TestData.TEST_COLLECTION_NAME + " with new stuff";
         Bundle newBundle = bundle.withId(unit.getId()).withDataValue("name", newName);
 
-        DocumentaryUnit changedUnit = api(validUser).update(newBundle, DocumentaryUnit.class).getNode();
+        DocumentaryUnit changedUnit = api(adminUser).update(newBundle, DocumentaryUnit.class).getNode();
         assertEquals(newName, changedUnit.getProperty("name"));
         assertTrue(changedUnit.getDescriptions().iterator().hasNext());
         DocumentaryUnitDescription desc = graph.frame(
@@ -69,13 +69,13 @@ public class ApiLoggingTest extends AbstractFixtureTest {
     @Test
     public void testUserUpdate() throws Exception {
         Bundle bundle = Bundle.fromData(TestData.getTestUserBundle());
-        UserProfile user = loggingApi(validUser).create(bundle, UserProfile.class);
+        UserProfile user = loggingApi(adminUser).create(bundle, UserProfile.class);
         assertEquals(TestData.TEST_USER_NAME, user.getName());
 
         String newName = TestData.TEST_USER_NAME + " with new stuff";
         Bundle newBundle = bundle.withId(user.getId()).withDataValue("name", newName);
 
-        UserProfile changedUser = loggingApi(validUser).update(newBundle, UserProfile.class).getNode();
+        UserProfile changedUser = loggingApi(adminUser).update(newBundle, UserProfile.class).getNode();
         assertEquals(newName, changedUser.getName());
 
         // Check we have an audit action.
@@ -83,8 +83,8 @@ public class ApiLoggingTest extends AbstractFixtureTest {
         // FIXME: getLatestAction() should return a single item, but due to
         // a current (2.2.0) limitation in frames' @GremlinGroovy mechanism
         // it can't
-        assertEquals(1, Iterables.size(validUser.getLatestAction()));
-        SystemEvent event = Iterables.getFirst(validUser.getLatestAction(), null);
+        assertEquals(1, Iterables.size(adminUser.getLatestAction()));
+        SystemEvent event = Iterables.getFirst(adminUser.getLatestAction(), null);
         assertNotNull(event);
         assertNotNull(event.getFirstSubject());
         assertEquals(changedUser.asVertex(), event.getFirstSubject().asVertex());
@@ -115,10 +115,10 @@ public class ApiLoggingTest extends AbstractFixtureTest {
     @Test
     public void testDelete() throws Exception {
         int shouldDelete = 1;
-        int origActionCount = toList(validUser.getHistory()).size();
+        int origActionCount = toList(adminUser.getHistory()).size();
 
         // FIXME: Surely there's a better way of doing this???
-        DocumentaryUnit item = api(validUser).get("c4", DocumentaryUnit.class);
+        DocumentaryUnit item = api(adminUser).get("c4", DocumentaryUnit.class);
         Iterator<Description> descIter = item.getDescriptions().iterator();
         for (; descIter.hasNext(); shouldDelete++) {
             DocumentaryUnitDescription d = graph.frame(descIter.next().asVertex(), DocumentaryUnitDescription.class);
@@ -128,10 +128,10 @@ public class ApiLoggingTest extends AbstractFixtureTest {
         }
 
         String log = "Deleting item";
-        int deleted = loggingApi(validUser).delete(item.getId(), Optional.of(log));
+        int deleted = loggingApi(adminUser).delete(item.getId(), Optional.of(log));
         assertEquals(shouldDelete, deleted);
 
-        List<SystemEvent> actions = toList(validUser.getActions());
+        List<SystemEvent> actions = toList(adminUser.getActions());
 
         // Check there's an extra audit log for the user
         assertEquals(origActionCount + 1, actions.size());

--- a/ehri-core/src/test/java/eu/ehri/project/api/QueryApiTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/QueryApiTest.java
@@ -46,7 +46,7 @@ public class QueryApiTest extends AbstractFixtureTest {
     }
 
     private QueryApi getQuery() {
-        return api(validUser).query();
+        return api(adminUser).query();
     }
 
     private QueryApi getQuery(Accessor accessor) {
@@ -58,7 +58,7 @@ public class QueryApiTest extends AbstractFixtureTest {
         QueryApi query = getQuery();
 
         // Check we're not admin
-        assertTrue(AclManager.belongsToAdmin(validUser));
+        assertTrue(AclManager.belongsToAdmin(adminUser));
 
         // Get the total number of DocumentaryUnits the old-fashioned way
         Iterable<Vertex> allDocs = manager
@@ -99,7 +99,7 @@ public class QueryApiTest extends AbstractFixtureTest {
         QueryApi query = getQuery();
 
         // Check we're not admin
-        assertTrue(AclManager.belongsToAdmin(validUser));
+        assertTrue(AclManager.belongsToAdmin(adminUser));
 
         // Get the total number of DocumentaryUnits the old-fashioned way
         Iterable<Vertex> allDocs = manager

--- a/ehri-core/src/test/java/eu/ehri/project/api/UserProfilesApiTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/UserProfilesApiTest.java
@@ -31,59 +31,59 @@ public class UserProfilesApiTest extends AbstractFixtureTest {
     public void testNoOpLogging() throws Exception {
         // If no items are given, we shouldn't log anything...
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        views(invalidUser).addWatching(invalidUser.getId(), Lists.<String>newArrayList());
+        views(basicUser).addWatching(basicUser.getId(), Lists.<String>newArrayList());
         assertEquals(latestEvent, am.getLatestGlobalEvent());
     }
 
     @Test
     public void testAddWatching() throws Exception {
-        views(invalidUser).addWatching(invalidUser.getId(), Lists.newArrayList(item.getId()));
+        views(basicUser).addWatching(basicUser.getId(), Lists.newArrayList(item.getId()));
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        assertEquals(invalidUser, latestEvent.getActioner());
+        assertEquals(basicUser, latestEvent.getActioner());
         assertEquals(EventTypes.watch, latestEvent.getEventType());
     }
 
     @Test
     public void testRemoveWatching() throws Exception {
-        invalidUser.addWatching(item);
+        basicUser.addWatching(item);
         List<String> ids = Lists.newArrayList(item.getId());
-        views(invalidUser).removeWatching(invalidUser.getId(), ids);
+        views(basicUser).removeWatching(basicUser.getId(), ids);
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        assertEquals(invalidUser, latestEvent.getActioner());
+        assertEquals(basicUser, latestEvent.getActioner());
         assertEquals(EventTypes.unwatch, latestEvent.getEventType());
     }
 
     @Test
     public void testAddFollowers() throws Exception {
-        views(invalidUser).addFollowers(invalidUser.getId(), Lists.newArrayList(validUser.getId()));
+        views(basicUser).addFollowers(basicUser.getId(), Lists.newArrayList(adminUser.getId()));
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        assertEquals(invalidUser, latestEvent.getActioner());
+        assertEquals(basicUser, latestEvent.getActioner());
         assertEquals(EventTypes.follow, latestEvent.getEventType());
     }
 
     @Test
     public void testRemoveFollowers() throws Exception {
-        invalidUser.addFollowing(validUser);
-        views(invalidUser).removeFollowers(invalidUser.getId(), Lists.newArrayList(validUser.getId()));
+        basicUser.addFollowing(adminUser);
+        views(basicUser).removeFollowers(basicUser.getId(), Lists.newArrayList(adminUser.getId()));
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        assertEquals(invalidUser, latestEvent.getActioner());
+        assertEquals(basicUser, latestEvent.getActioner());
         assertEquals(EventTypes.unfollow, latestEvent.getEventType());
     }
 
     @Test
     public void testAddBlocked() throws Exception {
-        views(invalidUser).addBlocked(invalidUser.getId(), Lists.newArrayList(validUser.getId()));
+        views(basicUser).addBlocked(basicUser.getId(), Lists.newArrayList(adminUser.getId()));
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        assertEquals(invalidUser, latestEvent.getActioner());
+        assertEquals(basicUser, latestEvent.getActioner());
         assertEquals(EventTypes.block, latestEvent.getEventType());
     }
 
     @Test
     public void testRemoveBlocked() throws Exception {
-        invalidUser.addBlocked(validUser);
-        views(invalidUser).removeBlocked(invalidUser.getId(), Lists.newArrayList(validUser.getId()));
+        basicUser.addBlocked(adminUser);
+        views(basicUser).removeBlocked(basicUser.getId(), Lists.newArrayList(adminUser.getId()));
         SystemEvent latestEvent = am.getLatestGlobalEvent();
-        assertEquals(invalidUser, latestEvent.getActioner());
+        assertEquals(basicUser, latestEvent.getActioner());
         assertEquals(EventTypes.unblock, latestEvent.getEventType());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/api/UserProfilesApiTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/UserProfilesApiTest.java
@@ -6,7 +6,6 @@ import eu.ehri.project.models.base.Accessor;
 import eu.ehri.project.models.events.SystemEvent;
 import eu.ehri.project.persistence.ActionManager;
 import eu.ehri.project.test.AbstractFixtureTest;
-import eu.ehri.project.api.UserProfilesApi;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/ehri-core/src/test/java/eu/ehri/project/api/VirtualUnitsApiTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/api/VirtualUnitsApiTest.java
@@ -59,7 +59,7 @@ public class VirtualUnitsApiTest extends AbstractFixtureTest {
         // Make a single-use iterator to test this works with streams.
         // The stream is iterated twice so it has to handle that correctly.
         Iterable<DocumentaryUnit> iter = () -> Lists.newArrayList(c1).iterator();
-        views(validUser).moveIncludedUnits(vu1, vu2, iter);
+        views(adminUser).moveIncludedUnits(vu1, vu2, iter);
         assertFalse(Iterables.contains(vu1.getIncludedUnits(), c1));
         assertTrue(Iterables.contains(vu2.getIncludedUnits(), c1));
     }

--- a/ehri-core/src/test/java/eu/ehri/project/models/CountryTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/CountryTest.java
@@ -44,7 +44,7 @@ public class CountryTest extends AbstractFixtureTest {
     public void testGetChildCountOnDeletion() throws Exception {
         Country country = manager.getEntity("nl", Country.class);
         assertEquals(2, country.countChildren());
-        api(validUser).delete("r3");
+        api(adminUser).delete("r3");
         assertEquals(1, country.countChildren());
     }
 

--- a/ehri-core/src/test/java/eu/ehri/project/models/GroupTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/GroupTest.java
@@ -45,9 +45,9 @@ public class GroupTest extends AbstractFixtureTest {
         List<Accessor> list = Lists.newArrayList(admin.getMembers());
         long numMembers = list.size();
         // Adding same member twice should affect member count - it should be idempotent
-        admin.addMember(validUser);
+        admin.addMember(adminUser);
         assertEquals(numMembers, Iterables.size(admin.getMembers()));
-        admin.addMember(invalidUser);
+        admin.addMember(basicUser);
         assertEquals(numMembers + 1, Iterables.size(admin.getMembers()));
     }
 
@@ -57,9 +57,9 @@ public class GroupTest extends AbstractFixtureTest {
         List<Accessor> list = Lists.newArrayList(admin.getMembers());
         long numMembers = list.size();
         // Adding same member twice should affect member count - it should be idempotent
-        admin.removeMember(invalidUser);
+        admin.removeMember(basicUser);
         assertEquals(numMembers, Iterables.size(admin.getMembers()));
-        admin.removeMember(validUser);
+        admin.removeMember(adminUser);
         assertEquals(numMembers - 1, Iterables.size(admin.getMembers()));
     }
 

--- a/ehri-core/src/test/java/eu/ehri/project/models/LinkTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/LinkTest.java
@@ -32,7 +32,7 @@ public class LinkTest extends AbstractFixtureTest {
     @Test
     public void testGetLinker() throws Exception {
         Link link = manager.getEntity("link1", Link.class);
-        assertEquals(validUser, link.getLinker());
+        assertEquals(adminUser, link.getLinker());
     }
 
     @Test

--- a/ehri-core/src/test/java/eu/ehri/project/models/base/AccessibleTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/base/AccessibleTest.java
@@ -42,7 +42,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         Accessible admin = manager.getEntity(Group.ADMIN_GROUP_IDENTIFIER, Accessible.class);
         List<Accessor> accessors = Lists.newArrayList(c1.getAccessors());
         assertEquals(2, accessors.size());
-        assertTrue(accessors.contains(validUser)); // mike
+        assertTrue(accessors.contains(adminUser)); // mike
         assertTrue(accessors.contains(admin));
     }
 
@@ -54,7 +54,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         assertEquals(2, accessors.size());
         c1.addAccessor(admin);
         assertEquals(2, Iterables.size(c1.getAccessors())); // same size
-        c1.addAccessor(invalidUser);
+        c1.addAccessor(basicUser);
         assertEquals(3, Iterables.size(c1.getAccessors()));
     }
 
@@ -65,7 +65,7 @@ public class AccessibleTest extends AbstractFixtureTest {
         c1.removeAccessor(admin);
         List<Accessor> accessors = Lists.newArrayList(c1.getAccessors());
         assertEquals(1, accessors.size());
-        assertTrue(accessors.contains(validUser));
+        assertTrue(accessors.contains(adminUser));
     }
 
     @Test
@@ -128,6 +128,6 @@ public class AccessibleTest extends AbstractFixtureTest {
     private Mutation<DocumentaryUnit> doUpdate(DocumentaryUnit unit) throws Exception {
         Bundle doc = new Serializer(graph).entityToBundle(unit)
                 .withDataValue("somekey", "someval");
-        return loggingApi(validUser).update(doc, DocumentaryUnit.class);
+        return loggingApi(adminUser).update(doc, DocumentaryUnit.class);
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventQueueTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventQueueTest.java
@@ -16,7 +16,7 @@ public class SystemEventQueueTest extends AbstractFixtureTest {
         SystemEventQueue queue = manager.getEntity(ActionManager.GLOBAL_EVENT_ROOT, SystemEventQueue.class);
         assertNull(queue.getLatestEvent());
         ActionManager.EventContext ctx = new ActionManager(graph)
-                .newEventContext(validUser, validUser.as(Actioner.class), EventTypes.creation);
+                .newEventContext(adminUser, adminUser.as(Actioner.class), EventTypes.creation);
         SystemEvent commit = ctx.commit();
         assertEquals(commit, queue.getLatestEvent());
     }
@@ -25,7 +25,7 @@ public class SystemEventQueueTest extends AbstractFixtureTest {
     public void testGetSystemEvents() throws Exception {
         SystemEventQueue queue = manager.getEntity(ActionManager.GLOBAL_EVENT_ROOT, SystemEventQueue.class);
         new ActionManager(graph)
-                .newEventContext(validUser, validUser.as(Actioner.class), EventTypes.creation)
+                .newEventContext(adminUser, adminUser.as(Actioner.class), EventTypes.creation)
                 .commit();
         assertEquals(1, Iterators.size(queue.getSystemEvents().iterator()));
     }

--- a/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/events/SystemEventTest.java
@@ -59,14 +59,14 @@ public class SystemEventTest extends AbstractFixtureTest {
         UserProfile user = bundleManager.create(userBundle, UserProfile.class);
 
         ActionManager.EventContext ctx = actionManager.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         SystemEvent first = ctx.commit();
         assertEquals(1, Iterables.size(first.getSubjects()));
 
         // Delete the user and log it
         ActionManager.EventContext ctx2 = actionManager.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.deletion);
         ctx2.commit();
         bundleManager.delete(serializer.entityToBundle(user));
@@ -84,14 +84,14 @@ public class SystemEventTest extends AbstractFixtureTest {
         UserProfile user = bundleManager.create(userBundle, UserProfile.class);
 
         ActionManager.EventContext ctx = actionManager.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         SystemEvent first = ctx.commit();
         assertEquals(1, Iterables.size(first.getSubjects()));
 
         // Delete the user and log it
         ActionManager.EventContext ctx2 = actionManager.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.modification);
         SystemEvent second = ctx2.commit();
         bundleManager.update(userBundle2, UserProfile.class);
@@ -100,7 +100,7 @@ public class SystemEventTest extends AbstractFixtureTest {
         bundleManager.update(userBundle3, UserProfile.class);
 
         ActionManager.EventContext ctx3 = actionManager.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.deletion);
         SystemEvent forth = ctx3.commit();
 
@@ -120,7 +120,7 @@ public class SystemEventTest extends AbstractFixtureTest {
 
         // Delete the user and log it
         ActionManager.EventContext ctx4 = actionManager.newEventContext(repository,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.modification);
         SystemEvent repoEvent = ctx4.commit();
 
@@ -133,7 +133,7 @@ public class SystemEventTest extends AbstractFixtureTest {
         UserProfile user = bundleManager.create(userBundle, UserProfile.class);
 
         ActionManager.EventContext ctx = actionManager.newEventContext(user,
-                validUser,
+                adminUser,
                 EventTypes.creation);
         SystemEvent first = ctx.commit();
         assertEquals(1, Iterables.size(first.getSubjects()));
@@ -141,14 +141,14 @@ public class SystemEventTest extends AbstractFixtureTest {
         // Do the same thing again after 1/2 second
         Thread.sleep(500);
         ActionManager.EventContext ctx2 = actionManager.newEventContext(user,
-                validUser,
+                adminUser,
                 EventTypes.creation);
         SystemEvent second = ctx2.commit();
 
         // And again after 1 full second
         Thread.sleep(500);
         ActionManager.EventContext ctx3 = actionManager.newEventContext(user,
-                validUser,
+                adminUser,
                 EventTypes.creation);
         SystemEvent third = ctx3.commit();
 

--- a/ehri-core/src/test/java/eu/ehri/project/models/events/VersionTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/models/events/VersionTest.java
@@ -51,14 +51,14 @@ public class VersionTest extends AbstractFixtureTest {
         UserProfile user = bundleManager.create(userBundle, UserProfile.class);
 
         SystemEvent first = actionManager.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation).commit();
         assertEquals(1, Iterables.size(first.getSubjects()));
 
         // Change the user twice in succession, with the data from userBundle2
         // and userBundle3
         SystemEvent second = actionManager.newEventContext(user,
-                validUser.as(Actioner.class),
+                adminUser.as(Actioner.class),
                 EventTypes.modification)
                 .createVersion(user).commit();
         Mutation<UserProfile> update1 = bundleManager
@@ -67,7 +67,7 @@ public class VersionTest extends AbstractFixtureTest {
 
         // and again
         SystemEvent third = actionManager.newEventContext(user,
-                validUser.as(Actioner.class),
+                adminUser.as(Actioner.class),
                 EventTypes.modification)
                 .createVersion(user).commit();
         Mutation<UserProfile> update2 = bundleManager.update(userBundle3, UserProfile.class);

--- a/ehri-core/src/test/java/eu/ehri/project/persistence/ActionManagerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/persistence/ActionManagerTest.java
@@ -55,7 +55,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         Bundle userBundle = Bundle.fromData(TestData.getTestUserBundle());
         UserProfile user = new BundleManager(graph).create(userBundle, UserProfile.class);
         ActionManager.EventContext ctx1 = am.newEventContext(user,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         SystemEvent first = ctx1.commit();
 
@@ -64,7 +64,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         Repository repository = new BundleManager(graph).create(repoBundle, Repository.class);
 
         ActionManager.EventContext ctx2 = am.newEventContext(repository,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         assertEquals(EventTypes.creation, ctx2.getEventType());
         SystemEvent second = ctx2.commit();
@@ -76,7 +76,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         assertNotNull(second.getActioner());
 
         // Check the user is correctly linked
-        assertEquals(validUser, second.getActioner());
+        assertEquals(adminUser, second.getActioner());
 
         assertEquals(1, Iterables.size(repository.getHistory()));
         assertNotNull(repository.getLatestEvent());
@@ -100,7 +100,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         Bundle docBundle = Bundle.fromData(TestData.getTestDocBundle());
         DocumentaryUnit doc = new BundleManager(graph).create(docBundle, DocumentaryUnit.class);
         ActionManager.EventContext ctx = am.newEventContext(doc,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         SystemEvent log = ctx.commit();
         assertNotNull(log.getEventScope());
@@ -116,7 +116,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         int nodesBefore = getNodeCount(graph);
         int edgesBefore = getEdgeCount(graph);
         ActionManager.EventContext ctx1 = am.newEventContext(doc,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         assertEquals(nodesBefore, getNodeCount(graph));
         assertEquals(edgesBefore, getEdgeCount(graph));
@@ -138,7 +138,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
         BundleManager dao = new BundleManager(graph);
         DocumentaryUnit doc = dao.create(docBundle, DocumentaryUnit.class);
         ActionManager.EventContext ctx1 = am.newEventContext(doc,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.creation);
         ctx1.commit();
         assertNull(doc.getPriorVersion());
@@ -146,7 +146,7 @@ public class ActionManagerTest extends AbstractFixtureTest {
                 .withId(doc.getId())
                 .withDataValue("identifier", "changed"), DocumentaryUnit.class);
         ActionManager.EventContext ctx2 = am.newEventContext(doc,
-                graph.frame(validUser.asVertex(), Actioner.class),
+                graph.frame(adminUser.asVertex(), Actioner.class),
                 EventTypes.modification).createVersion(doc, docBundle);
         SystemEvent event = ctx2.commit();
         assertTrue(update.updated());

--- a/ehri-core/src/test/java/eu/ehri/project/test/AbstractFixtureTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/test/AbstractFixtureTest.java
@@ -29,8 +29,8 @@ import org.junit.BeforeClass;
 abstract public class AbstractFixtureTest extends ModelTestBase {
 
     // Members closely coupled to the test data!
-    protected UserProfile validUser;
-    protected UserProfile invalidUser;
+    protected UserProfile adminUser;
+    protected UserProfile basicUser;
     protected DocumentaryUnit item;
 
     @BeforeClass
@@ -43,8 +43,8 @@ abstract public class AbstractFixtureTest extends ModelTestBase {
         super.setUp();
         try {
             item = manager.getEntity("c1", DocumentaryUnit.class);
-            validUser = manager.getEntity("mike", UserProfile.class);
-            invalidUser = manager.getEntity("reto", UserProfile.class);
+            adminUser = manager.getEntity("mike", UserProfile.class);
+            basicUser = manager.getEntity("reto", UserProfile.class);
         } catch (ItemNotFound e) {
             throw new RuntimeException(e);
         }

--- a/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/FindReplaceTest.java
@@ -23,7 +23,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
         List<List<String>> names = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
                 "name", "Description",
-                "Test", validUser, "This is a test");
+                "Test", adminUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         names.sort(Comparator.comparing(o -> o.get(0)));
         GraphDiff diff = diffGraph(before, after);
@@ -47,7 +47,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
                 manager.getEntity("rd4", Description.class).getName());
 
         assertThat(names, equalTo(out));
-        assertThat(api(validUser)
+        assertThat(api(adminUser)
                         .actionManager().getLatestGlobalEvent().getLogMessage(),
                 equalTo("This is a test"));
     }
@@ -59,7 +59,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
         List<List<String>> done = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
                 "name", "Description",
-                "Test", validUser, "This is a test");
+                "Test", adminUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
         assertEquals(6, diff.added.size());
@@ -74,7 +74,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
         List<List<String>> todo = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.REPOSITORY_DESCRIPTION,
                 "name", "Description",
-                "Test", validUser, "This is a test");
+                "Test", adminUser, "This is a test");
         List<VertexProxy> after = getGraphState(graph);
         GraphDiff diff = diffGraph(before, after);
         assertEquals(0, diff.added.size());
@@ -88,7 +88,7 @@ public class FindReplaceTest extends AbstractFixtureTest {
         List<List<String>> todo = findReplace.findAndReplace(
                 EntityClass.REPOSITORY, EntityClass.ADDRESS,
                 "name", "Description",
-                "Test", validUser, "This is a test");
+                "Test", adminUser, "This is a test");
         assertEquals(0, todo.size());
     }
 }

--- a/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
+++ b/ehri-core/src/test/java/eu/ehri/project/tools/LinkerTest.java
@@ -54,7 +54,7 @@ public class LinkerTest extends AbstractFixtureTest {
         int newLinkCount = linker
                 .withExcludeSingles(false)
                 .withLogMessage(logMessage)
-                .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
+                .createAndLinkRepositoryVocabulary(repository, vocabulary, adminUser);
         assertEquals(5, newLinkCount);
         assertEquals(eventCount + 2,
                 Iterables.size(actionManager.getLatestGlobalEvents()));
@@ -72,7 +72,7 @@ public class LinkerTest extends AbstractFixtureTest {
         int newLinkCount = linker
                 .withExcludeSingles(false)
                 .withAccessPointType(AccessPointType.genre)
-                .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
+                .createAndLinkRepositoryVocabulary(repository, vocabulary, adminUser);
         assertEquals(0, newLinkCount);
         // No new events should have been created...
         assertEquals(eventCount,
@@ -88,7 +88,7 @@ public class LinkerTest extends AbstractFixtureTest {
         // This won't create any links because all of the access points only point
         // to single items
         int newLinkCount = linker.withExcludeSingles(true)
-            .createAndLinkRepositoryVocabulary(repository, vocabulary, validUser);
+            .createAndLinkRepositoryVocabulary(repository, vocabulary, adminUser);
         assertEquals(0, newLinkCount);
         // No new events should have been created...
         assertEquals(eventCount,

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/dc/DublinCore11ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/dc/DublinCore11ExporterTest.java
@@ -57,7 +57,7 @@ public class DublinCore11ExporterTest extends XmlExporterTest {
     }
 
     private String testExport(Described item, String lang) throws Exception {
-        DublinCoreExporter exporter = new DublinCore11Exporter(api(validUser));
+        DublinCoreExporter exporter = new DublinCore11Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(item, baos, lang);
         String xml = baos.toString("UTF-8");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eac/Eac2010ExporterTest.java
@@ -51,7 +51,7 @@ public class Eac2010ExporterTest extends XmlExporterTest {
         AuthoritativeSet auths = manager.getEntity("auths", AuthoritativeSet.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("abwehr.xml");
         String logMessage = "Test EAC import/export";
-        SaxImportManager.create(graph, auths, validUser,
+        SaxImportManager.create(graph, auths, adminUser,
                 EacImporter.class, EacHandler.class, ImportOptions.properties("eac.properties"))
                 .importInputStream(ios, logMessage);
         HistoricalAgent repo = graph.frame(getVertexByIdentifier(graph, "381"), HistoricalAgent.class);
@@ -105,7 +105,7 @@ public class Eac2010ExporterTest extends XmlExporterTest {
     }
 
     private String testExport(HistoricalAgent agent, String lang) throws Exception {
-        Eac2010Exporter exporter = new Eac2010Exporter(api(validUser));
+        Eac2010Exporter exporter = new Eac2010Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(agent, baos, lang);
         String xml = baos.toString("UTF-8");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead2002ExporterTest.java
@@ -151,7 +151,7 @@ public class Ead2002ExporterTest extends XmlExporterTest {
     }
 
     private String testExport(DocumentaryUnit unit, String lang) throws Exception {
-        Ead2002Exporter exporter = new Ead2002Exporter(api(validUser));
+        Ead2002Exporter exporter = new Ead2002Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(unit, baos, lang);
         String xml = baos.toString("UTF-8");
@@ -162,12 +162,12 @@ public class Ead2002ExporterTest extends XmlExporterTest {
     private String testImportExport(Repository repository, String resourceName,
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
-        SaxImportManager.create(graph, repository, validUser,
+        SaxImportManager.create(graph, repository, adminUser,
                 EadImporter.class, EadHandler.class, ImportOptions.basic())
                 .importInputStream(ios, "Testing import/export");
         DocumentaryUnit fonds = graph.frame(
                 getVertexByIdentifier(graph, topLevelIdentifier), DocumentaryUnit.class);
-        Ead2002Exporter exporter = new Ead2002Exporter(api(validUser));
+        Ead2002Exporter exporter = new Ead2002Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(fonds, baos, lang);
         String xml = baos.toString("UTF-8");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead3ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/ead/Ead3ExporterTest.java
@@ -164,7 +164,7 @@ public class Ead3ExporterTest extends XmlExporterTest {
     }
 
     private String testExport(DocumentaryUnit unit, String lang) throws Exception {
-        Ead3Exporter exporter = new Ead3Exporter(api(validUser));
+        Ead3Exporter exporter = new Ead3Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(unit, baos, lang);
         String xml = baos.toString("UTF-8");
@@ -176,12 +176,12 @@ public class Ead3ExporterTest extends XmlExporterTest {
     private String testImportExport(Repository repository, String resourceName,
             String topLevelIdentifier, String lang) throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream(resourceName);
-        SaxImportManager.create(graph, repository, validUser,
+        SaxImportManager.create(graph, repository, adminUser,
                 EadImporter.class, EadHandler.class, ImportOptions.properties("ead3.properties"))
                 .importInputStream(ios, "Testing import/export");
         DocumentaryUnit fonds = graph.frame(
                 getVertexByIdentifier(graph, topLevelIdentifier), DocumentaryUnit.class);
-        Ead3Exporter exporter = new Ead3Exporter(api(validUser));
+        Ead3Exporter exporter = new Ead3Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(fonds, baos, lang);
         String xml = baos.toString("UTF-8");

--- a/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/exporters/eag/Eag2012ExporterTest.java
@@ -51,7 +51,7 @@ public class Eag2012ExporterTest extends XmlExporterTest {
     public void testImportExport1() throws Exception {
         Country nl = manager.getEntity("nl", Country.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream("eag-2896.xml");
-        SaxImportManager importManager = SaxImportManager.create(graph, nl, validUser,
+        SaxImportManager importManager = SaxImportManager.create(graph, nl, adminUser,
                 EagImporter.class, EagHandler.class, ImportOptions.properties("eag.properties"));
         importManager.importInputStream(ios, "Text EAG import/export");
         Repository repo = graph.frame(getVertexByIdentifier(graph, "NL-002896"), Repository.class);
@@ -103,7 +103,7 @@ public class Eag2012ExporterTest extends XmlExporterTest {
     }
 
     private String testExport(Repository repository, String lang) throws Exception {
-        Eag2012Exporter exporter = new Eag2012Exporter(api(validUser));
+        Eag2012Exporter exporter = new Eag2012Exporter(api(adminUser));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(repository, baos, lang);
         String xml = baos.toString("UTF-8");

--- a/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/base/AbstractImporterTest.java
@@ -66,11 +66,11 @@ public abstract class AbstractImporterTest extends AbstractFixtureTest {
      * Convenience method for creating a Sax import manager.
      */
     protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass, ImportOptions options) {
-        return SaxImportManager.create(graph, repository, validUser, importerClass, handlerClass, options);
+        return SaxImportManager.create(graph, repository, adminUser, importerClass, handlerClass, options);
     }
 
     protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass) {
-        return SaxImportManager.create(graph, repository, validUser, importerClass, handlerClass, ImportOptions.basic());
+        return SaxImportManager.create(graph, repository, adminUser, importerClass, handlerClass, ImportOptions.basic());
     }
 
     protected SaxImportManager saxImportManager(Class<? extends ItemImporter<?,?>> importerClass, Class<? extends SaxXmlHandler> handlerClass, String propertiesResource) {

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvAuthoritativeItemImporterTest.java
@@ -58,7 +58,7 @@ public class CsvAuthoritativeItemImporterTest extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_CSV);
 
         List<VertexProxy> graphState1 = getGraphState(graph);
-        ImportLog log = CsvImportManager.create(graph, authoritativeSet, validUser,
+        ImportLog log = CsvImportManager.create(graph, authoritativeSet, adminUser,
                 CsvAuthoritativeItemImporter.class, ImportOptions.basic()).importInputStream(ios, logMessage);
         assertEquals(9, log.getCreated());
         printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvConceptImporterTest.java
@@ -63,7 +63,7 @@ public class CsvConceptImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        CsvImportManager.create(graph, authoritativeSet, validUser, CsvConceptImporter.class, ImportOptions.basic())
+        CsvImportManager.create(graph, authoritativeSet, adminUser, CsvConceptImporter.class, ImportOptions.basic())
                 .importInputStream(ios, logMessage);
         /*
          * 18 Concept

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/CsvDossinImporterTest.java
@@ -49,7 +49,7 @@ public class CsvDossinImporterTest extends AbstractImporterTest {
         List<VertexProxy> graphState1 = getGraphState(graph);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream("dossin.csv");
-        ImportLog importLog = CsvImportManager.create(graph, ps, validUser, EadImporter.class, ImportOptions.basic())
+        ImportLog importLog = CsvImportManager.create(graph, ps, adminUser, EadImporter.class, ImportOptions.basic())
                 .importInputStream(ios, logMessage);
         System.out.println(importLog);
         // After...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/csv/PersonalitiesImporterTest.java
@@ -56,7 +56,7 @@ public class PersonalitiesImporterTest extends AbstractImporterTest {
 
         int count = getNodeCount(graph);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_EAD);
-        CsvImportManager.create(graph, authoritativeSet, validUser,
+        CsvImportManager.create(graph, authoritativeSet, adminUser,
                 PersonalitiesImporter.class, ImportOptions.basic()).importInputStream(ios, logMessage);
         SystemEvent ev = actionManager.getLatestGlobalEvent();
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/AbstractSkosTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractSkosTest extends AbstractFixtureTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        actioner = validUser.as(Actioner.class);
+        actioner = adminUser.as(Actioner.class);
         vocabulary = manager.getEntity("cvoc2", Vocabulary.class);
         actionManager = new ActionManager(graph);
     }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/CampsImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/CampsImporterTest.java
@@ -48,7 +48,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
         assertNotNull(ios);
 
-        SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary).importFile(ios, logMessage);
+        SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary).importFile(ios, logMessage);
 
         printGraph(graph);
         /*  How many new nodes will have been created? We should have
@@ -63,7 +63,7 @@ public class CampsImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "675";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, Concept.class));
@@ -84,7 +84,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
         importer.importFile(ios, "Importing the camps as a SKOS file");
 
@@ -101,7 +101,7 @@ public class CampsImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "675";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, Concept.class));
@@ -116,7 +116,7 @@ public class CampsImporterTest extends AbstractImporterTest {
         //import version 2
         String version2 = "cvoc/campsv02.rdf";
         ios = ClassLoader.getSystemResourceAsStream(version2);
-        SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary)
+        SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary)
             .allowUpdates(true)
             .importFile(ios, "Importing the modified camps as a SKOS file");
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/CampsV2_1Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/CampsV2_1Test.java
@@ -49,7 +49,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
         assertNotNull(ios);
 
-        SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary).importFile(ios, logMessage);
+        SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary).importFile(ios, logMessage);
 
         printGraph(graph);
         /*  How many new nodes will have been created? We should have
@@ -64,7 +64,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "675";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, Concept.class));
@@ -86,7 +86,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
 
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary)
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary)
                 .setTolerant(true);
         importer.importFile(ios, "Importing the camps as a SKOS file");
 
@@ -103,7 +103,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "675";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, Concept.class));
@@ -118,7 +118,7 @@ public class CampsV2_1Test extends AbstractImporterTest {
         //import version 2
         String version2 = "cvoc/camps-v2-1.rdf.xml";
         ios = ClassLoader.getSystemResourceAsStream(version2);
-        importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary)
+        importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary)
         .allowUpdates(true);
 
         // Before...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/EventsSkosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/EventsSkosImporterTest.java
@@ -49,7 +49,7 @@ public class EventsSkosImporterTest extends AbstractImporterTest {
     public void importAllEvents() throws Exception {
         InputStream ios = ClassLoader.getSystemResourceAsStream("cvoc/allEhriEvents.rdf");
         Vocabulary vocabulary = manager.getEntity("cvoc1", Vocabulary.class);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
         // Before...
         List<VertexProxy> graphState1 = getGraphState(graph);
@@ -76,7 +76,7 @@ public class EventsSkosImporterTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         Vocabulary vocabulary = manager.getEntity("cvoc1", Vocabulary.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream(EVENT_SKOS);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary)
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary)
                 .setTolerant(true);
         //auths
         // Before...
@@ -126,14 +126,14 @@ public class EventsSkosImporterTest extends AbstractImporterTest {
     public void withOutsideScheme() throws ItemNotFound, IOException, InputParseError, ValidationError {
         Vocabulary cvoc1 = manager.getEntity("cvoc1", Vocabulary.class);
         InputStream ios1 = ClassLoader.getSystemResourceAsStream(EHRI_SKOS_TERM);
-        SkosImporterFactory.newSkosImporter(graph, validUser, cvoc1)
+        SkosImporterFactory.newSkosImporter(graph, adminUser, cvoc1)
                 .setTolerant(true)
                 .importFile(ios1, logMessage);
 
         int count = getNodeCount(graph);
         Vocabulary vocabulary = manager.getEntity("cvoc2", Vocabulary.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream(EVENT_SKOS);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
 
         // Before...

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterTest.java
@@ -45,7 +45,7 @@ public class GhettosImporterTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
         ImportLog log = importer.importFile(ios, logMessage);
         //printGraph(graph);
@@ -63,7 +63,7 @@ public class GhettosImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "0";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
 
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/GhettosImporterV20140831Test.java
@@ -44,7 +44,7 @@ public class GhettosImporterV20140831Test extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream("cvoc/ghettos.rdf");
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary)
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary)
                 .setTolerant(true)
                 .allowUpdates(true);
         ImportLog log = importer.importFile(ios, logMessage);
@@ -62,7 +62,7 @@ public class GhettosImporterV20140831Test extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "0";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
 
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/JoodsRaadTest.java
@@ -58,7 +58,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
         InputStream ios = ClassLoader.getSystemResourceAsStream(EHRI_SKOS_TERM);
         assertNotNull(ios);
 
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
 
         // Before...
@@ -82,7 +82,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "698";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(
                 Ontology.IDENTIFIER_KEY, skosConceptId, Concept.class));
@@ -108,7 +108,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
 
         Vocabulary cvoc1 = manager.getEntity("cvoc1", Vocabulary.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream(EHRI_SKOS_TERM);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, cvoc1)
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, cvoc1)
                 .setTolerant(true);
         importer.importFile(ios, logMessage);
 
@@ -119,7 +119,7 @@ public class JoodsRaadTest extends AbstractImporterTest {
         Vocabulary cvoc2 = manager.getEntity("cvoc2", Vocabulary.class);
         InputStream niod_ios = ClassLoader.getSystemResourceAsStream(NIOD_SKOS_TERM);
         assertNotNull(niod_ios);
-        SkosImporter niod_importer = SkosImporterFactory.newSkosImporter(graph, validUser, cvoc2);
+        SkosImporter niod_importer = SkosImporterFactory.newSkosImporter(graph, adminUser, cvoc2);
         niod_importer.setTolerant(true);
         int voccount = toList(cvoc2.getConcepts()).size();
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/SkosImporterAdminDistrictTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/SkosImporterAdminDistrictTest.java
@@ -40,7 +40,7 @@ public class SkosImporterAdminDistrictTest extends AbstractImporterTest {
   
     @Test
     public void testImportItems() throws Exception {
-        UserProfile user = validUser; //graph.frame(graph.getVertex(validUserId), UserProfile.class);
+        UserProfile user = adminUser; //graph.frame(graph.getVertex(validUserId), UserProfile.class);
         Repository agent = manager.getEntity(TEST_REPO, Repository.class); //graph.frame(helper.getTestVertex(TEST_USER), Repository.class);
 
         final String logMessage = "Importing a single skos: " + SINGLE_SKOS;
@@ -49,7 +49,7 @@ public class SkosImporterAdminDistrictTest extends AbstractImporterTest {
         Vocabulary vocabulary = manager.getEntity("cvoc1", Vocabulary.class);
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_SKOS);
 //        SkosCoreCvocImporter importer = new SkosCoreCvocImporter(graph, validUser, vocabulary);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
         ImportLog log = importer.importFile(ios, logMessage);
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
@@ -46,7 +46,7 @@ public class Wp2KeywordsTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int vocCount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
-        SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary)
+        SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary)
                 .setTolerant(true).importFile(ios, logMessage);
 
         /*  How many new nodes will have been created? We should have

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2KeywordsTest.java
@@ -19,7 +19,6 @@
 
 package eu.ehri.project.importers.cvoc;
 
-import eu.ehri.project.importers.ImportLog;
 import eu.ehri.project.importers.base.AbstractImporterTest;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.cvoc.Concept;

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2OrganisationsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2OrganisationsTest.java
@@ -42,7 +42,7 @@ public class Wp2OrganisationsTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
         ImportLog log = importer.importFile(ios, logMessage);
     }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2PlacesImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/cvoc/Wp2PlacesImporterTest.java
@@ -45,7 +45,7 @@ public class Wp2PlacesImporterTest extends AbstractImporterTest {
         int count = getNodeCount(graph);
         int voccount = toList(vocabulary.getConcepts()).size();
         InputStream ios = ClassLoader.getSystemResourceAsStream(SKOS_FILE);
-        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, validUser, vocabulary);
+        SkosImporter importer = SkosImporterFactory.newSkosImporter(graph, adminUser, vocabulary);
         importer.setTolerant(true);
         ImportLog log = importer.importFile(ios, logMessage);
 
@@ -62,7 +62,7 @@ public class Wp2PlacesImporterTest extends AbstractImporterTest {
 
         // get a top concept
         String skosConceptId = "PLACE.ČSÚ.544256";
-        QueryApi query = api(validUser).query();
+        QueryApi query = api(adminUser).query();
 
         // Query for document identifier.
         List<Concept> list = toList(query.withLimit(1).page(

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eac/PersonalitiesV2Test.java
@@ -137,9 +137,9 @@ public class PersonalitiesV2Test extends AbstractImporterTest {
                 .withDataValue(Ontology.NAME_KEY, "FAST Keywords");
         Bundle conceptBundle = Bundle.of(EntityClass.CVOC_CONCEPT)
                 .withDataValue(Ontology.IDENTIFIER_KEY, "fst894382");
-        Vocabulary vocabulary = api(validUser).create(vocabularyBundle, Vocabulary.class);
+        Vocabulary vocabulary = api(adminUser).create(vocabularyBundle, Vocabulary.class);
         logger.debug(vocabulary.getId());
-        Concept concept_716 = api(validUser).create(conceptBundle, Concept.class);
+        Concept concept_716 = api(adminUser).create(conceptBundle, Concept.class);
         vocabulary.addItem(concept_716);
 
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadSyncTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/EadSyncTest.java
@@ -62,7 +62,7 @@ public class EadSyncTest extends AbstractImporterTest {
     public void testUnitSyncWithUserGeneratedContent() throws Exception {
         DocumentaryUnit scope = manager.getEntity("nl-r1-ctop_level_fonds", DocumentaryUnit.class);
         Set<String> excludes = Sets.newHashSet();
-        Annotation testAnnotation = api(validUser).createAnnotation(
+        Annotation testAnnotation = api(adminUser).createAnnotation(
                 "nl-r1-ctop_level_fonds-c00001-c00002-2",
                 "nl-r1-ctop_level_fonds-c00001-c00002-2.eng-test_desc_id_eng",
                 Bundle.of(EntityClass.ANNOTATION, ImmutableMap.of("body", "Test annotation!")),
@@ -81,7 +81,7 @@ public class EadSyncTest extends AbstractImporterTest {
         assertEquals(unit, testAnnotation.getTargets().iterator().next());
         assertEquals(desc, testAnnotation.getTargetParts().iterator().next());
         // Transfer event prior to delete event...
-        SystemEvent transferEvent = api(validUser).actionManager()
+        SystemEvent transferEvent = api(adminUser).actionManager()
                 .getLatestGlobalEvent().getPriorEvent();
         assertEquals(EventTypes.modification, transferEvent.getEventType());
         assertEquals(logMessage, transferEvent.getLogMessage());
@@ -91,7 +91,7 @@ public class EadSyncTest extends AbstractImporterTest {
     public void testUnitSyncWithAccessControl() throws Exception {
         DocumentaryUnit scope = manager.getEntity("nl-r1-ctop_level_fonds", DocumentaryUnit.class);
         DocumentaryUnit child = manager.getEntity("nl-r1-ctop_level_fonds-c00001-c00002-2", DocumentaryUnit.class);
-        api(validUser).acl().setAccessors(child, Sets.newHashSet(validUser));
+        api(adminUser).acl().setAccessors(child, Sets.newHashSet(adminUser));
         runSync(scope, Sets.newHashSet(), "Test access sync", "hierarchical-ead-sync-test.xml");
 
         // Check the new item is in the VC
@@ -99,7 +99,7 @@ public class EadSyncTest extends AbstractImporterTest {
                 "nl-r1-ctop_level_fonds-c00001-c00002-2_parent-c00002_2", DocumentaryUnit.class);
         List<Accessor> accessors = Lists.newArrayList(moved.getAccessors());
         assertEquals(1, accessors.size());
-        assertTrue(accessors.contains(validUser));
+        assertTrue(accessors.contains(adminUser));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class EadSyncTest extends AbstractImporterTest {
     }
 
     private SyncLog runSync(PermissionScope scope, Set<String> excludes, String logMessage, String ead) throws Exception {
-        EadSync sync = EadSync.create(graph, api(validUser), scope, validUser, importManager);
+        EadSync sync = EadSync.create(graph, api(adminUser), scope, adminUser, importManager);
         InputStream ios2 = ClassLoader.getSystemResourceAsStream(ead);
         return sync.sync(m -> {
             try {
@@ -156,7 +156,7 @@ public class EadSyncTest extends AbstractImporterTest {
         // right place
         assertFalse(manager.exists("nl-r1-ctop_level_fonds-c00001-c00002-2"));
         assertFalse(manager.exists("nl-r1-ctop_level_fonds-c00001-c00002-1"));
-        SystemEvent ev = api(validUser).actionManager().getLatestGlobalEvent();
+        SystemEvent ev = api(adminUser).actionManager().getLatestGlobalEvent();
         assertEquals(logMessage, ev.getLogMessage());
         assertEquals(log.deleted().size() + log.moved().size(), ev.subjectCount());
         assertEquals(scope, ev.getEventScope());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/VirtualEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/VirtualEadTest.java
@@ -137,15 +137,15 @@ public class VirtualEadTest extends AbstractImporterTest {
                 .withDataValue(Ontology.NAME_KEY, UNIT2 + "title")
                 .withDataValue(Ontology.LANGUAGE_OF_DESCRIPTION, "cze");
 
-        repository1 = api(validUser).create(repo1Bundle, Repository.class);
-        repository2 = api(validUser).create(repo2Bundle, Repository.class);
+        repository1 = api(adminUser).create(repo1Bundle, Repository.class);
+        repository2 = api(adminUser).create(repo2Bundle, Repository.class);
 
         documentaryUnit1Bundle = documentaryUnit1Bundle.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, documentDescription1Bundle);
-        unit1 = api(validUser).create(documentaryUnit1Bundle, DocumentaryUnit.class);
+        unit1 = api(adminUser).create(documentaryUnit1Bundle, DocumentaryUnit.class);
         unit1.setRepository(repository1);
 
         documentaryUnit2Bundle = documentaryUnit2Bundle.withRelation(Ontology.DESCRIPTION_FOR_ENTITY, documentDescription2Bundle);
-        unit2 = api(validUser).create(documentaryUnit2Bundle, DocumentaryUnit.class);
+        unit2 = api(adminUser).create(documentaryUnit2Bundle, DocumentaryUnit.class);
         unit2.setRepository(repository2);
     }
 }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2BtEadTest.java
@@ -69,9 +69,9 @@ public class Wp2BtEadTest extends AbstractImporterTest {
                 .withDataValue(Ontology.NAME_KEY, "WP2 Keywords");
         Bundle conceptBundle = Bundle.of(EntityClass.CVOC_CONCEPT)
                 .withDataValue(Ontology.IDENTIFIER_KEY, "KEYWORD.JMP.716");
-        Vocabulary vocabulary = api(validUser).create(vocabularyBundle, Vocabulary.class);
+        Vocabulary vocabulary = api(adminUser).create(vocabularyBundle, Vocabulary.class);
         logger.debug(vocabulary.getId());
-        Concept concept_716 = api(validUser).create(conceptBundle, Concept.class);
+        Concept concept_716 = api(adminUser).create(conceptBundle, Concept.class);
         vocabulary.addItem(concept_716);
 
 

--- a/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/ead/Wp2YvEadTest.java
@@ -64,9 +64,9 @@ public class Wp2YvEadTest extends AbstractImporterTest {
                 .withDataValue(Ontology.NAME_KEY, "WP2 Keywords");
         Bundle conceptBundle = Bundle.of(EntityClass.CVOC_CONCEPT)
                 .withDataValue(Ontology.IDENTIFIER_KEY, "KEYWORD.JMP.288");
-        Vocabulary vocabulary = api(validUser).create(vocabularyBundle, Vocabulary.class);
+        Vocabulary vocabulary = api(adminUser).create(vocabularyBundle, Vocabulary.class);
         logger.debug(vocabulary.getId());
-        Concept concept_288 = api(validUser).create(conceptBundle, Concept.class);
+        Concept concept_288 = api(adminUser).create(conceptBundle, Concept.class);
         vocabulary.addItem(concept_288);
 
         Vocabulary vocabularyTest = manager.getEntity("wp2_keywords", Vocabulary.class);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/eag/Eag2896Test.java
@@ -60,7 +60,7 @@ public class Eag2896Test extends AbstractImporterTest {
         logger.info("count of nodes before importing: " + count);
 
         InputStream ios = ClassLoader.getSystemResourceAsStream(SINGLE_UNIT);
-        SaxImportManager importManager = SaxImportManager.create(graph, country, validUser,
+        SaxImportManager importManager = SaxImportManager.create(graph, country, adminUser,
                 EagImporter.class, EagHandler.class, ImportOptions.properties("eag.properties"));
         ImportLog log = importManager.importInputStream(ios, logMessage);
         //printGraph(graph);

--- a/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/json/BatchOperationsTest.java
@@ -35,7 +35,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
 
         ImportLog log = new BatchOperations(graph)
                 .setScope(scope)
-                .batchImport(payloadStream, validUser.as(Actioner.class), Optional.of(logMsg));
+                .batchImport(payloadStream, adminUser.as(Actioner.class), Optional.of(logMsg));
         assertTrue(log.hasDoneWork());
         assertEquals(1, log.getCreated());
         DocumentaryUnit newItem = manager.getEntity("nl-r1-test", DocumentaryUnit.class);
@@ -49,7 +49,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("import-test.json");
         ImportLog log2 = new BatchOperations(graph).setScope(scope).batchImport(payloadStream,
-                validUser.as(Actioner.class), Optional.of(logMsg));
+                adminUser.as(Actioner.class), Optional.of(logMsg));
         assertFalse(log2.hasDoneWork());
         int nodesAfter = getNodeCount(graph);
         int edgesAfter = getEdgeCount(graph);
@@ -65,7 +65,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
                 .getClassLoader().getResourceAsStream("import-test-validation-error.json");
         try {
             new BatchOperations(graph).batchImport(payloadStream,
-                    validUser.as(Actioner.class), Optional.of("Test create"));
+                    adminUser.as(Actioner.class), Optional.of("Test create"));
             fail("Import with validation error succeeded when it should have failed");
         } catch (ValidationError e) {
             assertEquals(1, e.getErrorSet().getDataValue("identifier").size());
@@ -84,7 +84,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         String logMsg = "Test partial update";
         int nodesBeforePatch = getNodeCount(graph);
         ImportLog log = new BatchOperations(graph).batchUpdate(payloadStream,
-                validUser.as(Actioner.class), Optional.of(logMsg));
+                adminUser.as(Actioner.class), Optional.of(logMsg));
         assertTrue(log.hasDoneWork());
         assertEquals(1, log.getUpdated());
         assertEquals(1, log.getUnchanged());
@@ -109,7 +109,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("import-patch-test.json");
         ImportLog log2 = new BatchOperations(graph).batchUpdate(payloadStream,
-                validUser.as(Actioner.class), Optional.of(logMsg));
+                adminUser.as(Actioner.class), Optional.of(logMsg));
         assertFalse(log2.hasDoneWork());
         int nodesAfter = getNodeCount(graph);
         int edgesAfter = getEdgeCount(graph);
@@ -122,7 +122,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         InputStream emptyStream = new ByteArrayInputStream("[]".getBytes());
         int nodesBefore = getNodeCount(graph);
         ImportLog log = new BatchOperations(graph).batchUpdate(emptyStream,
-                validUser.as(Actioner.class), Optional.of("Test partial update"));
+                adminUser.as(Actioner.class), Optional.of("Test partial update"));
         assertFalse(log.hasDoneWork());
         int nodesAfter = getNodeCount(graph);
         assertEquals(nodesBefore, nodesAfter);
@@ -136,7 +136,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
                 .getClassLoader().getResourceAsStream("import-patch-test-validation-error.json");
         try {
             new BatchOperations(graph).batchUpdate(payloadStream,
-                    validUser.as(Actioner.class), Optional.of("Test partial update"));
+                    adminUser.as(Actioner.class), Optional.of("Test partial update"));
             fail("Import with validation error succeeded when it should have failed");
         } catch (ValidationError e) {
             Collection<ErrorSet> describes = e.getErrorSet().getRelations("describes");
@@ -154,7 +154,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         InputStream payloadStream = getClass()
                 .getClassLoader().getResourceAsStream("import-patch-test-validation-error.json");
         ImportLog log = new BatchOperations(graph).setTolerant(true).batchUpdate(payloadStream,
-                validUser.as(Actioner.class), Optional.of("Test partial update"));
+                adminUser.as(Actioner.class), Optional.of("Test partial update"));
         assertTrue(log.hasDoneWork());
         assertEquals(1, log.getUpdated());
         assertEquals(1, log.getErrored());
@@ -168,7 +168,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
                 .getClassLoader().getResourceAsStream("import-patch-test-deserialization-error.json");
         try {
             new BatchOperations(graph).batchUpdate(payloadStream,
-                    validUser.as(Actioner.class), Optional.of("Test partial update"));
+                    adminUser.as(Actioner.class), Optional.of("Test partial update"));
             fail("Import with deserialization error succeeded when it should have failed");
         } catch (DeserializationError e) {
             // Okay...
@@ -181,7 +181,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
     public void testBatchDeleteWithVersioning() throws Exception {
         int nodesBefore = getNodeCount(graph);
         int deleted = new BatchOperations(graph).batchDelete(Lists.newArrayList("a1"),
-                validUser.as(Actioner.class), Optional.of("Test delete"));
+                adminUser.as(Actioner.class), Optional.of("Test delete"));
         assertEquals(1, deleted);
         // By default, total nodes should have increased by 1, since we
         // deleted 3 nodes (item, description, date period) and created 4:
@@ -198,7 +198,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
         int deleted = new BatchOperations(graph)
                 .setVersioning(false)
                 .batchDelete(Lists.newArrayList("a1"),
-                        validUser.as(Actioner.class), Optional.of("Test delete"));
+                        adminUser.as(Actioner.class), Optional.of("Test delete"));
         assertEquals(1, deleted);
         // By default, total nodes should have increased by 0, since we
         // deleted 3 nodes (item, description, date period) and created 4:
@@ -212,7 +212,7 @@ public class BatchOperationsTest extends AbstractImporterTest {
     public void testBatchDeleteWithNoValidIds() throws Exception {
         int nodesBefore = getNodeCount(graph);
         int deleted = new BatchOperations(graph).setTolerant(true).batchDelete(Lists.newArrayList("NOT-AN-ID"),
-                validUser.as(Actioner.class), Optional.of("Test delete"));
+                adminUser.as(Actioner.class), Optional.of("Test delete"));
         assertEquals(0, deleted);
         assertEquals(nodesBefore, getNodeCount(graph));
     }

--- a/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkImporterTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkImporterTest.java
@@ -33,7 +33,7 @@ public class LinkImporterTest extends AbstractFixtureTest {
     @Test
     public void importLinks() throws Exception {
 
-        ImportLog log = new LinkImporter(graph, validUser, false)
+        ImportLog log = new LinkImporter(graph, adminUser, false)
                 .importLinks(goodData, "testing");
         assertEquals(3, log.getCreated());
         assertTrue("Link exists",
@@ -44,13 +44,13 @@ public class LinkImporterTest extends AbstractFixtureTest {
 
     @Test(expected = DeserializationError.class)
     public void importLinksWithMissingTarget() throws Exception {
-        new LinkImporter(graph, validUser, false)
+        new LinkImporter(graph, adminUser, false)
                 .importLinks(badData, "testing");
     }
 
     @Test
     public void importLinkWithAccessPoint() throws Exception {
-        new LinkImporter(graph, validUser, false)
+        new LinkImporter(graph, adminUser, false)
                 .importLinks(goodData, "testing");
         assertTrue("Link exists",
                 linkExists("r1", "c1", "ur1", "Test 2"));
@@ -58,7 +58,7 @@ public class LinkImporterTest extends AbstractFixtureTest {
 
     @Test
     public void importLinksWithMissingTargetInTolerantMode() throws Exception {
-        ImportLog log = new LinkImporter(graph, validUser, true)
+        ImportLog log = new LinkImporter(graph, adminUser, true)
                 .importLinks(badData, "testing");
         assertEquals(3, log.getCreated());
     }
@@ -72,7 +72,7 @@ public class LinkImporterTest extends AbstractFixtureTest {
                         ImmutableList.of("Disconnected Access 1", "r4") // Updated
 
         ));
-        ImportLog log = new LinkImporter(graph, validUser, false)
+        ImportLog log = new LinkImporter(graph, adminUser, false)
                 .importCoreferences(r1, data, "Testing");
         assertEquals(1, log.getCreated());
         assertEquals(1, log.getUpdated());

--- a/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkResolverTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/importers/links/LinkResolverTest.java
@@ -17,7 +17,7 @@ public class LinkResolverTest extends AbstractFixtureTest {
     @Test
     public void solveUndeterminedRelationships() throws Exception {
         Described unit = manager.getEntity("c5", Described.class);
-        LinkResolver linkResolver = new LinkResolver(graph, validUser);
+        LinkResolver linkResolver = new LinkResolver(graph, adminUser);
         int created = linkResolver.solveUndeterminedRelationships(unit);
         assertEquals(2, created);
 

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/GraphQLImplTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/GraphQLImplTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertTrue;
 public class GraphQLImplTest extends AbstractFixtureTest {
     @Test
     public void testGetSchema() throws Exception {
-        GraphQLImpl graphQL = new GraphQLImpl(api(validUser));
+        GraphQLImpl graphQL = new GraphQLImpl(api(adminUser));
         GraphQLSchema schema = graphQL.getSchema();
         String testQuery = readResourceFileAsString("testquery.graphql");
         ExecutionResult result = GraphQL.newGraphQL(schema).build().execute(testQuery);

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/StreamingExecutionStrategyTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/graphql/StreamingExecutionStrategyTest.java
@@ -47,7 +47,7 @@ public class StreamingExecutionStrategyTest extends AbstractFixtureTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonGenerator generator = mapper.getFactory().createGenerator(out)
                 .useDefaultPrettyPrinter()) {
-            GraphQLSchema schema = new GraphQLImpl(api(validUser), true).getSchema();
+            GraphQLSchema schema = new GraphQLImpl(api(adminUser), true).getSchema();
 
             final StreamingExecutionStrategy strategy = StreamingExecutionStrategy.jsonGenerator(generator);
             final ExecutionInput input = ExecutionInput.newExecutionInput()


### PR DESCRIPTION
Now when creating links with the ANNOTATE permission, non-admin users get an OWNER permission on the new link so that they can delete it without having content permission on the link type.

Also:

 - remove buggy and unused createOrUpdate method
 - add a tools method for creating OWNER perms on non-admin users

Remove unused and buggy createOrDelete method from core API

This would not assign ownership correctly, and in any case was not used except by the CLI