### PR TITLE
Improve the connection handling for fetching import resources

### DIFF
--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/AbstractImportManager.java
@@ -37,6 +37,7 @@ import eu.ehri.project.importers.base.PermissionScopeFinder;
 import eu.ehri.project.importers.exceptions.ImportValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
 import eu.ehri.project.importers.exceptions.ModeViolation;
+import eu.ehri.project.importers.util.ImportResourceFetcher;
 import eu.ehri.project.models.base.Accessible;
 import eu.ehri.project.models.base.Actioner;
 import eu.ehri.project.models.base.PermissionScope;
@@ -62,7 +63,6 @@ import java.util.Optional;
  */
 public abstract class AbstractImportManager implements ImportManager {
 
-    private static final int MAX_RETRIES = 3;
     private static final Logger logger = LoggerFactory.getLogger(AbstractImportManager.class);
     private static final JsonFactory factory = new JsonFactory();
 
@@ -70,6 +70,7 @@ public abstract class AbstractImportManager implements ImportManager {
     protected final PermissionScope permissionScope;
     protected final Actioner actioner;
     protected final ImportOptions options;
+    protected final ImportResourceFetcher resourceFetcher;
 
     // Ugly stateful variables for tracking import state
     // and reporting errors usefully...
@@ -77,7 +78,6 @@ public abstract class AbstractImportManager implements ImportManager {
     protected Integer currentPosition;
     protected PermissionScopeFinder scopeFinder;
     protected final Class<? extends ItemImporter<?, ?>> importerClass;
-    private int consecutiveIoErrors = 0;
 
     /**
      * Constructor.
@@ -100,6 +100,7 @@ public abstract class AbstractImportManager implements ImportManager {
         this.actioner = actioner;
         this.importerClass = importerClass;
         this.options = options;
+        this.resourceFetcher = new ImportResourceFetcher();
 
         if (options.hierarchyMap != null) {
             this.scopeFinder = new DynamicPermissionScopeFinder(scope, options.hierarchyMap);
@@ -165,10 +166,9 @@ public abstract class AbstractImportManager implements ImportManager {
 
             for (int i = 1; (currentFile = parser.nextFieldName()) != null; i++) {
                 URL url = new URL(parser.nextTextValue());
-                try (InputStream stream = readUrl(url, 0)) {
+                try {
                     logger.info("Importing URL {} with identifier: {}", i, currentFile);
-
-                    importInputStream(stream, currentFile, action, log);
+                    resourceFetcher.fetch(url, inputStream -> importInputStream(inputStream, currentFile, action, log));
                 } catch (ValidationError e) {
                     log.addError(formatErrorLocation(), e.getMessage());
                     if (!options.tolerant) {
@@ -176,12 +176,16 @@ public abstract class AbstractImportManager implements ImportManager {
                         // a formatted error location since the XML file is always null
                         throw new ImportValidationError(e.getMessage(), e);
                     }
-                } catch (IOException | InputParseError e) {
-                    logger.error("Input parse error", e);
+                } catch (InputParseError e) {
+                    logger.error(String.format("Input parse error: %s", url), e);
                     log.addError(formatErrorLocation(), e.getMessage());
-                    // Error regardless of tolerant setting if more than 5 consecutive items
-                    // fail to download... this prevents an endless blocking stall...
-                    if (!options.tolerant || consecutiveIoErrors > (MAX_RETRIES * 5)) {
+                    if (!options.tolerant) {
+                        throw e;
+                    }
+                } catch (IOException e) {
+                    logger.error(String.format("IO error on URL: %s", url), e);
+                    log.addError(formatErrorLocation(), e.getMessage());
+                    if (!options.tolerant) {
                         throw e;
                     }
                 }
@@ -348,37 +352,5 @@ public abstract class AbstractImportManager implements ImportManager {
 
     private String formatErrorLocation() {
         return String.format("File: %s, XML document: %d", currentFile, currentPosition);
-    }
-
-    private InputStream readUrl(URL url, int retry) throws IOException {
-        // EXTREMELY INADVISABLE CODE! This stuff runs inside the database
-        // where Thread.sleep()ing is obviously not a good idea. However,
-        // since import errors caused by HTTP rate-limiting are generally
-        // very rare I've resorted to it here with exponential backoff as
-        // by far the easiest way to prevent sporadic import problems.
-        // Generally we only need one retry with a 100ms sleep per several
-        // thousand import URLs to make HTTP imports much more resilient,
-        // and very few dataset batches have that many items anyway.
-        try {
-            InputStream stream = url.openStream();
-            consecutiveIoErrors = 0;
-            return stream;
-        } catch (IOException e) {
-            if (isSlowDownError(e) && retry < MAX_RETRIES) {
-                logger.debug("Got slow down error... retry {}, {}", retry + 1, url);
-                consecutiveIoErrors++;
-                try {
-                    Thread.sleep((long) (Math.pow(2, retry) * 100));
-                    return readUrl(url, retry + 1);
-                } catch (InterruptedException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
-            throw e;
-        }
-    }
-
-    private boolean isSlowDownError(IOException e) {
-        return e.getMessage().contains("Server returned HTTP response code: 503");
     }
 }

--- a/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/managers/SaxImportManager.java
@@ -55,7 +55,6 @@ public class SaxImportManager extends AbstractImportManager {
 
     private static final Logger logger = LoggerFactory.getLogger(SaxImportManager.class);
 
-    private static final Config config = ConfigFactory.load();
     private final Class<? extends SaxXmlHandler> handlerClass;
     private final ImportOptions options;
     private final List<ImportCallback> extraCallbacks;

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/HttpImportResourceFetcher.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/HttpImportResourceFetcher.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.importers.util;
+
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.exceptions.InputParseError;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Fetch HTTP resources with retry exponential backoff logic.
+ */
+class HttpImportResourceFetcher {
+
+    private static final int MAX_RETRIES = 3;
+    private static final long INITIAL_BACKOFF_MS = 1_000;
+    private static final long MAX_BACKOFF_MS = 30_000;
+    private static final double BACKOFF_MULTIPLIER = 2.0;
+    public static final int CONNECT_TIMEOUT = 10_000;
+    public static final int READ_TIMEOUT = 60_000;
+
+    public void fetch(URL url, ResponseHandler handler) throws IOException, ValidationError, InputParseError {
+        IOException lastException = null;
+
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            if (attempt > 0) {
+                sleepBeforeRetry(attempt);
+            }
+
+            HttpURLConnection connection = null;
+            try {
+                connection = openConnection(url);
+                try (InputStream in = connection.getInputStream()) {
+                    handler.handle(in);
+                    return; // success — return immediately
+                }
+            } catch (IOException e) {
+                lastException = e;
+                if (!isRetryable(e, connection)) {
+                    break;  // no point retrying (e.g. 404)
+                }
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        }
+
+        throw new IOException("Request failed after " + MAX_RETRIES + " retries", lastException);
+    }
+
+    private HttpURLConnection openConnection(URL url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setConnectTimeout(CONNECT_TIMEOUT);
+        connection.setReadTimeout(READ_TIMEOUT);
+        connection.setRequestProperty("Accept-Encoding", "gzip");
+
+        int status = connection.getResponseCode();
+        if (status != HttpURLConnection.HTTP_OK) {
+            drainErrorStream(connection);  // must drain to allow connection reuse
+            throw new HttpStatusException(status, url);
+        }
+        return connection;
+    }
+
+    private boolean isRetryable(IOException e, HttpURLConnection connection) {
+        // Always retry network-level errors (timeouts, resets, etc.)
+        if (!(e instanceof HttpStatusException)) {
+            return true;
+        }
+        int status = ((HttpStatusException) e).statusCode;
+        // Retry on server errors and 429 (rate limited), not client errors
+        return status == 429 || (status >= 500 && status < 600);
+    }
+
+    private void sleepBeforeRetry(int attempt) throws IOException {
+        // Exponential backoff with jitter to avoid thundering herd
+        long backoff = (long) (INITIAL_BACKOFF_MS * Math.pow(BACKOFF_MULTIPLIER, attempt - 1));
+        long jitter = (long) (Math.random() * backoff * 0.2);  // ±20% jitter
+        long delay = Math.min(backoff + jitter, MAX_BACKOFF_MS);
+
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted during retry backoff", ie);
+        }
+    }
+
+    private void drainErrorStream(HttpURLConnection connection) {
+        try (InputStream err = connection.getErrorStream()) {
+            if (err != null) {
+                byte[] buffer = new byte[4096];
+                //noinspection StatementWithEmptyBody
+                while (err.read(buffer) != -1) {
+                    // discard
+                }
+            }
+        } catch (IOException ignored) {
+        }
+    }
+
+    @FunctionalInterface
+    public interface ResponseHandler {
+        void handle(InputStream in) throws IOException, InputParseError, ValidationError;
+    }
+
+    public static class HttpStatusException extends IOException {
+        private static final long serialVersionUID = -2235809859661477987L;
+        public final int statusCode;
+
+        public HttpStatusException(int statusCode, URL url) {
+            super("HTTP " + statusCode + " for URL: " + url);
+            this.statusCode = statusCode;
+        }
+    }
+}

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/HttpImportResourceFetcher.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/HttpImportResourceFetcher.java
@@ -16,9 +16,13 @@
 
 package eu.ehri.project.importers.util;
 
+import com.google.common.io.ByteStreams;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import eu.ehri.project.exceptions.ValidationError;
 import eu.ehri.project.importers.exceptions.InputParseError;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -29,13 +33,31 @@ import java.net.URL;
  */
 class HttpImportResourceFetcher {
 
-    private static final int MAX_RETRIES = 3;
+    private static final Config config = ConfigFactory.load();
+    private static final boolean BUFFER_REMOTE = config.getBoolean("io.import.http.buffer");
+    private static final int MAX_RETRIES = config.getInt("io.import.http.maxRetries");
+
     private static final long INITIAL_BACKOFF_MS = 1_000;
     private static final long MAX_BACKOFF_MS = 30_000;
     private static final double BACKOFF_MULTIPLIER = 2.0;
-    public static final int CONNECT_TIMEOUT = 10_000;
-    public static final int READ_TIMEOUT = 60_000;
+    private static final int CONNECT_TIMEOUT = 10_000;
+    private static final int READ_TIMEOUT = 60_000;
 
+    @FunctionalInterface
+    public interface ResponseHandler {
+        void handle(InputStream in) throws IOException, InputParseError, ValidationError;
+    }
+
+    /**
+     * Fetch data from a URL, processing it with the given
+     * import response handler.
+     *
+     * @param url     a resource URL
+     * @param handler a handler function
+     * @throws IOException     if an error is encountered fetching the data
+     * @throws ValidationError if a validation error occurs on import
+     * @throws InputParseError if the fetched data is invalid
+     */
     public void fetch(URL url, ResponseHandler handler) throws IOException, ValidationError, InputParseError {
         IOException lastException = null;
 
@@ -47,14 +69,30 @@ class HttpImportResourceFetcher {
             HttpURLConnection connection = null;
             try {
                 connection = openConnection(url);
-                try (InputStream in = connection.getInputStream()) {
-                    handler.handle(in);
-                    return; // success — return immediately
+
+                final InputStream toUse;
+                if (BUFFER_REMOTE) {
+                    // Buffer fully, then we can release the connection early
+                    try (InputStream inputStream = connection.getInputStream()) {
+                        toUse = new ByteArrayInputStream(ByteStreams.toByteArray(inputStream));
+                    }
+                    connection.disconnect();
+                    connection = null; // prevent double-disconnect in finally
+                } else {
+                    toUse = connection.getInputStream();
                 }
+
+                try (InputStream is = toUse) {
+                    handler.handle(is);
+                }
+
+                // success — exit retry loop cleanly
+                break;
+
             } catch (IOException e) {
                 lastException = e;
                 if (!isRetryable(e, connection)) {
-                    break;  // no point retrying (e.g. 404)
+                    break;
                 }
             } finally {
                 if (connection != null) {
@@ -63,7 +101,9 @@ class HttpImportResourceFetcher {
             }
         }
 
-        throw new IOException("Request failed after " + MAX_RETRIES + " retries", lastException);
+        if (lastException != null) {
+            throw new IOException("Request failed after " + MAX_RETRIES + " retries", lastException);
+        }
     }
 
     private HttpURLConnection openConnection(URL url) throws IOException {
@@ -115,11 +155,6 @@ class HttpImportResourceFetcher {
             }
         } catch (IOException ignored) {
         }
-    }
-
-    @FunctionalInterface
-    public interface ResponseHandler {
-        void handle(InputStream in) throws IOException, InputParseError, ValidationError;
     }
 
     public static class HttpStatusException extends IOException {

--- a/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportResourceFetcher.java
+++ b/ehri-io/src/main/java/eu/ehri/project/importers/util/ImportResourceFetcher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Data Archiving and Networked Services (an institute of
+ * Koninklijke Nederlandse Akademie van Wetenschappen), King's College London,
+ * Georg-August-Universitaet Goettingen Stiftung Oeffentlichen Rechts
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package eu.ehri.project.importers.util;
+
+import com.google.common.collect.Maps;
+import eu.ehri.project.exceptions.ValidationError;
+import eu.ehri.project.importers.exceptions.InputParseError;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * Helper for fetching resources via URL using protocol
+ * specific handlers.
+ */
+public class ImportResourceFetcher {
+    private static final HttpImportResourceFetcher httpFetcher = new HttpImportResourceFetcher();
+
+    private interface FetchStrategy {
+        void fetch(URL url, HttpImportResourceFetcher.ResponseHandler handler) throws IOException, InputParseError, ValidationError;
+    }
+
+    private static class HttpStrategy implements FetchStrategy {
+
+        @Override
+        public void fetch(URL url, HttpImportResourceFetcher.ResponseHandler handler) throws IOException, InputParseError, ValidationError {
+            httpFetcher.fetch(url, handler);
+        }
+    }
+
+    private static class FileStrategy implements FetchStrategy {
+        @Override
+        public void fetch(URL url, HttpImportResourceFetcher.ResponseHandler handler) throws IOException, InputParseError, ValidationError {
+            try (InputStream in = url.openStream()) {
+                handler.handle(in);
+            }
+        }
+    }
+
+    private static final Map<String, FetchStrategy> STRATEGIES = Maps.newHashMap();
+
+    static {
+        HttpStrategy http = new HttpStrategy();
+        STRATEGIES.put("http", http);
+        STRATEGIES.put("https", http);
+        STRATEGIES.put("file", new FileStrategy());
+    }
+
+    public void fetch(URL url, HttpImportResourceFetcher.ResponseHandler handler) throws IOException, InputParseError, ValidationError {
+        String protocol = url.getProtocol().toLowerCase();
+        FetchStrategy strategy = STRATEGIES.get(protocol);
+        if (strategy == null) {
+            throw new IOException("Unsupported protocol: " + protocol);
+        }
+        strategy.fetch(url, handler);
+    }
+}

--- a/ehri-io/src/main/resources/reference.conf
+++ b/ehri-io/src/main/resources/reference.conf
@@ -15,6 +15,13 @@ io {
     # delimiter for tabular records
     defaultFieldSep = ","
     defaultArraySep = "||"
+
+    http {
+      # Whether to buffer HTTP resources before XML import
+      buffer = true
+      # How many times to retry a failing resource
+      maxRetries = 3
+    }
   }
 
   export {


### PR DESCRIPTION
This should encapsulate the (dodgy) HTTP retry logic for rate-limited or error-prone object stores.