### PR TITLE
GraphQL address name should be called `addressName` instead of `name`

### DIFF
--- a/ehri-core/src/test/resources/fixtures/testdata.yaml
+++ b/ehri-core/src/test/resources/fixtures/testdata.yaml
@@ -150,7 +150,7 @@
             - id: ar1
               type: Address
               data:
-                name: An Address
+                addressName: An Address
                 street: 1 Some St.
                 municipality: Amsterdam
                 email:
@@ -183,7 +183,7 @@
             - id: ar2
               type: Address
               data:
-                name: An Address
+                addressName: An Address
                 street: Strand
                 municipality: London
                 webpage: http://www.kcl.ac.uk

--- a/ehri-io/src/main/java/eu/ehri/project/definitions/ContactInfo.java
+++ b/ehri-io/src/main/java/eu/ehri/project/definitions/ContactInfo.java
@@ -2,7 +2,7 @@ package eu.ehri.project.definitions;
 
 public enum ContactInfo implements DefinitionList {
 
-    name,
+    addressName,
     contactPerson,
     street,
     municipality,

--- a/ehri-io/src/main/java/eu/ehri/project/definitions/messages.properties
+++ b/ehri-io/src/main/java/eu/ehri/project/definitions/messages.properties
@@ -328,8 +328,8 @@ Isaar.maintenanceNotes.description=To document the creation of and changes to th
 # Contact info
 #
 
-ContactInfo.name=Address Name / Type
-ContactInfo.name.description=A descriptive label or name for this address.
+ContactInfo.addressName=Address Name / Type
+ContactInfo.addressName.description=A descriptive label or name for this address.
 
 ContactInfo.contactPerson=Contact person
 ContactInfo.contactPerson.description=Provides information needed to contact members of staff.

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
@@ -122,7 +122,7 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
                 .path(0).path("context").path("body").path(0).path("name").textValue());
         assertEquals("An Address", data.path("data").path("c1").path("repository")
                 .path("english").path("addresses").path(0)
-                .path("name").textValue());
+                .path("addressName").textValue());
         assertEquals("Amsterdam", data.path("data").path("c1").path("repository")
                 .path("english").path("addresses").path(0)
                 .path("municipality").textValue());

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -34,7 +34,7 @@ query test {
             english: description(languageCode: "eng") {
                 name
                 addresses {
-                    name
+                    addressName
                     municipality
                     email
                 }


### PR DESCRIPTION
Presumably this is less easily confused with a person name, but I was misled by the test fixtures, which were also wrong.