### PR TITLE
Add a more usable (and succinct) `lang` param for GraphQL queries

### DIFF
--- a/ehri-core/src/main/java/eu/ehri/project/persistence/BundleValidator.java
+++ b/ehri-core/src/main/java/eu/ehri/project/persistence/BundleValidator.java
@@ -244,9 +244,7 @@ public final class BundleValidator {
      */
     private void checkIntegrity(Bundle bundle, ErrorSet.Builder builder) {
         if (bundle.getId() == null) {
-            builder.addError(Bundle.ID_KEY,
-                    MessageFormat.format(Messages.getString("BundleValidator.missingIdForCreate"),
-                    bundle.getId()));
+            builder.addError(Bundle.ID_KEY, Messages.getString("BundleValidator.missingIdForCreate"));
         }
         if (manager.exists(bundle.getId())) {
             ListMultimap<String, String> idErrors = bundle

--- a/ehri-io/src/main/java/eu/ehri/project/utils/LanguageHelpers.java
+++ b/ehri-io/src/main/java/eu/ehri/project/utils/LanguageHelpers.java
@@ -382,6 +382,21 @@ public class LanguageHelpers {
         return getBestDescription(item, Optional.empty(), langCode);
     }
 
+    public static Optional<String> convertCode(String twoOrThree) {
+        if (twoOrThree == null) {
+            return Optional.empty();
+        }
+        String codeLower = twoOrThree.toLowerCase();
+        if (twoOrThree.length() == 2 && locale2Map.containsKey(twoOrThree)) {
+            return Optional.of(locale2Map.get(twoOrThree).getISO3Language());
+        } else if (twoOrThree.length() == 3 && iso639BibTermLookup.containsKey(twoOrThree)) {
+            return Optional.of(iso639BibTermLookup.get(twoOrThree));
+        } else if (locale3Map.containsKey(codeLower)) {
+            return Optional.of(codeLower);
+        }
+        return Optional.empty();
+    }
+
     /**
      * Take an ISO-639-1 code or a language name and try and map to a valid ISO639-2 code.
      *

--- a/ehri-io/src/test/java/eu/ehri/project/utils/LanguageHelpersTest.java
+++ b/ehri-io/src/test/java/eu/ehri/project/utils/LanguageHelpersTest.java
@@ -23,14 +23,13 @@ import org.junit.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 public class LanguageHelpersTest {
 
     @Test
-    public void testIso639DashTwoCode() throws Exception {
+    public void testIso639DashTwoCode() {
         // two-to-three
         assertEquals("sqi", LanguageHelpers.iso639DashTwoCode("sq"));
         // bibliographic to term
@@ -41,7 +40,16 @@ public class LanguageHelpersTest {
     }
 
     @Test
-    public void testIso639DashOneCode() throws Exception {
+    public void testConvertCode() {
+        assertEquals(Optional.of("sqi"), LanguageHelpers.convertCode("sq"));
+        assertEquals(Optional.of("sqi"), LanguageHelpers.convertCode("alb"));
+        assertEquals(Optional.of("eng"), LanguageHelpers.convertCode("en"));
+        assertEquals(Optional.empty(), LanguageHelpers.convertCode(null));
+        assertEquals(Optional.empty(), LanguageHelpers.convertCode("unknown"));
+    }
+
+    @Test
+    public void testIso639DashOneCode() {
         assertEquals("en", LanguageHelpers.iso639DashOneCode("eng"));
         assertEquals("cs", LanguageHelpers.iso639DashOneCode("ces"));
         assertEquals("cs", LanguageHelpers.iso639DashOneCode("cze"));
@@ -53,7 +61,7 @@ public class LanguageHelpersTest {
     }
 
     @Test
-    public void testCountryCodeToContinent() throws Exception {
+    public void testCountryCodeToContinent() {
         Optional<String> c1 = LanguageHelpers.countryCodeToContinent("gb");
         assertTrue(c1.isPresent());
         assertEquals("Europe", c1.get());
@@ -68,7 +76,7 @@ public class LanguageHelpersTest {
     }
 
     @Test
-    public void testCodeToName() throws Exception {
+    public void testCodeToName() {
         assertEquals("English", LanguageHelpers.codeToName("eng"));
         assertEquals("German", LanguageHelpers.codeToName("deu"));
         assertEquals("German", LanguageHelpers.codeToName("ger"));

--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/messages.properties
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/messages.properties
@@ -65,6 +65,7 @@ graphql.argument.from.description=Fetch items from this cursor
 graphql.argument.id.description=An item string identifier
 graphql.argument.identifier.description=The description's identifier code
 graphql.argument.languageCode.description=The description's language code
+graphql.argument.lang.description=An ISO 639-1 or 639-2 language code to match the description's language
 
 graphql.enum.accessPointType.description=Access point types
 

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -22,7 +22,7 @@ query test {
                 type
             }
         }
-        description(languageCode: "eng", identifier: "c1-desc2") {
+        description(lang: "EN", identifier: "c1-desc2") {
             name
             languageCode
             scopeAndContent


### PR DESCRIPTION
This accepts 639-1 codes as well as 639-2 and is shorter and more tolerant to bad input.