### PR TITLE
Add the linkType filter param to all `links` fields

### DIFF
--- a/ehri-ws-graphql/src/main/resources/reference.conf
+++ b/ehri-ws-graphql/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ graphql {
         # very high limit here because there's no way to
         # override it when testing. this should be lower
         # in production
-        maxComplexity: 160
+        maxComplexity: 200
         maxComplexityAnonymous: 50
     }
 }

--- a/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
+++ b/ehri-ws-graphql/src/test/java/eu/ehri/project/ws/test/GraphQLResourceClientTest.java
@@ -165,6 +165,8 @@ public class GraphQLResourceClientTest extends AbstractResourceClientTest {
         assertEquals("associative", data.path("data").path("link3").path("linkType").textValue());
         assertEquals("c4", data.path("data").path("link4").path("source").path("id").textValue());
         assertEquals("copy", data.path("data").path("link4").path("linkType").textValue());
+        assertEquals(5, data.path("data").path("allLinks").path("items").size());
+        assertEquals(2, data.path("data").path("allCopyLinks").path("items").size());
     }
 
     @Test

--- a/ehri-ws-graphql/src/test/resources/testquery.graphql
+++ b/ehri-ws-graphql/src/test/resources/testquery.graphql
@@ -204,7 +204,7 @@ query test {
     }
 
     r4: Repository(id: "r4") {
-        links {
+        links(linkType: copy) {
             targets {
                 id
             }
@@ -255,5 +255,17 @@ query test {
             id
         }
         linkType
+    }
+
+    allLinks: links {
+        items {
+            id
+        }
+    }
+
+    allCopyLinks: links(linkType: copy) {
+        items {
+            id
+        }
     }
 }


### PR DESCRIPTION
This is in addition to the `connected` field we had before.

Pretty ugly patch, should probably break up the GraphQLImpl class before it becomes unmanageable.