### PR TITLE
fixed an error when the total path length exceeds 100 characters

### DIFF
--- a/ehri-core/src/test/java/eu/ehri/project/test/IOHelpers.java
+++ b/ehri-core/src/test/java/eu/ehri/project/test/IOHelpers.java
@@ -54,7 +54,10 @@ public class IOHelpers {
              TarArchiveOutputStream tos = new TarArchiveOutputStream(fos)) {
             for (String resource : resources) {
                 URL url = Resources.getResource(resource);
-                tos.putArchiveEntry(new TarArchiveEntry(new File(url.toURI())));
+                File resourceFile = new File(url.toURI());
+                TarArchiveEntry entry = new TarArchiveEntry(resource);
+                entry.setSize(resourceFile.length());
+                tos.putArchiveEntry(entry);
                 Resources.copy(url, tos);
                 tos.closeArchiveEntry();
             }

--- a/ehri-core/src/test/java/eu/ehri/project/test/IOHelpers.java
+++ b/ehri-core/src/test/java/eu/ehri/project/test/IOHelpers.java
@@ -52,12 +52,10 @@ public class IOHelpers {
             throws URISyntaxException, IOException {
         try (OutputStream fos = Files.newOutputStream(file.toPath());
              TarArchiveOutputStream tos = new TarArchiveOutputStream(fos)) {
+            tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
             for (String resource : resources) {
                 URL url = Resources.getResource(resource);
-                File resourceFile = new File(url.toURI());
-                TarArchiveEntry entry = new TarArchiveEntry(resource);
-                entry.setSize(resourceFile.length());
-                tos.putArchiveEntry(entry);
+                tos.putArchiveEntry(new TarArchiveEntry(new File(url.toURI())));
                 Resources.copy(url, tos);
                 tos.closeArchiveEntry();
             }


### PR DESCRIPTION
`TarArchiveEntry()` has a 100-byte name limit. Here I only use the last part of the resource names, and set the size from the actual file.