### PR TITLE
Don't deprecate the `languageCode` field

### DIFF
--- a/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
+++ b/ehri-ws-graphql/src/main/java/eu/ehri/project/graphql/GraphQLImpl.java
@@ -714,7 +714,6 @@ public class GraphQLImpl {
                 .argument(newArgument()
                         .name(Ontology.LANGUAGE_OF_DESCRIPTION)
                         .description(__("graphql.argument.languageCode.description"))
-                        .deprecate("Use the 'lang' argument instead. This accepts ISO 639-1 2-letter codes in addition to 639-2 3-letter codes.")
                         .type(GraphQLString)
                         .build()
                 )


### PR DESCRIPTION
Instead leave it as a more precise alternative